### PR TITLE
docs: define branching model and English-only artifact rule

### DIFF
--- a/.claude/rules/ecc/common/coding-style.md
+++ b/.claude/rules/ecc/common/coding-style.md
@@ -1,5 +1,11 @@
 # Coding Style
 
+## Language (CRITICAL)
+
+Write **everything in English**: code comments, doc comments, identifiers, log and error
+messages, markdown docs, commit messages, and PR text. The conversation language never
+changes the language of the artifact.
+
 ## Immutability (CRITICAL)
 
 ALWAYS create new objects, NEVER mutate existing ones:

--- a/.claude/rules/ecc/common/git-workflow.md
+++ b/.claude/rules/ecc/common/git-workflow.md
@@ -1,5 +1,33 @@
 # Git Workflow
 
+## Branching Model
+
+| Branch | Role | Merged from |
+|--------|------|-------------|
+| `main` | Production / release. Only released code. | `dev` -> `main` (release PR) or `hotfix/*` -> `main` |
+| `dev` | Integration / development branch. Default base branch. | `feat/*`, `fix/*`, ... -> `dev` PR |
+| `<type>/<slug>` | A single feature or fix. Short-lived. | Deleted after merge |
+
+Rules:
+
+- **Every feature lives on its own branch.** Never commit directly to `dev` or `main`.
+- Feature branches are **cut from `dev`** and return to **`dev`** through a PR:
+  ```bash
+  git checkout dev && git pull
+  git checkout -b feat/<slug>
+  # ... commits ...
+  git push -u origin feat/<slug>
+  gh pr create --base dev
+  ```
+- Branch names reuse the commit types: `feat/`, `fix/`, `refactor/`, `docs/`, `test/`,
+  `chore/`, `perf/`, `ci/`. Example: `feat/pairing-endpoint`, `fix/tls-handshake-timeout`.
+- **Release:** `dev` -> `main` PR. A merge into `main` means "releasable" and is tagged
+  `vX.Y.Z`.
+- **Hotfix:** only when production is broken — cut `hotfix/<slug>` from `main`, merge into
+  `main`, then merge `main` back into `dev` so the fix is not lost.
+- Delete merged feature branches locally and on the remote.
+- Treat `main` and `dev` as protected: no force push, no merge without a PR.
+
 ## Commit Message Format
 ```
 <type>: <description>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,24 @@ client can inspect and restart containers without SSH and without exposing the D
 - Go: 1.26
 - License: AGPL-3.0-only
 
+## Language (MANDATORY)
+
+**All written artifacts in this repository are English-only**, regardless of the language
+used in chat. This is non-negotiable and applies to:
+
+- every `.md` file (README, PRDs, plans, rules, ADRs, docs)
+- code comments and doc comments
+- identifiers, log messages, and error strings
+- commit messages, branch names, PR titles and bodies, issue text
+
+If the user writes in another language, still produce these artifacts in English.
+
+## Branching
+
+`main` = production/release, `dev` = integration, every feature on its own
+`<type>/<slug>` branch cut from `dev`. Never commit directly to `main` or `dev`.
+Full model: `.claude/rules/ecc/common/git-workflow.md`.
+
 ## Commands
 
 Nothing is implemented yet — `go.mod` is created by Task 1 of the current plan, so these


### PR DESCRIPTION
## Summary

The repo had no documented branching model and no `dev` branch. This adds both the branching
contract and a hard rule that every written artifact is English.

**Branching model** (`.claude/rules/ecc/common/git-workflow.md`)
- `main` — production/release only, tagged `vX.Y.Z`
- `dev` — integration branch, default PR base
- `<type>/<slug>` — one short-lived branch per feature/fix, cut from `dev`, deleted after merge
- Hotfix path: `main` -> `hotfix/*` -> `main` -> back-merge into `dev`
- `main` and `dev` are treated as protected: no force push, no merge without a PR

**English-only artifacts** (`CLAUDE.md`, `.claude/rules/ecc/common/coding-style.md`)
- Applies to markdown, code and doc comments, identifiers, log/error strings, commit messages,
  branch names, and PR text — regardless of the language used in conversation.

Docs only; no code, build, or test changes.

## Test plan

- [ ] Confirm `dev` is set as the default branch on GitHub
- [ ] Enable branch protection on `main` and `dev` (require PR, block force push)
- [ ] Retarget the open `feat/secure-foundation-and-persistence` work onto `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
