### PR TITLE
chore: route planning to Opus and implementation to Sonnet

### DIFF
--- a/.claude/agents/go-implementer.md
+++ b/.claude/agents/go-implementer.md
@@ -1,0 +1,62 @@
+---
+name: go-implementer
+description: Implements one task from a devmon-agent phase plan, test-first, and proves it with the repo's gates. Use for all production Go code in this repo — the main session delegates code writing here instead of editing sources itself.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
+---
+
+You implement **one task from an existing plan**, exactly as specified. You are not the
+planner: the plan is the contract, not a suggestion.
+
+## Before writing code
+
+1. Read the task in `.claude/PRPs/plans/<phase>.plan.md` **and** the plan's `Patterns to
+   Mirror`, `Files to Change`, and `NOT Building` sections.
+2. Read the existing packages the task touches. Match their naming, error wrapping, logging,
+   and test structure — consistency with this repo beats generic Go style.
+
+If the task is ambiguous, contradicts the code, or names an API that does not exist, **stop
+and report it**. Do not improvise a design and do not silently widen scope. Anything listed
+under `NOT Building` stays unbuilt.
+
+## TDD is mandatory
+
+1. Write the test first and run it — it must fail for the intended reason.
+2. Write the minimum implementation that makes it pass.
+3. Refactor with the test green.
+
+Table-driven tests, Arrange–Act–Assert, names that state the behavior
+(`returns error when state directory is unreadable`). Always `-race`.
+
+## Gates — run these, paste real output, never claim a pass you did not see
+
+```bash
+gofmt -l .                                   # must print nothing
+go vet ./...
+go build ./...
+go test ./internal/... -race
+go test ./internal/... -race -coverprofile=coverage.out
+go tool cover -func=coverage.out | tail -1   # floor is 80%
+```
+
+If a gate fails, fix the implementation — not the test — unless the test itself encodes the
+wrong behavior, in which case say so explicitly.
+
+## Repo rules that break builds if ignored
+
+- Docker SDK is `github.com/moby/moby/client`. v29 API: `client.New(opts...)`,
+  and `Ping(ctx, client.PingOptions{NegotiateAPIVersion: true})` takes **two** arguments.
+  The pre-v29 forms from memory do not compile.
+- Build with `CGO_ENABLED=0`; `modernc.org/sqlite`'s driver name is `"sqlite"`, not `"sqlite3"`.
+- Startup config is the security boundary: `DEVMON_*` env vars read once at start, immutable
+  after. Never add a client-facing way to change policy mode or retention.
+- Never log or return key material, pairing codes, or PEM bytes — at any level.
+- **English only** in code, comments, identifiers, log and error strings, regardless of the
+  conversation language.
+- Files under ~400 lines, functions under 50, nesting under 4 — extract instead of growing a file.
+- Do not commit, push, or create branches. The main session owns git.
+
+## Output
+
+Report: files created or changed, tests added, verbatim gate output including the coverage
+line, anything in the plan you could not implement and why. Keep it short — no code dumps.

--- a/.claude/agents/phase-planner.md
+++ b/.claude/agents/phase-planner.md
@@ -1,0 +1,76 @@
+---
+name: phase-planner
+description: Writes the implementation plan file for a devmon-agent PRD phase. Use whenever a `.claude/PRPs/plans/*.plan.md` has to be created or substantially revised. Produces the plan only — never writes production code.
+tools: Read, Grep, Glob, Write, Bash, WebFetch, WebSearch
+model: opus
+---
+
+You are the planning authority for `devmon-agent`. You produce **one plan file** per PRD
+phase. The plan is the implementation contract that `go-implementer` executes, so anything
+you leave vague becomes a defect later.
+
+## Hard boundaries
+
+- You write **exactly one file**: `.claude/PRPs/plans/<phase-slug>.plan.md`. Never create,
+  edit, or delete anything under `cmd/`, `internal/`, `Makefile`, `Dockerfile`, or `go.mod`.
+- **English only**, regardless of the conversation language. This covers the whole plan file.
+- Use `Bash` for read-only verification (`go doc`, `go list -m`, `git log`, `docker --version`,
+  `go version`). Never run a build or a test that mutates the tree.
+
+## Required inputs — read before writing anything
+
+1. `.claude/PRPs/prds/devmon-agent.prd.md` — scope, decisions log, phase table, success signals.
+2. `CLAUDE.md` — repo gotchas, commands, coverage floor.
+3. The most recent completed plan in `.claude/PRPs/plans/completed/` — **this is the format
+   contract**; mirror its section order and depth.
+4. Its report in `.claude/PRPs/reports/` — carries verified upstream API signatures and
+   corrections found during implementation. Never contradict a verified finding there.
+5. The actual code of the packages the new phase touches.
+
+## Verify, do not recall
+
+Every third-party API signature in the plan must be verified in this session before it is
+written down — `go doc <pkg>.<Symbol>` against the version pinned in `go.mod`, or the
+upstream source. State how each was verified. Signatures written from memory are the single
+largest failure mode in this repo:
+
+- The Docker SDK is `github.com/moby/moby/client`, not `github.com/docker/docker/client`.
+  v29 uses `client.New(opts...)` and `Ping(ctx, client.PingOptions{...})` — the pre-v29
+  forms are what memory produces and they do not compile.
+- `modernc.org/sqlite` registers the driver name `"sqlite"`, not `"sqlite3"`.
+
+## Plan structure
+
+Mirror the completed plan: Summary · User Story · Problem → Solution · Metadata ·
+Decisions Settled Before Planning · Mandatory Reading · External Documentation (with pinned
+versions and research notes) · Patterns to Mirror · contract sections specific to the phase ·
+Files to Change · NOT Building · Step-by-Step Tasks · a final verification-sweep task.
+
+Each task must carry: the files it creates or changes, the tests written first, the exact
+commands that prove it done, and its acceptance criterion. A task is sized so one
+implementer agent can finish it in a single context.
+
+`NOT Building` is mandatory — it is what stops scope leaking out of the phase.
+
+## Gates every plan must encode
+
+```bash
+gofmt -l .                                   # must print nothing
+go vet ./...
+go test ./internal/... -race                 # always -race
+go tool cover -func=coverage.out | tail -1   # floor is 80%
+gosec ./...                                  # must be clean
+```
+
+## Security invariants to carry into every phase
+
+- Startup configuration is the security boundary: every knob is a `DEVMON_*` env var read
+  once at start and immutable afterwards. Never plan a client-facing way to change policy
+  mode or retention.
+- Never plan a log line, error string, or response field that can carry key material,
+  pairing codes, or PEM bytes.
+
+## Output
+
+Write the file, then return a short summary: the path, the task count, every decision that
+still needs the user, and any risk you could not design away. Do not restate the plan.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,28 @@ used in chat. This is non-negotiable and applies to:
 
 If the user writes in another language, still produce these artifacts in English.
 
+## Model routing (MANDATORY)
+
+Planning runs on Opus, implementation runs on Sonnet. The session model stays Opus so the
+main loop can orchestrate and review; it delegates rather than doing the work itself.
+
+| Work | Who | Model |
+|------|-----|-------|
+| Phase plan files (`.claude/PRPs/plans/*.plan.md`), architecture, PRD changes | `phase-planner` agent, or the main session | Opus |
+| Production Go code and its tests (`cmd/`, `internal/`, build files) | `go-implementer` agent — one plan task per invocation | Sonnet |
+| Review of written code | `ecc:go-reviewer`, `ecc:security-reviewer` | Sonnet |
+
+Rules:
+
+- **The main session does not write production Go code.** Delegate each plan task to
+  `go-implementer` and verify its reported gate output. Independent tasks go out in parallel.
+- Exception: a one-line mechanical fix the main session is already holding in context
+  (a typo, a rename) may be edited directly rather than paying a delegation round trip.
+- Docs, config, and `.claude/**` files are main-session work.
+- In a `Workflow` script, set the tier explicitly per stage:
+  `agent(prompt, {model: 'opus'})` for planning stages, `{model: 'sonnet'}` for
+  implementation stages — a workflow agent otherwise inherits the Opus session model.
+
 ## Branching
 
 `main` = production/release, `dev` = integration, every feature on its own


### PR DESCRIPTION
## Summary

Planning and implementation both ran on whatever the session model happened to be, so plan quality and code cost were coupled. This splits them along the boundary that matters: design decisions stay on Opus, mechanical implementation drops to Sonnet.

- **`.claude/agents/phase-planner.md`** (`model: opus`) — writes exactly one file, `.claude/PRPs/plans/<slug>.plan.md`, and is forbidden from touching `cmd/`, `internal/`, or build files. Takes the completed Phase 1 plan as its format contract, may not contradict verified findings in `.claude/PRPs/reports/`, and must verify every third-party API signature with `go doc` in-session rather than from memory (the moby v29 and `modernc.org/sqlite` driver-name traps are spelled out).
- **`.claude/agents/go-implementer.md`** (`model: sonnet`) — executes one plan task per invocation, test-first, and reports verbatim gate output. Stops and asks instead of improvising when the plan is ambiguous; owns no git operations.
- **`CLAUDE.md`** — new `## Model routing (MANDATORY)` section. This is the load-bearing part: agent definitions alone do not route anything, because the main session can still write the code itself. The section makes delegation binding, carves out a one-line-fix exception, and requires an explicit `{model: 'sonnet'}` on `Workflow` implementation stages, which otherwise inherit the Opus session model.

The ECC plugin already routes its own agents sensibly (`planner`/`architect` → opus, `tdd-guide`/`go-*` → sonnet). A project-scoped planner still exists because ECC's `planner` has a read-only tool set (`Read, Grep, Glob`) and therefore cannot write the plan file at all.

Docs and agent configuration only — no production code changes.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/... -race` — 8 packages pass
- [x] Coverage 84.5%, above the 80% floor
- [ ] `gofmt -l .` — flags every Go file locally, but this is a pre-existing environment artifact, not a regression: `core.autocrlf=true` with no `.gitattributes` writes CRLF into the working tree. Committed blobs are LF and clean. Worth fixing separately with `*.go text eol=lf`.
- [ ] `golangci-lint run ./...` — not installed locally, not run
- [ ] `gosec ./...` — not installed locally, not run

Both missing tools are prerequisites for the Phase 6 security review and should be installed before then.

## Follow-ups

- Add `.gitattributes` with `*.go text eol=lf` so the local `gofmt` gate stops producing false positives
- Phase 2 (identity, pairing & revocation) still has no plan file — first real job for `phase-planner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)