### PR TITLE
feat: agent CA, device pairing and immediate revocation

### DIFF
--- a/.claude/PRPs/plans/completed/identity-pairing-and-revocation.plan.md
+++ b/.claude/PRPs/plans/completed/identity-pairing-and-revocation.plan.md
@@ -1,0 +1,976 @@
+# Plan: Identity, Pairing & Revocation (DevMon Agent Phase 2)
+
+## Summary
+
+Turn the agent into its own certificate authority. It issues a unique client certificate to each
+Android device during a one-time, host-authorised pairing step, authenticates every subsequent
+request against that certificate, renews it silently before expiry, and lets access be withdrawn
+either by the device itself or by an operator with host access — taking effect in the running agent
+immediately, with no restart.
+
+This is the phase that makes the product's core claim true: safer than an exposed Docker socket.
+Everything after it (reads, logs, lifecycle) sits behind the channel built here.
+
+## User Story
+
+As an operator who self-hosts Docker on a VPS,
+I want to pair my phone with the agent once and have it authenticate on its own credential thereafter,
+So that I can reach my containers without SSH, and revoke a lost phone without rebuilding the host.
+
+## Problem → Solution
+
+**Current state (end of Phase 1)**: the agent terminates TLS with a self-signed server certificate,
+reaches the Docker Engine, and persists state and logs. `tlsconf.Build` is called with `nil` client
+CAs, so no client certificate can be verified against anything. `requireDevice` fails closed and
+guards no route. `GET /v1/status` is the only endpoint. The `devices` table exists and is empty.
+
+**Desired state**: the agent holds a long-lived CA on the state mount, issues 90-day device
+certificates against operator-generated single-use pairing codes, verifies every guarded request
+against the device registry on each call, renews certificates over the authenticated channel before
+they expire, re-issues its own server certificate from the CA when the host address changes, refuses
+to start when its identity is half-missing, and exposes host-side `device` subcommands for listing,
+revoking, and minting pairing codes.
+
+## Metadata
+
+- **Complexity**: Large (16 files, 12 tasks; ~1,400 lines of production Go plus tests)
+- **Source PRD**: `.claude/PRPs/prds/devmon-agent.prd.md`
+- **PRD Phase**: 2 — Identity, pairing & revocation
+- **Depends on**: Phase 1 (complete)
+- **Estimated Files**: 16 changed (9 created, 7 updated)
+
+---
+
+## Decisions Settled Before Planning
+
+These were open questions during PRD review. They are settled here so implementation never has to
+re-litigate them. Each one has a rationale because each one has a plausible-looking wrong answer.
+
+| # | Decision | Choice | Why not the alternative |
+|---|---|---|---|
+| D1 | How the device's private key is created | Device generates its own keypair and sends a **PKCS#10 CSR**; the agent signs it and never sees a private key | The alternative — agent generates the keypair and ships the key to the phone — puts a private key on the wire and in the agent's memory and logs-adjacent code paths. A CSR flow makes key exfiltration structurally impossible. |
+| D2 | What authenticates the pairing call | The **pairing code itself**, on a route that requires no client certificate | The device has no certificate yet, so it cannot be mTLS-authenticated. This does not violate the PRD's "may inform, never issue" rule — that rule constrains `GET /v1/status` specifically. `POST /v1/pair` is a distinct, code-authenticated route. |
+| D3 | Pairing code strength | `crypto/rand.Text()` — 26 base32 characters, ~130 bits | Rate limiting is Phase 6. A 6-digit human-friendly code would be brute-forceable in seconds on an internet-facing port before that lands. High entropy makes the code safe **independently** of rate limiting, which is the only responsible ordering. |
+| D4 | Pairing code at rest | Stored as **SHA-256 of the code**, never in plaintext | The state directory is readable in VPS snapshots and backups (an accepted MVP risk per the PRD). A plaintext pending code in a backup is a live credential. |
+| D5 | Revocation propagation | **No in-memory device cache.** Every guarded request does one indexed SQLite lookup | This is the entire mechanism behind "a revoked device loses access immediately, without restarting the agent". Any cache — even a 5-second one — turns a hard guarantee into a race. At a few requests per minute the lookup cost is irrelevant. |
+| D6 | Renewal overlap | The **old certificate stays valid until its own `not_after`**; the row is kept with `superseded_at` set | If the renewal response is lost in transit, the device still holds the old certificate. Invalidating it on issue would strand exactly the user renewal exists to protect. Revocation targets the **device**, not a certificate, so overlap never weakens it. |
+| D7 | Revocation granularity | Revoking marks the **device** revoked; all its certificates die at once | A per-certificate revocation list would let a device survive revocation by renewing first. |
+| D8 | Host-side CLI shape | **Subcommands on the same binary**, run via `docker exec` | The image is `distroless/static:nonroot` — there is no shell and no second binary. `docker exec devmon-agent /usr/local/bin/devmon-agent device list` is the only shape that works. |
+| D9 | Missing-state detection | A **consistency matrix** over (state DB present, CA present) — both absent is a genuine first run; exactly one present is fatal | A bare "is the CA missing?" check cannot tell a first install from a destroyed state directory, and getting that wrong means either a false alarm on every fresh install or silent re-identification after data loss. |
+| D10 | Server certificate on address change | **Re-issued from the retained CA**, automatically, on detected SAN drift | Clients pin the **CA**, not the leaf, so re-issuance is invisible to them. This is what makes a VPS IP change survivable without re-pairing. Phase 1 already detects the drift and logs it; this phase acts on it. |
+| D11 | `last_seen_at` write cost | Updated only when the stored value is older than 60s | Writing on every request, against a pool capped at `MaxOpenConns(1)`, would serialise reads behind a write for no operational benefit. |
+
+---
+
+## UX Design
+
+### Before
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Operator                                                 │
+│    $ docker run ... devmon-agent                          │
+│    agent listening addr=:8443 policy=default              │
+│                                                           │
+│  Phone                                                    │
+│    GET /v1/status  ──────────────►  200 {version, policy} │
+│    (anything else) ──────────────►  404                   │
+│                                                           │
+│  There is no way to become a client.                      │
+└──────────────────────────────────────────────────────────┘
+```
+
+### After
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Operator (host, once per device)                                     │
+│    $ docker exec devmon-agent /usr/local/bin/devmon-agent \           │
+│          device pair-code --name "Pixel 9"                            │
+│    Pairing code: K25YDO5XNWWNL2GQJUKB6TTFYZ                           │
+│    Expires:      2026-08-07T14:12:00Z (10 minutes, single use)        │
+│                                                                       │
+│  Phone (once)                                                         │
+│    generates keypair ─► POST /v1/pair {code, csr}                     │
+│                     ◄── 201 {device_id, cert, ca_cert, not_after}     │
+│    pins ca_cert                                                       │
+│                                                                       │
+│  Phone (every time after)                                             │
+│    mTLS handshake with its own cert ──► guarded routes                │
+│    near expiry: POST /v1/device/renew ──► 200 {cert, not_after}       │
+│    user taps "forget server": DELETE /v1/device/self ──► 204          │
+│                                                                       │
+│  Operator (phone lost)                                                │
+│    $ ... device list                                                  │
+│    ID        NAME      PAIRED       LAST SEEN   STATE                 │
+│    d3f9a1c2  Pixel 9   2026-08-07   2m ago      active                │
+│    $ ... device revoke d3f9a1c2                                       │
+│    revoked d3f9a1c2 (Pixel 9)                                         │
+│    → the phone's very next request fails. No restart.                 │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Interaction Changes
+
+| Touchpoint | Before | After | Notes |
+|---|---|---|---|
+| `GET /v1/status` | 4 fields | 5 fields — adds `ca_fingerprint` | Lets a client tell "my credential expired" from "this server's identity changed". `status_test.go:54` asserts the exact count and must change 4 → 5. |
+| Guarded routes | none exist | `requireDevice` resolves a real device | Rejection stays the terse `client certificate required` — never *why*. |
+| First start, empty state | generates self-signed server cert | generates CA **and** CA-issued server cert; logs the fingerprint at WARN | The operator should record the fingerprint; it is what detects a later identity change. |
+| First start, partial state | not detected | **fatal, specific error** | PRD requirement: a regenerated identity is indistinguishable from an attack. |
+| Host address change | WARN only | WARN **then re-issues** the server cert from the CA | No re-pair. |
+| Host CLI | none | `device list` / `device revoke` / `device pair-code` | Same binary, via `docker exec`. |
+
+---
+
+## Mandatory Reading
+
+Read these before writing any code. Line numbers are current as of this plan.
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| P0 | `internal/state/store.go` | 1–195 | The store contract, `FirstRun`, the DSN pragmas, and `verifyAndMigrate` — which this phase extends into a real migration ladder. |
+| P0 | `internal/state/schema.go` | 1–48 | The v1 schema and the comment claiming this phase adds rows, not migrations. Task 1 revises that intent deliberately. |
+| P0 | `internal/certs/selfsigned.go` | 25–111 | Certificate template conventions, PEM types, serial entropy, the 398-day leaf rule, and `splitSANs`. |
+| P0 | `internal/certs/store.go` | 16–162 | `os.OpenRoot` + `O_EXCL` write discipline, the both-or-neither keypair check, and the drift reporting this phase acts on. |
+| P0 | `internal/httpapi/middleware.go` | 9–35 | `requireDevice` as Phase 1 left it, including the exact `_ = next` placeholder to replace. |
+| P0 | `internal/tlsconf/tlsconf.go` | 10–47 | Why `VerifyClientCertIfGiven` rather than `RequireAndVerifyClientCert`. Do not "fix" this. |
+| P1 | `internal/httpapi/respond.go` | 9–47 | `writeJSON` / `writeError` — the single exit point for every body, and the rule that error text stays terse. |
+| P1 | `internal/httpapi/status.go` | 15–40 | The strict-allowlist comment on `statusResponse`, which already names `ca_fingerprint` as this phase's addition. |
+| P1 | `internal/httpapi/server.go` | 63–75 | `routes()` and the Go 1.22+ method-pattern requirement. |
+| P1 | `internal/config/config.go` | 85–98 | Derived-path methods. New paths belong here, never concatenated by hand. |
+| P1 | `cmd/devmon-agent/main.go` | 52–145 | `run`/`serve` construction order and `runAll`. |
+| P2 | `internal/httpapi/status_test.go` | 30–62, 188–233 | `TestStatusFieldCount` (the 4→5 edit) and the `requireDevice` table test to extend. |
+| P2 | `internal/state/store_test.go` | 17–90 | Test helpers (`testLogger`, `tempDBPath`, `openStore`) and the Arrange/Act/Assert comment style. |
+| P2 | `Dockerfile` | 29–36 | `distroless/static:nonroot`, no shell — the constraint behind D8. |
+| P2 | `Makefile` | 31–55 | Gate commands. `-race` needs `CGO_ENABLED=1`; the shipped binary does not. |
+
+## External Documentation
+
+No third-party research is needed: the CA, CSR, and verification path is entirely `crypto/x509`, and
+this phase adds no new module dependency. Every API below was **compile-verified against the
+project's own toolchain (go1.26.4)** rather than recalled — the probe output is reproduced so the
+implementer can trust the shapes.
+
+| Topic | Source | Key Takeaway |
+|---|---|---|
+| Pairing code entropy | `crypto/rand.Text()` (Go 1.24+) | Returns a 26-character base32 string, ~130 bits. Verified: `rand.Text len: 26 sample: K25YDO5XNWWNL2GQJUKB6TTFYZ`. |
+| CSR handling | `crypto/x509` | `x509.ParseCertificateRequest(der)` then `csr.CheckSignature()` (method, no args, returns `error`). Verified both return `<nil>` on a well-formed CSR. |
+| Signing a leaf from a CSR | `x509.CreateCertificate(rand.Reader, leafTmpl, caCert, csr.PublicKey, caKey)` | `csr.PublicKey` is `any`; for a P-256 CSR it type-asserts to `*ecdsa.PublicKey`. Verified. |
+| Client-cert verification | `leaf.Verify(x509.VerifyOptions{Roots: pool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}})` | Returned `<nil>` for a CA-issued leaf carrying `ExtKeyUsageClientAuth`. **A leaf without that EKU is rejected by `crypto/tls` during the handshake** — omitting it is the single most likely silent failure in this phase. |
+| Serial as a registry key | `big.Int.Text(16)` / `new(big.Int).SetString(s, 16)` | Round-trips exactly. Verified. Use lowercase hex, no `0x`, no colons. |
+| CA constraints | `x509.Certificate` | `IsCA: true`, `BasicConstraintsValid: true`, `MaxPathLenZero: true`, `KeyUsage: CertSign \| CRLSign`. Verified to sign and verify. |
+
+```
+KEY_INSIGHT: A CA-issued client certificate MUST carry ExtKeyUsage{ExtKeyUsageClientAuth}.
+APPLIES_TO:  Task 4 (CA.IssueDeviceCert)
+GOTCHA:      crypto/tls verifies peer certificates with KeyUsages=ClientAuth. A leaf missing the
+             EKU fails at the TLS handshake with an opaque "bad certificate" alert, before any
+             handler or middleware runs — so no agent log line will name the real cause. The unit
+             test in Task 4 must assert the EKU explicitly; the handshake test in Task 7 will not
+             tell you which of a dozen things was wrong.
+
+KEY_INSIGHT: MaxPathLenZero must be set on the CA, not just MaxPathLen: 0.
+APPLIES_TO:  Task 4 (certs.LoadOrCreateCA)
+GOTCHA:      x509 treats MaxPathLen=0 as "unset" unless MaxPathLenZero is true. Without it the CA
+             encodes no path-length constraint at all, permitting sub-CAs.
+```
+
+---
+
+## Patterns to Mirror
+
+Every snippet below is copied verbatim from this repository. New code must be indistinguishable
+from it.
+
+### NAMING_CONVENTION
+```go
+// SOURCE: internal/config/config.go:22-27
+// Environment variable keys. Declared as constants so a typo is a compile error
+// and so error messages can name the exact variable the operator must fix.
+const (
+	envStateDir        = "DEVMON_STATE_DIR"
+	envListenAddr      = "DEVMON_LISTEN_ADDR"
+```
+```go
+// SOURCE: internal/certs/store.go:16-24
+// File names and modes within $DEVMON_STATE_DIR/certs.
+const (
+	serverCertFile = "server.crt"
+	serverKeyFile  = "server.key"
+
+	certsDirMode      = 0o700
+	serverKeyFileMode = 0o600
+	serverCrtFileMode = 0o644
+)
+```
+Unexported package-level constants for every file name, mode, timeout, and limit. No literal
+appears twice. Every constant carries a comment saying why that value.
+
+### ERROR_HANDLING
+```go
+// SOURCE: internal/state/store.go:27-33
+var (
+	// ErrStateCorrupt means the file exists but is not a usable database — the
+	// realistic outcome of a botched restore or a truncated copy.
+	ErrStateCorrupt = errors.New("state store is unreadable or corrupt")
+	// ErrSchemaTooNew means the store was written by a newer agent version.
+	ErrSchemaTooNew = errors.New("state store was written by a newer agent version")
+)
+```
+```go
+// SOURCE: internal/certs/store.go:36-38
+	if err := os.MkdirAll(dir, certsDirMode); err != nil {
+		return tls.Certificate{}, false, fmt.Errorf("create certs dir %s: %w", dir, err)
+	}
+```
+Sentinels only where a caller must branch. Every other error is wrapped with `%w` and a lowercase
+verb-phrase naming the operation and its subject. Never `errors.New` inline for a wrapped cause.
+
+### LOGGING_PATTERN
+```go
+// SOURCE: internal/dockerx/client.go:58-61
+	log.Info("docker engine reachable",
+		slog.String("api_version", res.APIVersion),
+		slog.String("os_type", res.OSType),
+	)
+```
+```go
+// SOURCE: internal/certs/store.go:60-64
+		log.Warn("server certificate does not cover every configured address",
+			slog.Any("configured", sans),
+			slog.Any("covered_dns", leaf.DNSNames),
+			slog.Any("covered_ip", ipStrings(leaf.IPAddresses)),
+		)
+```
+Lowercase message, no punctuation, typed `slog` attributes with `snake_case` keys. The injected
+`*slog.Logger` only — never `slog.Default()`. **Never log key material, pairing codes, or PEM
+bytes, at any level** (`internal/certs/selfsigned.go:8-9`). Log a certificate's serial, subject, and
+expiry; never its bytes.
+
+### REPOSITORY_PATTERN
+```go
+// SOURCE: internal/state/store.go:1-7
+// Package state owns the agent's durable store: the device registry, the audit
+// trail, and the schema version that gates upgrades.
+//
+// The store is a SQLite database in WAL mode on the operator's bind mount.
+// Callers never see *sql.DB or a SQL string — everything goes through methods on
+// Store, each taking a context.Context first.
+```
+```go
+// SOURCE: internal/state/store.go:203-231
+func (s *Store) PruneAudit(ctx context.Context, maxAge time.Duration, maxRows int) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin audit prune: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	...
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit audit prune: %w", err)
+	}
+```
+No SQL string escapes the `state` package. Every method takes `ctx` first. Multi-statement writes
+go in a transaction with `defer tx.Rollback()` before the commit.
+
+### SERVICE_PATTERN
+```go
+// SOURCE: internal/state/pruner.go:28-36
+func NewPruner(store *Store, maxAge time.Duration, maxRows int, log *slog.Logger) *Pruner {
+	return &Pruner{
+		store:    store,
+		maxAge:   maxAge,
+		maxRows:  maxRows,
+		interval: defaultPruneInterval,
+		log:      log,
+	}
+}
+```
+Constructor injection, dependencies as parameters, no package-level mutable state, no singletons.
+Long-lived components expose `Run(ctx) error` and are passed to `runAll` in `main`.
+
+### HTTP_HANDLER_PATTERN
+```go
+// SOURCE: internal/httpapi/status.go:33-40
+func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	s.writeJSON(w, http.StatusOK, statusResponse{
+		APIVersion:   APIVersion,
+		AgentVersion: version.Version,
+		PolicyMode:   s.cfg.PolicyMode.String(),
+		ServerTime:   time.Now().UTC().Format(time.RFC3339),
+	})
+}
+```
+```go
+// SOURCE: internal/httpapi/server.go:70-72
+	// The Go 1.22+ method pattern matters. Registering "/v1/status" alone would
+	// also match POST, DELETE, and everything else.
+	mux.HandleFunc("GET /v1/status", s.handleStatus)
+```
+Handlers are methods on `*Server`, named `handleX`. Every route registers a method. Every response
+goes through `writeJSON`/`writeError`. Request and response types are unexported structs with
+`json` tags declared next to the handler.
+
+### TEST_STRUCTURE
+```go
+// SOURCE: internal/httpapi/status_test.go:64-90
+func TestStatusContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode policy.Mode
+		want string
+	}{
+		{name: "read-only is advertised", mode: policy.ModeReadOnly, want: "read-only"},
+		...
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s := testServer(t, tt.mode)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+
+			// Assert
+			var body statusResponse
+```
+```go
+// SOURCE: internal/state/store_test.go:17-34
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func openStore(t *testing.T, path string) *Store {
+	t.Helper()
+	s, err := Open(context.Background(), path, testLogger())
+	if err != nil {
+		t.Fatalf("Open(%s) unexpected error: %v", path, err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+```
+`t.Parallel()` at both levels. Literal `// Arrange` / `// Act` / `// Assert` comments. Table entries
+have prose `name` fields. `t.Fatalf` for setup faults, `t.Errorf` for assertions. Failure messages
+follow `got = X, want Y` and often add *why it matters* (`store_test.go:89`).
+
+---
+
+## State Directory Layout (after this phase)
+
+```
+$DEVMON_STATE_DIR/                 (0700)
+├── devmon.db                      (0600)  schema v2
+├── devmon.db-wal / -shm           (0600)
+├── certs/                         (0700)
+│   ├── ca.crt                     (0644)  ← NEW  long-lived, 10 years
+│   ├── ca.key                     (0600)  ← NEW  unencrypted (PRD-accepted risk)
+│   ├── server.crt                 (0644)  now CA-issued, was self-signed
+│   └── server.key                 (0600)
+└── logs/                          (0700)
+    └── agent.log                  (0600)
+```
+
+## Database Schema (v2)
+
+```sql
+-- devices: one row per paired device. Identity only; certificates live separately
+-- so a renewal is an INSERT, not a destructive UPDATE (see D6).
+CREATE TABLE devices (
+    id           TEXT PRIMARY KEY,   -- 16 lowercase hex chars
+    name         TEXT NOT NULL,
+    paired_at    INTEGER NOT NULL,
+    last_seen_at INTEGER,
+    revoked_at   INTEGER             -- NULL = active
+);
+CREATE INDEX idx_devices_revoked ON devices(revoked_at);
+
+-- device_certs: every certificate ever issued to a device. Auth resolves the
+-- peer's serial here, then checks the owning device is not revoked.
+CREATE TABLE device_certs (
+    serial        TEXT PRIMARY KEY,  -- big.Int.Text(16), lowercase, no 0x
+    device_id     TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    not_before    INTEGER NOT NULL,
+    not_after     INTEGER NOT NULL,
+    issued_at     INTEGER NOT NULL,
+    superseded_at INTEGER             -- set on renewal; the cert stays valid (D6)
+);
+CREATE INDEX idx_device_certs_device ON device_certs(device_id);
+
+-- pairing_codes: pending single-use codes. The code is never stored in plaintext (D4).
+CREATE TABLE pairing_codes (
+    code_hash   TEXT PRIMARY KEY,    -- hex SHA-256 of the code
+    device_name TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    expires_at  INTEGER NOT NULL,
+    used_at     INTEGER,             -- NULL = unused; set atomically on redemption
+    used_by     TEXT                 -- device id, once redeemed
+);
+CREATE INDEX idx_pairing_codes_expires ON pairing_codes(expires_at);
+```
+
+All timestamps are Unix seconds, matching the v1 convention in `schema.go`.
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|---|---|---|
+| `internal/state/schema.go` | UPDATE | Add `schemaV2`, bump `currentSchemaVersion` to 2, add the migration ladder. |
+| `internal/state/store.go` | UPDATE | Replace the single-schema apply with versioned migrations; add new sentinels. |
+| `internal/state/devices.go` | CREATE | Device + certificate registry methods. |
+| `internal/state/pairing.go` | CREATE | Pairing-code mint and atomic single-use redemption. |
+| `internal/state/devices_test.go` | CREATE | Registry tests, including concurrent redemption. |
+| `internal/certs/ca.go` | CREATE | `LoadOrCreateCA`, `Fingerprint`, `Pool`. |
+| `internal/certs/issue.go` | CREATE | `IssueDeviceCert` (CSR → leaf) and `IssueServerCert` (CA-signed). |
+| `internal/certs/store.go` | UPDATE | Server cert now CA-issued; re-issue on SAN drift; identity consistency check. |
+| `internal/certs/ca_test.go` | CREATE | CA properties, issuance, EKU, verification. |
+| `internal/httpapi/pair.go` | CREATE | `POST /v1/pair`. |
+| `internal/httpapi/device.go` | CREATE | `POST /v1/device/renew`, `DELETE /v1/device/self`. |
+| `internal/httpapi/middleware.go` | UPDATE | `requireDevice` resolves a real device; adds context injection. |
+| `internal/httpapi/status.go` | UPDATE | Add `ca_fingerprint`. |
+| `internal/httpapi/server.go` | UPDATE | New routes; `NewServer` takes the CA fingerprint and issuer. |
+| `internal/httpapi/*_test.go` | UPDATE | 4→5 field count; new endpoint and auth tests. |
+| `cmd/devmon-agent/cli.go` | CREATE | `device list\|revoke\|pair-code`. |
+| `cmd/devmon-agent/main.go` | UPDATE | CA load, consistency check, CLI dispatch, wire `tlsconf.Build(cert, pool)`. |
+| `README.md` | UPDATE | Pairing walkthrough, CLI reference, fingerprint guidance. |
+
+## NOT Building
+
+Explicitly out of scope. Adding any of these is scope creep, not thoroughness.
+
+- **Rate limiting** — Phase 6. D3 makes the pairing code safe without it; do not add a limiter here.
+- **Any container, image, network, or volume operation** — Phases 3–5. `dockerx` gains no methods.
+- **Audit log writes** — Phase 5. The `audit` table stays empty; do not write to it, even for pairing.
+- **A CRL or OCSP responder** — revocation is a registry lookup (D5). No CRL is published.
+- **Encrypting `ca.key` at rest** — the PRD settles this explicitly; document it, do not solve it.
+- **Cross-device management from the app** — a device may act on itself and nothing else.
+- **Notifications on pair/revoke** — post-MVP, `Won't` in the PRD.
+- **CA renewal or rotation tooling** — the CA is 10-year; rotation is a later concern.
+- **Changing `VerifyClientCertIfGiven`** — `tlsconf.go:10-27` explains why. Leave it.
+
+---
+
+## Step-by-Step Tasks
+
+Tasks 1–2, 3–4, and 9 are the natural parallel groups; 5 onward serialise on them. Each task is
+sized for one `go-implementer` invocation.
+
+### Task 1: Schema v2 and the migration ladder
+- **ACTION**: Extend `internal/state/schema.go` and `verifyAndMigrate` in `store.go`.
+- **IMPLEMENT**: Bump `currentSchemaVersion` to `2`. Add `schemaV2` containing the three statements
+  in the Database Schema section. Replace the unconditional `ExecContext(ctx, schemaV1)` in
+  `verifyAndMigrate` (`store.go:147`) with a ladder: read the current version, then apply each
+  migration whose target exceeds it, in order, **inside a single transaction per step**, stamping
+  `schema_meta.version` in that same transaction. A fresh store applies v1 then v2.
+- **MIRROR**: REPOSITORY_PATTERN — SQL stays in the package; the transaction uses
+  `defer tx.Rollback()` before `Commit`, exactly as `PruneAudit` does.
+- **IMPORTS**: no new ones.
+- **GOTCHA**: The v1 `devices` table has `cert_serial`/`cert_not_after` columns that v2 replaces.
+  **Drop and recreate `devices` in the v2 migration.** This is safe and is the only time it will be:
+  Phase 1 never wrote a device row, so every existing deployment's table is provably empty. Do not
+  attempt `ALTER TABLE` gymnastics — preserving data that cannot exist is complexity for nothing.
+  Note the deviation from `schema.go:13-15`, which predicted no Phase 2 migration; update that
+  comment rather than leaving it to mislead the next reader.
+- **GOTCHA**: `_foreign_keys=1` is already in the DSN (`store.go:127`), so `device_certs`'s
+  `REFERENCES` is enforced. Insert the device row before its certificate row.
+- **GOTCHA**: `reconcileVersion` (`store.go:155-175`) currently stamps the version only when the row
+  is absent. The ladder subsumes that logic — rewrite it rather than layering on top, or a v1 store
+  will migrate and then keep reporting v1.
+- **VALIDATE**: `go test ./internal/state/... -race`. New tests: a fresh store reports version 2 and
+  has all five tables; a v1 store on disk (build one by exec'ing `schemaV1` and stamping version 1)
+  migrates to v2 and keeps its `schema_meta` row; a store stamped version 3 still returns
+  `ErrSchemaTooNew`.
+
+### Task 2: Device and certificate registry
+- **ACTION**: Create `internal/state/devices.go` and `internal/state/devices_test.go`.
+- **IMPLEMENT**:
+  ```go
+  type Device struct {
+      ID         string
+      Name       string
+      PairedAt   time.Time
+      LastSeenAt time.Time // zero when never seen
+      RevokedAt  time.Time // zero when active
+  }
+  func (d Device) IsRevoked() bool
+
+  func (s *Store) CreateDevice(ctx context.Context, name string) (Device, error)
+  func (s *Store) DeleteDevice(ctx context.Context, id string) error
+  func (s *Store) RecordDeviceCert(ctx context.Context, deviceID, serial string, notBefore, notAfter time.Time) error
+  func (s *Store) SupersedePriorCerts(ctx context.Context, deviceID, keepSerial string) error
+  func (s *Store) DeviceByCertSerial(ctx context.Context, serial string) (Device, error)
+  func (s *Store) ListDevices(ctx context.Context) ([]Device, error)
+  func (s *Store) RevokeDevice(ctx context.Context, id string) error
+  func (s *Store) TouchDevice(ctx context.Context, id string) error
+  ```
+  `CreateDevice` generates the ID as 8 random bytes hex-encoded via `crypto/rand.Read`.
+  `DeviceByCertSerial` joins `device_certs` to `devices` and returns `ErrDeviceNotFound` when the
+  serial is unknown; it returns the device **even when revoked**, so the caller can distinguish and
+  log precisely. `RevokeDevice` is idempotent and returns `ErrDeviceNotFound` for an unknown id.
+  `DeleteDevice` exists only for the pairing rollback path in Task 7. `TouchDevice` implements D11:
+  `UPDATE ... SET last_seen_at=? WHERE id=? AND (last_seen_at IS NULL OR last_seen_at < ?)`.
+- **MIRROR**: REPOSITORY_PATTERN for method shape and transactions; ERROR_HANDLING for the new
+  `ErrDeviceNotFound` sentinel (declare it beside `ErrStateCorrupt` in `store.go`).
+- **IMPORTS**: `crypto/rand`, `encoding/hex`, `database/sql`, `errors`, `fmt`, `time`, `context`.
+- **GOTCHA**: Times are Unix seconds in the DB and `time.Time` in Go — convert at the boundary in
+  this package only. Nullable columns (`last_seen_at`, `revoked_at`) must scan into `sql.NullInt64`;
+  scanning a NULL into `int64` fails at runtime, not compile time.
+- **GOTCHA**: `TouchDevice`'s 60-second threshold is a named constant (`lastSeenResolution`), not a
+  literal — see NAMING_CONVENTION.
+- **VALIDATE**: `go test ./internal/state/... -race`. Cover: create → look up by serial; revoked
+  device is returned with `IsRevoked()` true; unknown serial gives `ErrDeviceNotFound`; `TouchDevice`
+  twice in quick succession performs one write (assert `last_seen_at` is unchanged by the second).
+
+### Task 3: Pairing-code mint and redemption
+- **ACTION**: Create `internal/state/pairing.go`; tests in `devices_test.go`.
+- **IMPLEMENT**:
+  ```go
+  const pairingCodeTTL = 10 * time.Minute
+
+  // MintPairingCode returns the PLAINTEXT code to show the operator once. Only its
+  // hash is persisted (D4); the plaintext is unrecoverable afterwards.
+  func (s *Store) MintPairingCode(ctx context.Context, deviceName string) (code string, expiresAt time.Time, err error)
+
+  // RedeemPairingCode atomically marks the code used and returns the device name
+  // it was minted for. It is the single-use guarantee.
+  func (s *Store) RedeemPairingCode(ctx context.Context, code, deviceID string) (deviceName string, err error)
+
+  func (s *Store) PrunePairingCodes(ctx context.Context) (int64, error)
+  ```
+  `MintPairingCode` uses `rand.Text()` and stores the hex SHA-256 of the code.
+  `RedeemPairingCode` runs `UPDATE pairing_codes SET used_at=?, used_by=? WHERE code_hash=? AND
+  used_at IS NULL AND expires_at > ?` and treats `RowsAffected() == 0` as `ErrPairingCodeInvalid`.
+- **MIRROR**: REPOSITORY_PATTERN; ERROR_HANDLING for `ErrPairingCodeInvalid`.
+- **IMPORTS**: `crypto/rand`, `crypto/sha256`, `encoding/hex`.
+- **GOTCHA**: **The single-use guarantee lives in that one conditional UPDATE**, not in a
+  read-then-write pair. A `SELECT` followed by an `UPDATE` is a TOCTOU race that two simultaneous
+  pairing attempts with the same leaked code would win. The DSN's `_txlock=immediate`
+  (`store.go:128`) plus the `used_at IS NULL` predicate is what makes it atomic.
+- **GOTCHA**: `RedeemPairingCode` needs the device name **and** must set `used_by` in one statement.
+  Use `RETURNING device_name` on the UPDATE (SQLite 3.35+; `modernc.org/sqlite` v1.56 supports it)
+  rather than an UPDATE followed by a SELECT, which reintroduces the race.
+- **GOTCHA**: `ErrPairingCodeInvalid` must be **one** error covering unknown, expired, and
+  already-used. Three distinct errors would let a caller enumerate code state, and the handler must
+  not tell a client which it was.
+- **GOTCHA**: Never log the code. `MintPairingCode` returns it; only the CLI prints it, to stdout.
+- **VALIDATE**: `go test ./internal/state/... -race`. Cover: mint → redeem succeeds; second redeem
+  of the same code fails; expired code fails (mint, then rewrite `expires_at` into the past
+  directly); **N goroutines redeeming one code concurrently produce exactly one success** — this is
+  the test that justifies the conditional UPDATE, and it must run under `-race`.
+
+### Task 4: The certificate authority
+- **ACTION**: Create `internal/certs/ca.go` and `internal/certs/issue.go`.
+- **IMPLEMENT**:
+  ```go
+  const (
+      caValidity         = 10 * 365 * 24 * time.Hour
+      deviceCertValidity = 90 * 24 * time.Hour
+      caCertFile         = "ca.crt"
+      caKeyFile          = "ca.key"
+      caKeyFileMode      = 0o600
+      caCrtFileMode      = 0o644
+  )
+
+  type CA struct { cert *x509.Certificate; key *ecdsa.PrivateKey }
+
+  func LoadOrCreateCA(dir string, log *slog.Logger) (*CA, bool, error) // bool = created
+  func (c *CA) Fingerprint() string          // hex SHA-256 over cert.Raw
+  func (c *CA) CertPEM() []byte
+  func (c *CA) Pool() *x509.CertPool
+  func (c *CA) IssueDeviceCert(csrDER []byte, commonName string, now time.Time) (certPEM []byte, serial string, notAfter time.Time, err error)
+  func (c *CA) IssueServerCert(sans []string, now time.Time) (certPEM, keyPEM []byte, err error)
+  ```
+  `IssueDeviceCert` parses the CSR, calls `csr.CheckSignature()`, rejects a non-ECDSA or non-P-256
+  public key, then signs a leaf with `KeyUsage: DigitalSignature` and
+  `ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}`.
+- **MIRROR**: `selfsigned.go:53-98` for template construction, serial generation
+  (`rand.Int` over `1<<serialBits`), clock-skew tolerance (`notBefore.Add(-time.Minute)`), and PEM
+  encoding with the existing `pemTypeCertificate` / `pemTypePrivateKey` constants.
+  `store.go:92-116` for the `os.OpenRoot` + `writeExclusive` write discipline.
+- **IMPORTS**: `crypto/ecdsa`, `crypto/elliptic`, `crypto/rand`, `crypto/sha256`, `crypto/x509`,
+  `crypto/x509/pkix`, `encoding/hex`, `encoding/pem`, `math/big`.
+- **GOTCHA**: `ExtKeyUsageClientAuth` is mandatory — see the KEY_INSIGHT block above. Assert it in
+  the unit test; the handshake will not tell you.
+- **GOTCHA**: `MaxPathLenZero: true` alongside `IsCA: true`, or the CA permits sub-CAs.
+- **GOTCHA**: `IssueServerCert` keeps the existing 398-day `serverCertValidity`, **not** `caValidity`
+  — the comment at `selfsigned.go:26-29` explains that mobile stacks reject longer leaves.
+- **GOTCHA**: Write `ca.key` first with `O_EXCL` at `0600` (never `WriteFile`-then-`Chmod`; gosec
+  G306 and a real world-readable window), and remove it if the `ca.crt` write then fails — mirror
+  `store.go:99-116` exactly.
+- **GOTCHA**: `csr.Subject` is attacker-controlled. Ignore it entirely and set the CN from the
+  agent's own `commonName` argument (the device ID). A CSR asking to be `CN=admin` must not get it.
+- **VALIDATE**: `go test ./internal/certs/... -race`. Cover: created CA has `IsCA`, `MaxPathLenZero`,
+  `CertSign`; a second `LoadOrCreateCA` on the same dir returns the same fingerprint and
+  `created=false`; an issued device cert verifies against `Pool()` with
+  `KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}`; a CSR with a broken signature is
+  rejected; a CSR requesting `CN=admin` yields a cert whose CN is the supplied device ID; `ca.key`
+  is mode `0600`.
+
+### Task 5: Server certificate from the CA, and the identity consistency check
+- **ACTION**: Update `internal/certs/store.go`.
+- **IMPLEMENT**: Change `LoadOrCreateServerCert` to take a `*CA` and issue from it instead of
+  self-signing. On detected `sanDrift`, **re-issue**: log at WARN, remove `server.crt`/`server.key`,
+  and write a fresh CA-issued pair covering the current SANs (D10). Add:
+  ```go
+  // ErrIdentityIncomplete reports that the state directory holds some of the
+  // agent's identity but not all of it — the signature of a partial restore or a
+  // destroyed bind mount, not of a first install.
+  var ErrIdentityIncomplete = errors.New("agent identity is incomplete")
+
+  func CheckIdentityConsistency(certsDir string, dbExisted bool) error
+  ```
+  implementing D9: `(dbExisted=false, ca absent)` → nil, genuine first run;
+  `(true, absent)` or `(false, present)` → `ErrIdentityIncomplete` naming which half is missing and
+  telling the operator that every device must re-pair if they proceed by clearing the directory;
+  `(true, present)` → nil.
+- **MIRROR**: ERROR_HANDLING sentinel style; LOGGING_PATTERN for the drift warning already at
+  `store.go:60-64`.
+- **IMPORTS**: no new ones.
+- **GOTCHA**: Re-issuance must remove **both** files before writing, or `writeExclusive`'s `O_EXCL`
+  fails with "file exists" and the agent refuses to start after an address change — the exact
+  outcome D10 exists to prevent.
+- **GOTCHA**: `LoadOrCreateServerCert` currently returns `(tls.Certificate, bool, error)` where the
+  bool is drift. Once drift triggers re-issuance the bool is always false at return; drop it and fix
+  the one caller (`main.go:122`) rather than returning a value that can no longer be true.
+- **GOTCHA**: Keep `keypairExists`'s both-or-neither check. It is a different failure (a torn write)
+  from `ErrIdentityIncomplete` (a lost directory) and both messages should survive.
+- **VALIDATE**: `go test ./internal/certs/... -race`. Cover: server cert chains to the CA; changing
+  the SAN set re-issues and the new leaf covers the new address while the CA fingerprint is
+  unchanged; the four consistency-matrix cases.
+
+### Task 6: `requireDevice` resolves a real device
+- **ACTION**: Update `internal/httpapi/middleware.go`.
+- **IMPLEMENT**: Replace the Phase 1 placeholder (`middleware.go:29-33`, including `_ = next`) with:
+  extract `r.TLS.PeerCertificates[0]`, format `SerialNumber.Text(16)`, call
+  `s.st.DeviceByCertSerial`, reject on `ErrDeviceNotFound` or `IsRevoked()`, call `TouchDevice`,
+  inject the device into the request context, and call `next`. Add:
+  ```go
+  type deviceCtxKey struct{}
+  func DeviceFrom(ctx context.Context) (state.Device, bool)
+  ```
+- **MIRROR**: the existing `requireDevice` shape and `writeError` usage; LOGGING_PATTERN for the
+  rejection log line.
+- **IMPORTS**: `context`, `errors`, `github.com/scnplt/devmon-agent/internal/state`.
+- **GOTCHA**: **Every rejection reason returns the same body and status** — the terse
+  `msgClientCertRequired` with 401. Unknown serial, revoked device, and no certificate must be
+  indistinguishable to the client (`respond.go:38-44`). The *reason* goes to the agent log, where
+  the operator can read it and a scanner cannot.
+- **GOTCHA**: A `TouchDevice` failure must **not** fail the request. Log it and continue; a
+  last-seen write is bookkeeping, not authorisation.
+- **GOTCHA**: `deviceCtxKey` is an empty struct type, not a string — a string key can collide with
+  another package's context value.
+- **GOTCHA**: `testServer` (`status_test.go:24-28`) passes `nil` for the store. Any test exercising
+  the new lookup path needs a real `*state.Store`; add a second helper rather than changing the
+  existing one, which several passing tests rely on.
+- **VALIDATE**: `go test ./internal/httpapi/... -race`. Extend the existing table at
+  `status_test.go:188` with: unknown serial → 401; revoked device → 401; active device → handler runs
+  and `DeviceFrom` returns it. Assert the revoked and unknown bodies are byte-identical.
+
+### Task 7: `POST /v1/pair`
+- **ACTION**: Create `internal/httpapi/pair.go`.
+- **IMPLEMENT**:
+  ```go
+  type pairRequest struct {
+      PairingCode string `json:"pairing_code"`
+      CSRPEM      string `json:"csr_pem"`
+  }
+  type pairResponse struct {
+      DeviceID       string `json:"device_id"`
+      CertificatePEM string `json:"certificate_pem"`
+      CACertificate  string `json:"ca_certificate_pem"`
+      NotAfter       string `json:"not_after"`   // RFC3339
+  }
+  ```
+  Handler order: decode with a body size limit → decode the CSR PEM → `CreateDevice` →
+  `RedeemPairingCode` → `IssueDeviceCert` → `RecordDeviceCert` → 201. The device name comes from the
+  redeemed code, never from the request.
+- **MIRROR**: HTTP_HANDLER_PATTERN; register as `mux.HandleFunc("POST /v1/pair", s.handlePair)`.
+- **IMPORTS**: `encoding/pem`, `net/http`, `errors`, `time`.
+- **GOTCHA**: Wrap the body in `http.MaxBytesReader(w, r.Body, maxPairBodyBytes)` with
+  `maxPairBodyBytes = 8 << 10`. This route is reachable **without a client certificate**; an
+  unbounded JSON body is a trivial memory-exhaustion vector and there is no rate limiting until
+  Phase 6.
+- **GOTCHA**: If issuance or recording fails **after** the code was redeemed, the operator's code is
+  spent and the device got nothing. Order the sequence so failure leaves no orphan: create the
+  device row first, redeem second, issue third; on any post-creation failure call `DeleteDevice` and
+  log at ERROR. Return 500 with a terse body.
+- **GOTCHA**: A failed pairing returns **401 with a terse body** for every cause — bad code, expired
+  code, used code, malformed CSR. Do not distinguish; do not echo the code back; do not log the code.
+- **VALIDATE**: `go test ./internal/httpapi/... -race`. Cover: valid code + CSR → 201, and the
+  returned cert verifies against the CA pool; the same code twice → second is 401; malformed CSR →
+  401; oversized body → 413; the response CN equals the returned `device_id`.
+
+### Task 8: `POST /v1/device/renew` and `DELETE /v1/device/self`
+- **ACTION**: Create `internal/httpapi/device.go`.
+- **IMPLEMENT**: Both routes wrapped in `requireDevice`. `handleRenew` takes `{csr_pem}`, issues a
+  new certificate for the **calling device's own ID**, records it, calls `SupersedePriorCerts`, and
+  returns `{certificate_pem, not_after}`. `handleUnpairSelf` calls `RevokeDevice` on the calling
+  device and returns 204.
+- **MIRROR**: HTTP_HANDLER_PATTERN; `DeviceFrom(r.Context())` from Task 6.
+- **IMPORTS**: same as Task 7.
+- **GOTCHA**: The device ID comes **only** from `DeviceFrom` — never from the request body or a path
+  parameter. Accepting an ID from the client is how "a device can act only on itself" becomes "any
+  device can revoke any other", which the PRD forbids outright.
+- **GOTCHA**: `SupersedePriorCerts` sets `superseded_at`; it must **not** delete rows or shorten
+  validity (D6). The old certificate keeps working until its own expiry so a lost response cannot
+  strand the device.
+- **GOTCHA**: Self-unpair is permitted under **every** policy mode. Do not gate it on
+  `policy.Mode.Allows` — giving up your own access is not a privileged act.
+- **VALIDATE**: `go test ./internal/httpapi/... -race`. Cover: renew returns a cert with a later
+  `not_after` and a different serial, and **both** old and new serials still resolve to the device;
+  self-unpair returns 204 and the device's next request is 401; renew under `ModeReadOnly` succeeds.
+
+### Task 9: Status endpoint gains `ca_fingerprint`
+- **ACTION**: Update `internal/httpapi/status.go`, `server.go`, `status_test.go`.
+- **IMPLEMENT**: Add `CAFingerprint string` with tag `json:"ca_fingerprint"` to `statusResponse`.
+  Pass the fingerprint into `NewServer` and store it on `Server`. Update the allowlist comment at
+  `status.go:15-20`, which currently says the fingerprint arrives "from Phase 2".
+- **MIRROR**: HTTP_HANDLER_PATTERN.
+- **IMPORTS**: none.
+- **GOTCHA**: `status_test.go:54` asserts `len(body) != 4`. Change it to 5 and add
+  `"ca_fingerprint"` to the key list at line 57. The comment at `status_test.go:30-34` explicitly
+  anticipates this edit — update it too, so it keeps guarding rather than describing a past state.
+- **GOTCHA**: The fingerprint is a **public** value — it is the pinning anchor, and publishing it is
+  the point. Nothing else about the CA may join it.
+- **VALIDATE**: `go test ./internal/httpapi/... -race`; assert the field is 64 lowercase hex
+  characters and matches `ca.Fingerprint()`.
+
+### Task 10: Host-side `device` subcommands
+- **ACTION**: Create `cmd/devmon-agent/cli.go`; dispatch from `run` in `main.go`.
+- **IMPLEMENT**: Before the server path, if `flag.Arg(0) == "device"`, dispatch to
+  `runDeviceCommand(ctx, cfg, args)` and return. Subcommands:
+  - `device list` — tabular: ID, NAME, PAIRED, LAST SEEN, STATE (`active` / `revoked`).
+  - `device revoke <id>` — calls `RevokeDevice`; prints `revoked <id> (<name>)`; exit 1 on unknown.
+  - `device pair-code --name <name>` — calls `MintPairingCode`; prints the code and its expiry.
+- **MIRROR**: SERVICE_PATTERN for construction; `main.go:39-50` for the exit-code discipline.
+- **IMPORTS**: `text/tabwriter`, `flag`, `os`.
+- **GOTCHA**: The CLI opens the **same** SQLite file as the running agent. That is intended and is
+  what WAL + `_busy_timeout=5000` (`store.go:117-122`) was configured for. It must **not** touch
+  `certs/` at all — `LoadOrCreateCA` from a second process could race the agent's own start.
+- **GOTCHA**: The CLI runs via `docker exec`, so it inherits the container's environment and
+  `config.Load` succeeds unchanged. It must not require any variable the agent does not already
+  need.
+- **GOTCHA**: Print the pairing code to **stdout only**. Never to the logger — the log file is
+  persisted and rotated, and a pairing code in `agent.log` is a durable credential
+  (`selfsigned.go:8-9`). The CLI should not construct a `logging.Sink` at all.
+- **GOTCHA**: `flag.Parse()` at `main.go:54` consumes the arguments; the subcommand check must read
+  `flag.Arg(0)` after it, and `device`'s own flags need a separate `flag.NewFlagSet`.
+- **VALIDATE**: `go build ./...`, then against a running container:
+  `docker exec devmon-agent /usr/local/bin/devmon-agent device pair-code --name test` prints a
+  26-character code; `device list` shows the device after pairing; `device revoke <id>` makes the
+  paired client's next call fail **without restarting the agent**.
+
+### Task 11: Wire it together in `main`
+- **ACTION**: Update `cmd/devmon-agent/main.go`.
+- **IMPLEMENT**: In `serve`, after `state.Open` and before certificate loading:
+  `certs.CheckIdentityConsistency(cfg.CertsDir(), !st.FirstRun)` → fatal on error;
+  `certs.LoadOrCreateCA(cfg.CertsDir(), log)` → on `created==true`, log at WARN with the fingerprint
+  and the "record this" guidance; `certs.LoadOrCreateServerCert(cfg.CertsDir(), cfg.PublicAddrs, ca,
+  log)`; `tlsconf.Build(cert, ca.Pool())` — replacing the `nil` at `main.go:135`; pass
+  `ca.Fingerprint()` and the CA into `httpapi.NewServer`.
+- **MIRROR**: the existing construction-order comment at `main.go:100-103`; `runAll` is unchanged.
+- **IMPORTS**: none new.
+- **GOTCHA**: The consistency check must run **before** `LoadOrCreateCA`, or the CA is created and
+  the check it was supposed to trigger can never fire again.
+- **GOTCHA**: Update the two stale comments at `main.go:121` ("re-issuance needs the Phase 2 CA")
+  and `main.go:133-134` ("nil client CAs: there is no CA until Phase 2"). Leaving them is how the
+  next reader concludes mTLS is still unfinished.
+- **VALIDATE**: `go build ./...`; `make lint`; start the agent on a clean state dir and confirm the
+  CA fingerprint appears once at WARN; restart and confirm it does not reappear as a creation event.
+
+### Task 12: Gates, docs, and the manual sweep
+- **ACTION**: Run every gate; update `README.md`.
+- **IMPLEMENT**: README gains a pairing walkthrough (mint → pair → verify), the `device` CLI
+  reference, guidance to record the CA fingerprint at install, and a note that `ca.key` is
+  unencrypted at rest and therefore present in host backups and VPS snapshots.
+- **MIRROR**: existing README tone.
+- **VALIDATE**: every command in Validation Commands below, plus the manual checklist.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test | Input | Expected Output | Edge Case? |
+|---|---|---|---|
+| Fresh store migrates to v2 | empty dir | version 2, five tables | |
+| v1 store migrates to v2 | store stamped v1 | version 2, `schema_meta` preserved | ✓ |
+| v3 store refuses to open | store stamped v3 | `ErrSchemaTooNew` | ✓ |
+| Device lookup by serial | issued cert serial | the owning device | |
+| Revoked device still resolves | revoked device's serial | device with `IsRevoked()` true | ✓ |
+| Unknown serial | random hex | `ErrDeviceNotFound` | ✓ |
+| `TouchDevice` throttles | two calls < 60s apart | one write | ✓ |
+| Pairing code single use | same code twice | 1 success, 1 `ErrPairingCodeInvalid` | ✓ |
+| **Concurrent redemption** | N goroutines, one code | **exactly one success** | ✓ |
+| Expired pairing code | `expires_at` in the past | `ErrPairingCodeInvalid` | ✓ |
+| CA is a CA | fresh CA | `IsCA`, `MaxPathLenZero`, `CertSign` | |
+| CA is stable | `LoadOrCreateCA` twice | same fingerprint, `created=false` | |
+| Device cert has ClientAuth EKU | issued cert | EKU present; verifies against pool | ✓ |
+| CSR subject is ignored | CSR with `CN=admin` | cert CN = device ID | ✓ |
+| Broken CSR signature | tampered CSR | error | ✓ |
+| Non-P-256 CSR key | RSA CSR | error | ✓ |
+| `ca.key` permissions | fresh CA | mode `0600` | ✓ |
+| Server cert chains to CA | fresh state | verifies against CA pool | |
+| SAN drift re-issues | changed `PublicAddrs` | new leaf covers it, same CA fingerprint | ✓ |
+| Identity matrix | 4 (db, ca) combinations | 2 nil, 2 `ErrIdentityIncomplete` | ✓ |
+| Auth rejects uniformly | unknown / revoked / absent cert | identical 401 bodies | ✓ |
+| Pair happy path | valid code + CSR | 201, cert verifies | |
+| Pair body too large | 9 KiB body | 413 | ✓ |
+| Renew keeps old cert valid | renew once | both serials resolve | ✓ |
+| Renew under read-only | `ModeReadOnly` | succeeds | ✓ |
+| Self-unpair | authenticated DELETE | 204; next request 401 | |
+| Status has 5 fields | `GET /v1/status` | exactly 5, incl. 64-hex fingerprint | ✓ |
+
+### Edge Cases Checklist
+- [ ] Empty input — blank pairing code, empty CSR, empty device name
+- [ ] Maximum size input — oversized pair body (413), oversized CSR
+- [ ] Invalid types — malformed JSON, non-PEM CSR, PEM of the wrong block type
+- [ ] Concurrent access — simultaneous redemption of one code; CLI revoking while the agent serves
+- [ ] Clock skew — cert `notBefore` one minute in the past (existing convention)
+- [ ] Permission denied — read-only state mount at CA creation
+- [ ] Partial failure — issuance fails after device creation (row cleaned up)
+- [ ] Restart durability — pairings survive a restart **and** an image rebuild
+- [ ] Renewal response lost — old certificate still authenticates
+
+---
+
+## Validation Commands
+
+### Static Analysis
+```bash
+gofmt -l .
+go vet ./...
+```
+EXPECT: `gofmt -l` prints nothing; `go vet` is silent.
+
+### Lint
+```bash
+make lint
+```
+EXPECT: clean, or `golangci-lint not installed — go vet was the only lint run`.
+
+### Security Scan
+```bash
+gosec ./...
+```
+EXPECT: no findings. Watch G306 (file permissions) and G404 (weak random) — both are live risks in
+this phase; every random value here must come from `crypto/rand`.
+
+### Unit Tests
+```bash
+CGO_ENABLED=1 go test ./internal/... -race
+```
+EXPECT: all pass. `-race` is mandatory — the concurrent-redemption test is meaningless without it.
+
+### Full Test Suite with Coverage
+```bash
+make cover
+```
+EXPECT: total coverage ≥ 80%.
+
+### Build Verification
+```bash
+go build ./...
+make build
+make image
+```
+EXPECT: `bin/devmon-agent` builds; the image builds with `CGO_ENABLED=0`.
+
+### Database Validation
+```bash
+# With the agent stopped:
+sqlite3 "$DEVMON_STATE_DIR/devmon.db" "SELECT value FROM schema_meta WHERE key='version';"
+sqlite3 "$DEVMON_STATE_DIR/devmon.db" ".tables"
+```
+EXPECT: version `2`; tables `audit devices device_certs pairing_codes schema_meta`.
+
+### End-to-End Validation (real host)
+```bash
+docker exec devmon-agent /usr/local/bin/devmon-agent device pair-code --name "Pixel 9"
+# pair a client with the printed code, then:
+docker exec devmon-agent /usr/local/bin/devmon-agent device list
+docker exec devmon-agent /usr/local/bin/devmon-agent device revoke <id>
+curl --cacert ca.crt --cert dev.crt --key dev.key https://host:8443/v1/status
+```
+EXPECT: pairing succeeds; `device list` shows the device; after `revoke`, the client's next
+authenticated call returns 401 **with the agent still running**.
+
+### Manual Validation
+- [ ] Two devices pair with distinct codes and receive distinct certificates
+- [ ] Both survive an agent restart
+- [ ] Both survive `make image` + recreate (same bind mount) — **no device re-pairs**
+- [ ] A device near expiry renews with no user interaction
+- [ ] A revoked device loses access immediately, no restart
+- [ ] `DEVMON_PUBLIC_ADDR` changed → server cert re-issued, CA fingerprint unchanged, no re-pair
+- [ ] `rm -rf $DEVMON_STATE_DIR/certs` with the DB intact → explicit `ErrIdentityIncomplete`, not a
+      silent new identity
+- [ ] `GET /v1/status` on a client holding an expired cert returns a fingerprint matching the pinned
+      one (expiry, not attack); after wiping state entirely, the fingerprint differs (attack signal)
+- [ ] `grep -riE 'PRIVATE KEY|pairing|BEGIN CERT' $DEVMON_STATE_DIR/logs/agent.log` → no credential
+      material
+
+---
+
+## Acceptance Criteria
+- [ ] All 12 tasks completed
+- [ ] Every validation command passes
+- [ ] Coverage ≥ 80% over `./internal/...`
+- [ ] `gofmt -l .` silent, `go vet` clean, `gosec` clean
+- [ ] Two clients pair with distinct credentials; an unpaired client is rejected
+- [ ] Pairings survive a restart **and** an image upgrade
+- [ ] A near-expiry client renews with no user interaction
+- [ ] A host-revoked device loses access immediately, without an agent restart
+- [ ] An expired credential and a regenerated CA are distinguishable from `/v1/status` alone
+- [ ] A removed state directory produces an explicit operator error, never a silent new identity
+- [ ] No key material, PEM bytes, or pairing code appears in any log at any level
+
+## Completion Checklist
+- [ ] Code follows the discovered patterns
+- [ ] Error handling matches the codebase style (`%w`, sentinels only where branched on)
+- [ ] Logging follows conventions (typed attrs, snake_case, injected logger)
+- [ ] Tests follow AAA with `t.Parallel()` at both levels
+- [ ] No hardcoded values — every threshold is a named constant
+- [ ] Stale Phase 1 comments updated: `main.go:121`, `main.go:133-134`, `middleware.go:22`,
+      `status.go:17-18`, `status_test.go:30-34`, `schema.go:13-15`, `tlsconf.go:12-13`
+- [ ] README updated
+- [ ] No scope additions from the NOT Building list
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Device cert missing `ClientAuth` EKU; handshake fails opaquely | M | High | Explicit unit assertion in Task 4; the KEY_INSIGHT block calls it out as the top silent failure |
+| Pairing code brute-forced before Phase 6 rate limiting | L | Critical | ~130-bit code (D3), 10-minute TTL, single-use enforced by a conditional UPDATE |
+| Race lets one code pair two devices | M | High | Atomic conditional UPDATE with `RETURNING` (Task 3); concurrent test under `-race` |
+| Renewal response lost; device stranded | M | High | Old cert valid to its own expiry (D6); test asserts both serials resolve |
+| Revocation not immediate because of a cache | M | Critical | No cache by design (D5); e2e check with the agent running |
+| v1→v2 migration corrupts a real device registry | L | High | Provably empty in Phase 1; transactional migration; version stamped in the same tx |
+| CLI and agent contend on SQLite | M | Medium | WAL + `_busy_timeout=5000` + `_txlock=immediate`, already configured; CLI never touches `certs/` |
+| Pairing code leaks into `agent.log` | L | Critical | Code returned, never logged; CLI prints to stdout and builds no log sink; grep in the manual checklist |
+| Consistency check fires on a legitimate first install | M | Medium | Matrix keyed on (db, ca) together (D9), not on the CA alone; all four cases unit-tested |
+| `ca.key` in VPS snapshots | M | High | Accepted and documented per the PRD; `0600` + `0700` dir; README states it |
+
+## Notes
+
+- **Phase 1 comments that predict this phase are load-bearing.** `schema.go:13-15` predicted "no
+  migrations"; Task 1 deviates and must say why in the code. Several others (`middleware.go:22`,
+  `status.go:17-18`, `tlsconf.go:12-13`) describe Phase 1 as a temporary state — each must be
+  rewritten as it is fulfilled, or the codebase will read as unfinished forever.
+- **`tlsconf.Build` needs no signature change** — it already accepts `*x509.CertPool` and handles
+  non-nil correctly. Phase 1 anticipated this precisely; passing `ca.Pool()` is the whole change.
+- **No new module dependency.** `go.mod` is untouched.
+- **Model routing**: per `CLAUDE.md`, every task here goes to `go-implementer` (Sonnet), one task per
+  invocation. Tasks 1–2, 3–4, and 9 are independent and can be dispatched in parallel.
+- **All `crypto/x509` API shapes in this plan were compile-verified against go1.26.4**, not recalled.
+  The probe covered `rand.Text`, CA creation, CSR parse + `CheckSignature`, leaf signing, pool
+  verification with `ClientAuth`, and hex serial round-trip.

--- a/.claude/PRPs/prds/devmon-agent.prd.md
+++ b/.claude/PRPs/prds/devmon-agent.prd.md
@@ -205,7 +205,7 @@ Every operation requested maps directly onto a well-documented Docker Engine API
 | # | Phase | Description | Status | Parallel | Depends | PRP Plan |
 |---|-------|-------------|--------|----------|---------|----------|
 | 1 | Secure foundation & persistence | Agent runs as a container, serves TLS, talks to the Docker socket, exposes a health/version check, and persists state and its own logs across restarts | complete | - | - | [secure-foundation-and-persistence.plan.md](../plans/completed/secure-foundation-and-persistence.plan.md) · [report](../reports/secure-foundation-and-persistence-report.md) |
-| 2 | Identity, pairing & revocation | Agent CA, pairing codes, per-device credentials, device registry, renewal, self-unpair, host-side device commands, missing-state handling | pending | - | 1 | - |
+| 2 | Identity, pairing & revocation | Agent CA, pairing codes, per-device credentials, device registry, renewal, self-unpair, host-side device commands, missing-state handling | complete | - | 1 | [identity-pairing-and-revocation.plan.md](../plans/completed/identity-pairing-and-revocation.plan.md) · [report](../reports/identity-pairing-and-revocation-report.md) |
 | 3 | Read operations | Container/image/network/volume list and inspect | pending | with 4 | 2 | - |
 | 4 | Logs & live streaming | Historical logs plus a resilient live stream channel | pending | with 3 | 2 | - |
 | 5 | Lifecycle, policy & audit | start/restart/stop/kill/delete, server-side mode enforcement, agent self-exclusion, audit logging | pending | - | 3 | - |

--- a/.claude/PRPs/reports/identity-pairing-and-revocation-report.md
+++ b/.claude/PRPs/reports/identity-pairing-and-revocation-report.md
@@ -1,0 +1,189 @@
+# Implementation Report: Identity, Pairing & Revocation (PRD Phase 2)
+
+## Summary
+
+The agent is now its own certificate authority and authenticates every guarded
+request against a per-device client certificate it issued itself.
+
+An operator mints a single-use pairing code on the host; the device generates its
+own keypair and exchanges a PKCS#10 CSR for a 90-day client certificate over the
+one route that requires no client certificate. The agent never sees a device
+private key. Certificates renew silently with overlap — the old credential stays
+valid until its own `not_after`, so a half-failed renewal cannot lock a device
+out. Revocation marks the device rather than a certificate, and because every
+authenticated request costs one indexed lookup with no in-memory device cache, it
+takes effect on the very next request.
+
+State schema moved v1 → v2 through a versioned migration ladder, the server
+certificate is now issued by the retained CA (and re-issued automatically on SAN
+drift), `/v1/status` advertises the CA fingerprint as a pinning anchor, and a
+host-side `device` CLI ships as subcommands on the same binary because the
+distroless image has no shell.
+
+## Assessment vs Reality
+
+| Metric | Predicted (Plan) | Actual |
+|---|---|---|
+| Complexity | Large | Large — matched |
+| Production Go | ~1,400 lines | ~1,530 lines across 9 new + 7 updated files |
+| Files Changed | 16 (9 created, 7 updated) | 16 (9 created, 7 updated) + 2 extra test files |
+| Tasks | 12 | 12 — all complete |
+| Coverage floor | ≥ 80% | 80.8% |
+
+## Tasks Completed
+
+| # | Task | Status | Notes |
+|---|---|---|---|
+| 1 | Schema v2 + migration ladder | Complete | `devices` dropped and recreated; version stamped inside each migration tx |
+| 2 | Device & certificate registry | Complete | Deviated — extra `RenameDevice` method |
+| 3 | Pairing code mint / redemption | Complete | Deviated — split into its own file and test file |
+| 4 | The CA (`LoadOrCreateCA`, `IssueDeviceCert`) | Complete | ClientAuth EKU and `MaxPathLenZero` both verified by test |
+| 5 | Server cert from CA + identity consistency | Complete | Drift bool dropped from signature; caller updated |
+| 6 | `requireDevice` middleware | Complete | Uniform 401 body on every rejection; reason logged only |
+| 7 | `POST /v1/pair` | Complete | Compensating `DeleteDevice` on post-creation failure |
+| 8 | `POST /v1/device/renew`, `DELETE /v1/device/self` | Complete | Device ID from client cert only; self-unpair works in every policy mode |
+| 9 | `ca_fingerprint` in `/v1/status` | Complete | Deviated — `*certs.CA` passed to `NewServer`, not the string |
+| 10 | Host CLI (`device list/revoke/pair-code`) | Complete | Verified live: never touches `certs/`, writes no log |
+| 11 | Wire in `main.go` | Complete | Consistency check precedes CA load; `tlsconf.Build(cert, ca.Pool())` |
+| 12 | Gates, docs, manual sweep | Complete | README rewritten this session — it was the one outstanding item |
+
+## Validation Results
+
+| Level | Status | Notes |
+|---|---|---|
+| Static analysis | Pass | `go vet` silent; `golangci-lint run ./...` → **0 issues**; `gofmt` clean (see note) |
+| Security scan | Pass | `gosec ./...` → no findings |
+| Unit tests | Pass | 117 test functions, all green under `-race` |
+| Coverage | Pass | **80.8%** over `./internal/...` (floor 80%) |
+| Build | Pass | `go build ./...`; static `CGO_ENABLED=0` binary; `docker build` → `devmon-agent:dev` |
+| Integration | Pass | Live binary: schema v2 on disk, correct tables, CLI mint/list verified |
+| Edge cases | Pass | Concurrent redemption, expired/reused code, SAN drift, half-keypair, corrupt files, revoked-device rejection |
+
+**gofmt note.** `gofmt -l .` lists 23 files on this machine, including Phase 1
+files untouched by this work (`internal/version/version.go`). The cause is
+`core.autocrlf=true`: the working tree is CRLF while git stores LF. Every listed
+file is clean once normalized to LF — verified by re-running `gofmt` over
+`tr -d '\r'` output, which reported no real formatting issue in any file. The
+committed content is correctly formatted.
+
+### Live verification performed
+
+```
+$ devmon-agent device pair-code --name "smoke-phone"
+Pairing code: <redacted>
+Expires:      2026-08-07T20:12:00Z
+
+$ sqlite3 devmon.db "SELECT value FROM schema_meta WHERE key='version';"   → 2
+$ sqlite3 devmon.db ".tables"   → audit  device_certs  devices  pairing_codes  schema_meta
+$ grep -r "<the code>" $DEVMON_STATE_DIR                                    → no match
+```
+
+Confirmed on disk: only the hex SHA-256 of the code is stored, the plaintext code
+appears nowhere in the state directory, and the CLI created neither `logs/` nor
+`certs/`.
+
+## Files Changed
+
+| File | Action | Lines |
+|---|---|---|
+| `internal/state/devices.go` | CREATED | 239 |
+| `internal/state/pairing.go` | CREATED | 96 |
+| `internal/certs/ca.go` | CREATED | 239 |
+| `internal/certs/issue.go` | CREATED | 122 |
+| `internal/httpapi/pair.go` | CREATED | 170 |
+| `internal/httpapi/device.go` | CREATED | 146 |
+| `cmd/devmon-agent/cli.go` | CREATED | 198 |
+| `internal/state/devices_test.go` | CREATED | 339 |
+| `internal/state/pairing_test.go` | CREATED | 178 |
+| `internal/certs/ca_test.go` | CREATED | 438 |
+| `internal/certs/store_test.go` | CREATED | 243 |
+| `internal/httpapi/pair_test.go` | CREATED | 212 |
+| `internal/httpapi/device_test.go` | CREATED | 287 |
+| `cmd/devmon-agent/cli_test.go` | CREATED | 209 |
+| `README.md` | UPDATED | +178 / -14 |
+| `internal/certs/store.go` | UPDATED | +130 / -41 |
+| `internal/httpapi/status_test.go` | UPDATED | +197 / -12 |
+| `internal/state/store.go` | UPDATED | +78 / -22 |
+| `internal/state/store_test.go` | UPDATED | +89 / -1 |
+| `internal/state/schema.go` | UPDATED | +76 / -8 |
+| `internal/httpapi/middleware.go` | UPDATED | +59 / -9 |
+| `cmd/devmon-agent/main.go` | UPDATED | +34 / -5 |
+| `internal/httpapi/status.go` | UPDATED | +24 / -13 |
+| `internal/httpapi/server.go` | UPDATED | +19 / -3 |
+| `internal/tlsconf/tlsconf.go` | UPDATED | +3 / -2 |
+| `internal/httpapi/server_test.go` | UPDATED | +1 / -1 |
+| `internal/certs/certs_test.go` | UPDATED | -126 (split into `ca_test.go` / `store_test.go`) |
+
+## Deviations from Plan
+
+1. **Pairing tests live in `internal/state/pairing_test.go`.** The plan folded
+   them into `devices_test.go`. *Why:* pairing already had its own production
+   file (`pairing.go`), so mirroring that split keeps each test file matched to
+   one source file and both under the 800-line ceiling.
+
+2. **`internal/certs/certs_test.go` split into `ca_test.go` and
+   `store_test.go`.** *Why:* the phase roughly quadrupled the package's test
+   surface; one file would have run past 900 lines and violated the repo's file
+   ceiling.
+
+3. **`NewServer` takes `*certs.CA`, not the fingerprint string.** The plan said
+   to pass `ca.Fingerprint()`. *Why:* `handlePair` and `handleRenew` need the CA
+   itself to issue certificates, so passing the string as well would mean
+   threading the same object through twice.
+
+4. **`state.RenameDevice` exists beyond the plan's method list.** *Why:* the
+   pairing flow creates the device row before the code is redeemed, and the
+   authoritative name only arrives from the redeemed code — so the name is set
+   after creation. No route exposes it; a device still cannot name itself.
+
+5. **`gosec` and `golangci-lint` were run via `go run …@latest`.** *Why:*
+   neither tool, nor `make`, is installed on this Windows workstation. The
+   Makefile's own commands were reproduced directly. Both gates genuinely ran
+   and both are clean.
+
+## Issues Encountered
+
+- **`gofmt -l` reported 23 files, none of them real.** Traced to
+  `core.autocrlf=true` rather than to any formatting drift — Phase 1 files that
+  this work never touched were flagged identically. Resolved by verifying against
+  LF-normalized content; no file was rewritten, since doing so would produce a
+  whitespace-only diff that git would normalize straight back.
+
+- **A stray `clicheck_tmp.exe` build artifact** was left untracked in the repo
+  root by an earlier session. Deleted. It is not covered by `.gitignore`, which
+  ignores `/bin/` but not root-level executables.
+
+## Tests Written
+
+| Test File | Tests | Coverage |
+|---|---|---|
+| `internal/state/devices_test.go` | 12 | Create/lookup by serial, revoked lookup, idempotent revoke, rename, delete, supersede-keeps-validity, `TouchDevice` throttling both sides of the 60s window |
+| `internal/state/pairing_test.go` | 6 | Mint→redeem, double-redeem, unknown, expired, prune, **concurrent redemption yields exactly one winner** (meaningful only under `-race`) |
+| `internal/certs/ca_test.go` | 13 | CA properties (`IsCA`, `MaxPathLenZero`), stability across loads, **ClientAuth EKU verifies against the pool**, broken-signature/non-ECDSA/non-P256 CSR rejection, `ca.key` mode 0600, half-keypair and corrupt-file rejection |
+| `internal/certs/store_test.go` | 7 | Server cert chains to CA, idempotency, **re-issue on SAN drift**, key mode, half-keypair, corrupt key, identity-consistency matrix (D9) |
+| `internal/httpapi/pair_test.go` | 4 | Successful pair, reused code, malformed CSR, oversized body |
+| `internal/httpapi/device_test.go` | 5 | Renew issues newer cert while **old serial stays valid**, renew under read-only policy, malformed CSR, self-unpair blocks subsequent requests, self-unpair under every policy mode |
+| `cmd/devmon-agent/cli_test.go` | 10 | Subcommand dispatch, missing/unknown subcommand, revoke arg validation, `pair-code` requires `--name`, mint, `never` for zero last-seen |
+| `internal/httpapi/status_test.go` | +7 | Field count 4→5, `ca_fingerprint` present, `requireDevice` rejects without cert and resolves a real device |
+| `internal/state/store_test.go` | +6 | v1→v2 migration, schema-too-new at v3, non-numeric version, missing version row |
+
+**Total: 117 test functions**, all passing under `-race`.
+
+## Scope Discipline
+
+Nothing outside the plan was added. Confirmed absent: rate limiting (Phase 6),
+any container/image/network/volume operation (Phases 3–5 — `dockerx` gained no
+methods), audit-log writes (Phase 5 — the `audit` table is still created and
+pruned but never written), CRL/OCSP, `ca.key` encryption, cross-device management
+from the app, and CA rotation tooling. `VerifyClientCertIfGiven` is unchanged —
+`RequireAndVerifyClientCert` would break `/v1/pair`, which by design serves
+clients that have no certificate yet.
+
+## Next Steps
+
+- [ ] Code review via `/code-review` (recommend `ecc:go-reviewer` **and**
+      `ecc:security-reviewer` — this phase is entirely auth and crypto)
+- [ ] Manual sweep on a real VPS: first-run CA creation, pairing from the
+      Android client, fingerprint match, revoke-then-request
+- [ ] Create PR via `/prp-pr` (base `dev`)
+- [ ] Phase 3 — read operations — is unblocked once this merges

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so an
 Android client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: Phase 1 — secure foundation & persistence.** The agent starts, validates
-its configuration, opens durable state, terminates TLS, and serves one
-unauthenticated informational endpoint. There is no pairing, no authentication,
-and no Docker read or write operation yet; those arrive in Phases 2–5.
+**Status: Phase 2 — identity, pairing & revocation.** The agent is its own
+certificate authority. An operator mints a pairing code on the host, the device
+generates a keypair and exchanges a CSR for a client certificate, and every
+guarded request is authenticated against that certificate. Revocation takes
+effect on the next request. There is still no Docker read or write operation;
+those arrive in Phases 3–5.
 
 License: AGPL-3.0-only.
 
@@ -49,11 +51,27 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.1.0","policy_mode":"default","server_time":"…Z"}
+# {"api_version":"v1","agent_version":"0.1.0","policy_mode":"default",
+#  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 
-The certificate is self-signed in Phase 1, so `-k` is expected. Phase 2 issues it
-from an agent-held CA that the Android client pins during pairing.
+`-k` is expected: the server certificate is issued by the agent's own CA, which
+no public root store knows. The client pins that CA rather than a public one.
+
+### Record the CA fingerprint now
+
+On first start the agent creates its CA and logs the fingerprint at WARN:
+
+```bash
+docker logs devmon-agent 2>&1 | grep -i fingerprint
+```
+
+**Write it down, off the host.** It is the same value `/v1/status` serves as
+`ca_fingerprint`, and it is the one thing that lets you tell "my credential
+expired" apart from "something else is answering on this port". Comparing the
+fingerprint your phone shows during pairing against the one you recorded at
+install is what makes the pairing exchange safe over an untrusted network. If
+you only ever read it from the server you are about to trust, it proves nothing.
 
 ---
 
@@ -126,7 +144,9 @@ $DEVMON_STATE_DIR/                 bind mount — not a named volume        0700
 ├── devmon.db-wal                  created by SQLite
 ├── devmon.db-shm                  created by SQLite
 ├── certs/                                                                0700
-│   ├── server.crt                 self-signed in Phase 1                 0644
+│   ├── ca.crt                     the agent's CA, valid 10 years         0644
+│   ├── ca.key                     CA private key — UNENCRYPTED           0600
+│   ├── server.crt                 issued by the CA above                 0644
 │   └── server.key                 EC P-256 private key                   0600
 └── logs/                                                                 0700
     ├── agent.log                  current                                0600
@@ -134,9 +154,19 @@ $DEVMON_STATE_DIR/                 bind mount — not a named volume        0700
 ```
 
 A **bind mount, not a named volume**, deliberately: the operator can see, back
-up, and restore it, and `docker compose down -v` cannot destroy it. From Phase 2
-onward this directory holds the agent's identity — losing it unpairs every
-device.
+up, and restore it, and `docker compose down -v` cannot destroy it. This
+directory holds the agent's identity — losing it unpairs every device.
+
+> **`ca.key` is stored unencrypted.** There is nowhere to keep a passphrase that
+> an unattended container restart could reach, so encrypting it would buy
+> nothing but ceremony. The consequence is concrete and worth stating plainly:
+> anyone who can read that file can mint a client certificate this agent will
+> accept. It is protected by file mode `0600` and directory mode `0700` — and by
+> nothing else. **It is therefore present, in the clear, in every host backup
+> and every VPS snapshot of this directory.** Treat those backups as
+> credentials: encrypt them at rest, and if one is exposed, delete `certs/` on
+> the host and restart. The agent then creates a new CA, every paired device is
+> unpaired, and the fingerprint changes.
 
 The audit trail lives in `devmon.db`, not in `logs/`. That is what the SQLite
 choice bought: the host-side CLI can read it while the agent writes, and
@@ -161,18 +191,152 @@ than failing obscurely at the first query.
 
 ## API
 
-| Route | Auth | Response |
+| Route | Auth | Purpose |
 |---|---|---|
-| `GET /v1/status` | none | `api_version`, `agent_version`, `policy_mode`, `server_time` |
+| `GET /v1/status` | none | `api_version`, `agent_version`, `policy_mode`, `server_time`, `ca_fingerprint` |
+| `POST /v1/pair` | pairing code | Exchange a CSR for a client certificate |
+| `POST /v1/device/renew` | client cert | Exchange a CSR for a fresh certificate |
+| `DELETE /v1/device/self` | client cert | Unpair this device |
 
 `/v1/status` is the only endpoint served without a client certificate. Its fields
 are a strict allowlist — it may inform, never issue — and it carries no host,
 container, or credential data. Advertising the policy mode lets a client tell
 "the agent refuses to restart containers" apart from "the agent is broken"
-without needing a credential.
+without needing a credential. The CA fingerprint is deliberately public: it is
+the value a client pins against.
+
+`/v1/pair` is reachable without a client certificate because a device that has
+none is exactly what it exists to serve. The pairing code is the credential for
+that one request.
+
+Every authenticated request costs one indexed lookup against the device
+registry — there is no in-memory cache of paired devices. That is what makes
+revocation immediate rather than eventually-consistent: `device revoke` is a
+single `UPDATE`, and the next request the revoked device makes is already
+rejected.
 
 TLS 1.3 is the floor. Both peers are ours, so there is nothing to negotiate down
 to, and Android has supported it since API 29.
+
+---
+
+## Pairing
+
+A device generates its own keypair and sends only a certificate signing request.
+The agent never sees a device private key, so there is no moment at which one is
+in transit or at rest anywhere but on the device that owns it.
+
+### 1. Mint a code on the host
+
+```bash
+docker exec devmon-agent /usr/local/bin/devmon-agent \
+  device pair-code --name "pixel-8"
+# Pairing code: B4HJFH3KEAZ2QMY546LLN3IDOW
+# Expires:      2026-08-07T20:12:00Z
+```
+
+The code is single-use, valid for **10 minutes**, and printed to stdout only —
+never to `agent.log`, which is persisted and rotated. Only its SHA-256 is
+stored. Nobody, including the operator, can read it back out of the database, so
+a lost code is minted again rather than recovered.
+
+### 2. Redeem it
+
+The Android app does this. To do it by hand:
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out device.key
+openssl req -new -key device.key -subj "/CN=ignored" -out device.csr
+
+curl -sk https://vps.example.com:8443/v1/pair \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -Rn --arg c "B4HJFH3KEAZ2QMY546LLN3IDOW" \
+        --arg r "$(cat device.csr)" \
+        '{pairing_code:$c, csr_pem:$r}')" | tee paired.json
+```
+
+The response carries the issued certificate, the CA to pin, and the expiry:
+
+```json
+{
+  "device_id": "3f9a1c74b2e05d68",
+  "certificate_pem": "-----BEGIN CERTIFICATE-----\n…",
+  "ca_certificate_pem": "-----BEGIN CERTIFICATE-----\n…",
+  "not_after": "2026-11-05T20:02:00Z"
+}
+```
+
+The CSR's subject is ignored on purpose. The device name comes from the code the
+operator minted, so a device cannot name itself — the subject line is the one
+field in the request an attacker fully controls.
+
+Check `ca_certificate_pem` against the fingerprint you recorded at install:
+
+```bash
+jq -r .ca_certificate_pem paired.json > ca.crt
+openssl x509 -in ca.crt -noout -fingerprint -sha256
+```
+
+If it does not match, stop: something else answered.
+
+### 3. Verify the credential works
+
+```bash
+jq -r .certificate_pem paired.json > device.crt
+curl -s --cacert ca.crt --cert device.crt --key device.key \
+  https://vps.example.com:8443/v1/status
+```
+
+`--cacert` replaces the earlier `-k`: from here the connection is verified in
+both directions.
+
+### Renewal
+
+Client certificates are valid for **90 days**. The app renews silently against
+`POST /v1/device/renew` with a fresh CSR, well before expiry. The old
+certificate keeps working until its own `not_after` — renewal never invalidates
+the credential the device is currently holding, so a renewal that fails halfway
+cannot lock a device out.
+
+---
+
+## Managing devices
+
+These run against the same state directory the agent is using. The image is
+`distroless/static:nonroot` — no shell, no second binary — so the host CLI is
+subcommands on the agent binary itself:
+
+```bash
+docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
+```
+
+| Subcommand | Effect |
+|---|---|
+| `device list` | Every registered device: ID, name, paired, last seen, state |
+| `device pair-code --name <name>` | Mint a single-use code, valid 10 minutes |
+| `device revoke <id>` | Withdraw a device's access, effective immediately |
+
+```bash
+$ docker exec devmon-agent /usr/local/bin/devmon-agent device list
+ID                NAME     PAIRED                LAST SEEN             STATE
+3f9a1c74b2e05d68  pixel-8  2026-08-07T20:02:00Z  2026-08-07T21:14:33Z  active
+
+$ docker exec devmon-agent /usr/local/bin/devmon-agent device revoke 3f9a1c74b2e05d68
+revoked 3f9a1c74b2e05d68 (pixel-8)
+```
+
+Revocation marks the **device**, not a certificate, so it covers every
+certificate that device holds — including one issued seconds earlier by a
+renewal. The revoked row is kept rather than deleted: a device that was removed
+and a device that never existed should not look the same to whoever reads this
+later.
+
+`last seen` is written at most once a minute. It is an operator aid, not an
+audit record, and paying a write on every request to sharpen it would be a poor
+trade.
+
+Reading this list while the agent runs is safe and expected — that is what WAL
+mode and the busy timeout were configured for.
 
 ---
 

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -1,0 +1,198 @@
+// Host-side `device` subcommands (D8 in the Phase 2 plan). The image is
+// distroless/static:nonroot — there is no shell and no second binary — so
+// `docker exec devmon-agent /usr/local/bin/devmon-agent device ...` is the
+// only shape that works for an operator managing paired devices.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// Subcommand names, declared as constants so a typo is a compile error.
+const (
+	subcommandList     = "list"
+	subcommandRevoke   = "revoke"
+	subcommandPairCode = "pair-code"
+)
+
+// pairCodeNameFlag is the --name flag on `device pair-code`.
+const pairCodeNameFlag = "name"
+
+// Device states shown in `device list`.
+const (
+	deviceStateActive  = "active"
+	deviceStateRevoked = "revoked"
+)
+
+// lastSeenNever is printed for a device whose LastSeenAt is still zero — it
+// has never made an authenticated request since it was paired.
+const lastSeenNever = "never"
+
+// Tabwriter layout for `device list`.
+const (
+	tabwriterMinWidth = 0
+	tabwriterPadding  = 2
+)
+
+// deviceTimeFormat is used for every timestamp column in `device list` and
+// for the pairing code expiry printed by `device pair-code`.
+const deviceTimeFormat = time.RFC3339
+
+// runDeviceCommand dispatches a `device <subcommand>` invocation. args holds
+// everything after "device" on the command line — the caller (main's run) is
+// expected to pass flag.Args()[1:] once flag.Arg(0) == "device" has been
+// confirmed.
+//
+// This opens the SAME SQLite file the running agent has open — intentional,
+// and exactly what WAL plus the DSN's _busy_timeout=5000 and _txlock=immediate
+// (internal/state/store.go) were configured for. It deliberately never touches
+// certs/: a second process creating or loading the CA here could race the
+// agent's own startup.
+func runDeviceCommand(ctx context.Context, cfg config.Config, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("device: missing subcommand (want one of: %s, %s, %s)",
+			subcommandList, subcommandRevoke, subcommandPairCode)
+	}
+
+	st, err := openDeviceStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.Close() }()
+
+	switch args[0] {
+	case subcommandList:
+		return runDeviceList(ctx, st)
+	case subcommandRevoke:
+		return runDeviceRevoke(ctx, st, args[1:])
+	case subcommandPairCode:
+		return runDevicePairCode(ctx, st, args[1:])
+	default:
+		return fmt.Errorf("device: unknown subcommand %q (want one of: %s, %s, %s)",
+			args[0], subcommandList, subcommandRevoke, subcommandPairCode)
+	}
+}
+
+// openDeviceStore opens the state store without constructing a logging.Sink.
+// The CLI must never build a log sink: a pairing code printed to a persisted,
+// rotated log file would turn a one-time credential into a durable one. A
+// discard-backed logger satisfies state.Open's signature without writing
+// anywhere.
+func openDeviceStore(ctx context.Context, cfg config.Config) (*state.Store, error) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st, err := state.Open(ctx, cfg.DBPath(), log)
+	if err != nil {
+		return nil, fmt.Errorf("open state store for device command: %w", err)
+	}
+	return st, nil
+}
+
+// runDeviceList prints every registered device as a table: ID, NAME, PAIRED,
+// LAST SEEN, STATE.
+func runDeviceList(ctx context.Context, st *state.Store) error {
+	devices, err := st.ListDevices(ctx)
+	if err != nil {
+		return fmt.Errorf("list devices: %w", err)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, tabwriterMinWidth, tabwriterPadding, tabwriterPadding, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tNAME\tPAIRED\tLAST SEEN\tSTATE"); err != nil {
+		return fmt.Errorf("write device list header: %w", err)
+	}
+	for _, d := range devices {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			d.ID, d.Name, d.PairedAt.Format(deviceTimeFormat), formatLastSeen(d.LastSeenAt), deviceStateOf(d)); err != nil {
+			return fmt.Errorf("write device list row: %w", err)
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("write device list: %w", err)
+	}
+	return nil
+}
+
+// formatLastSeen renders a zero LastSeenAt honestly instead of printing the
+// zero time value.
+func formatLastSeen(t time.Time) string {
+	if t.IsZero() {
+		return lastSeenNever
+	}
+	return t.Format(deviceTimeFormat)
+}
+
+func deviceStateOf(d state.Device) string {
+	if d.IsRevoked() {
+		return deviceStateRevoked
+	}
+	return deviceStateActive
+}
+
+// runDeviceRevoke withdraws a device's access. It looks the device up first
+// so the confirmation message can name it — state.RevokeDevice itself returns
+// no name, only an error.
+func runDeviceRevoke(ctx context.Context, st *state.Store, args []string) error {
+	fs := flag.NewFlagSet(subcommandRevoke, flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("device revoke: %w", err)
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("device revoke: expected exactly one device id argument, got %d", fs.NArg())
+	}
+	id := fs.Arg(0)
+
+	devices, err := st.ListDevices(ctx)
+	if err != nil {
+		return fmt.Errorf("list devices before revoke: %w", err)
+	}
+	name := deviceNameByID(devices, id)
+
+	if err := st.RevokeDevice(ctx, id); err != nil {
+		return fmt.Errorf("revoke device %s: %w", id, err)
+	}
+
+	fmt.Printf("revoked %s (%s)\n", id, name)
+	return nil
+}
+
+func deviceNameByID(devices []state.Device, id string) string {
+	for _, d := range devices {
+		if d.ID == id {
+			return d.Name
+		}
+	}
+	return ""
+}
+
+// runDevicePairCode mints a single-use pairing code and prints it to stdout
+// ONLY. It must never reach the logger — the log file is persisted and
+// rotated, so a pairing code in agent.log would be a durable credential.
+func runDevicePairCode(ctx context.Context, st *state.Store, args []string) error {
+	fs := flag.NewFlagSet(subcommandPairCode, flag.ContinueOnError)
+	name := fs.String(pairCodeNameFlag, "", "name of the device to mint a pairing code for")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("device pair-code: %w", err)
+	}
+	if strings.TrimSpace(*name) == "" {
+		return fmt.Errorf("device pair-code: --%s is required", pairCodeNameFlag)
+	}
+
+	code, expiresAt, err := st.MintPairingCode(ctx, *name)
+	if err != nil {
+		return fmt.Errorf("mint pairing code: %w", err)
+	}
+
+	fmt.Printf("Pairing code: %s\n", code)
+	fmt.Printf("Expires:      %s\n", expiresAt.Format(deviceTimeFormat))
+	return nil
+}

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+func openTestStore(t *testing.T) *state.Store {
+	t.Helper()
+	cfg := testStateConfig(t)
+	if err := prepareStateDir(cfg); err != nil {
+		t.Fatalf("prepareStateDir() unexpected error: %v", err)
+	}
+	st, err := openDeviceStore(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("openDeviceStore() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestRunDeviceCommandMissingSubcommandReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+	if err := prepareStateDir(cfg); err != nil {
+		t.Fatalf("prepareStateDir() unexpected error: %v", err)
+	}
+
+	// Act
+	err := runDeviceCommand(context.Background(), cfg, nil)
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDeviceCommand() = nil, want an error for a missing subcommand")
+	}
+}
+
+func TestRunDeviceCommandUnknownSubcommandReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+	if err := prepareStateDir(cfg); err != nil {
+		t.Fatalf("prepareStateDir() unexpected error: %v", err)
+	}
+
+	// Act
+	err := runDeviceCommand(context.Background(), cfg, []string{"bogus"})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDeviceCommand() = nil, want an error for an unknown subcommand")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Errorf("runDeviceCommand() error = %v, want it to name the unknown subcommand", err)
+	}
+}
+
+func TestRunDeviceListEmptyStorePrintsHeaderOnly(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act / Assert — an empty store must not error; the table is header-only.
+	if err := runDeviceList(context.Background(), st); err != nil {
+		t.Fatalf("runDeviceList() unexpected error: %v", err)
+	}
+}
+
+func TestRunDeviceRevokeUnknownIDReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDeviceRevoke(context.Background(), st, []string{"does-not-exist"})
+
+	// Assert
+	if !errors.Is(err, state.ErrDeviceNotFound) {
+		t.Errorf("runDeviceRevoke() error = %v, want it to wrap ErrDeviceNotFound", err)
+	}
+}
+
+func TestRunDeviceRevokeKnownIDSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+	ctx := context.Background()
+	device, err := st.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+
+	// Act
+	err = runDeviceRevoke(ctx, st, []string{device.ID})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDeviceRevoke() unexpected error: %v", err)
+	}
+	devices, err := st.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	if len(devices) != 1 || !devices[0].IsRevoked() {
+		t.Errorf("device %s is not revoked after runDeviceRevoke()", device.ID)
+	}
+}
+
+func TestRunDeviceRevokeRequiresExactlyOneArgument(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDeviceRevoke(context.Background(), st, nil)
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDeviceRevoke() = nil, want an error when no device id is given")
+	}
+}
+
+func TestRunDevicePairCodeRequiresName(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDevicePairCode(context.Background(), st, nil)
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDevicePairCode() = nil, want an error when --name is missing")
+	}
+}
+
+func TestRunDevicePairCodeMintsCode(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDevicePairCode(context.Background(), st, []string{"--" + pairCodeNameFlag, "Pixel 9"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDevicePairCode() unexpected error: %v", err)
+	}
+}
+
+func TestRunDeviceCommandDispatchesToSubcommands(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+	if err := prepareStateDir(cfg); err != nil {
+		t.Fatalf("prepareStateDir() unexpected error: %v", err)
+	}
+	ctx := context.Background()
+
+	// Act — mint a pairing code through the full dispatch path, not the
+	// package-level helper directly, so the switch in runDeviceCommand is
+	// exercised too.
+	err := runDeviceCommand(ctx, cfg, []string{subcommandPairCode, "--" + pairCodeNameFlag, "Pixel 9"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDeviceCommand(pair-code) unexpected error: %v", err)
+	}
+
+	// Act — list must now see nothing yet, since pair-code only mints a code
+	// and does not create a device row.
+	if err := runDeviceCommand(ctx, cfg, []string{subcommandList}); err != nil {
+		t.Fatalf("runDeviceCommand(list) unexpected error: %v", err)
+	}
+}
+
+func TestFormatLastSeenReportsNeverForZeroTime(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+	ctx := context.Background()
+	device, err := st.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+
+	// Act
+	got := formatLastSeen(device.LastSeenAt)
+
+	// Assert
+	if got != lastSeenNever {
+		t.Errorf("formatLastSeen() = %q, want %q for a device never seen", got, lastSeenNever)
+	}
+}

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -66,6 +66,15 @@ func run() error {
 		return err
 	}
 
+	// The `device` CLI is a host-side management path (D8): it opens the same
+	// SQLite file the running agent has open and must never build a log sink
+	// or touch certs/ — see cli.go for why. It is dispatched before the
+	// server path so it never triggers state-dir prep, log-sink construction,
+	// or certificate loading meant only for the long-running agent.
+	if flag.Arg(0) == "device" {
+		return runDeviceCommand(context.Background(), cfg, flag.Args()[1:])
+	}
+
 	if err := prepareStateDir(cfg); err != nil {
 		return err
 	}
@@ -118,8 +127,27 @@ func serve(ctx context.Context, cfg config.Config, sink *logging.Sink, log *slog
 		slog.Int("schema_version", schemaVersion),
 	)
 
-	// certs already logs the WARN on drift; re-issuance needs the Phase 2 CA.
-	cert, _, err := certs.LoadOrCreateServerCert(cfg.CertsDir(), cfg.PublicAddrs, log)
+	// The identity consistency check MUST run before LoadOrCreateCA: once the CA
+	// is created, the partial-restore signature this check exists to catch can
+	// never fire again (D9).
+	if err := certs.CheckIdentityConsistency(cfg.CertsDir(), !st.FirstRun); err != nil {
+		return err
+	}
+
+	ca, caCreated, err := certs.LoadOrCreateCA(cfg.CertsDir(), log)
+	if err != nil {
+		return err
+	}
+	if caCreated {
+		log.Warn("generated a new certificate authority; record this fingerprint, it is the pairing anchor every device pins",
+			slog.String("fingerprint", ca.Fingerprint()),
+		)
+	}
+
+	// certs already logs the WARN on SAN drift and re-issues the leaf from ca
+	// automatically; no device has to re-pair because clients pin the CA, not
+	// this leaf.
+	cert, err := certs.LoadOrCreateServerCert(cfg.CertsDir(), cfg.PublicAddrs, ca, log)
 	if err != nil {
 		return err
 	}
@@ -130,9 +158,10 @@ func serve(ctx context.Context, cfg config.Config, sink *logging.Sink, log *slog
 	}
 	defer func() { _ = dc.Close() }()
 
-	// nil client CAs: there is no CA until Phase 2, so no client certificate can
-	// be verified against anything.
-	srv := httpapi.NewServer(cfg, st, tlsconf.Build(cert, nil), log)
+	// Client CAs come from the agent's own certificate authority: a device's
+	// client certificate is verified against ca.Pool() at the handshake.
+	tlsCfg := tlsconf.Build(cert, ca.Pool())
+	srv := httpapi.NewServer(cfg, st, ca, tlsCfg, log)
 	pruner := state.NewPruner(st, cfg.AuditMaxAge, cfg.AuditMaxRows, log)
 
 	log.Info("agent listening",

--- a/internal/certs/ca.go
+++ b/internal/certs/ca.go
@@ -1,0 +1,239 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// File names and modes for the certificate authority within
+// $DEVMON_STATE_DIR/certs. The CA is retained across the agent's whole
+// lifetime: it is what lets a device pin the agent's identity once and never
+// have to re-pair, even when the server leaf is re-issued (see store.go).
+const (
+	// caValidity is 10 years. Unlike a leaf, a CA is never presented to a TLS
+	// stack directly, so the mobile-TLS 398-day ceiling that bounds
+	// serverCertValidity does not apply here.
+	caValidity = 10 * 365 * 24 * time.Hour
+	// deviceCertValidity is 90 days. Short enough that a lost or stolen
+	// device's credential expires on its own well within a plausible
+	// detection window; renewal (Task 8) keeps a healthy device from ever
+	// noticing.
+	deviceCertValidity = 90 * 24 * time.Hour
+
+	caCertFile = "ca.crt"
+	caKeyFile  = "ca.key"
+
+	caKeyFileMode = 0o600
+	caCrtFileMode = 0o644
+
+	// caCommonName is cosmetic, like certCommonName in selfsigned.go — nothing
+	// verifies against it.
+	caCommonName = "devmon-agent CA"
+)
+
+// CA is the agent's certificate authority: a self-signed root that issues
+// the server leaf and every paired device's client certificate. Its private
+// key never leaves this process; nothing in this package logs it, its PEM
+// encoding, or any other key material.
+type CA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+// LoadOrCreateCA returns the persisted certificate authority, generating and
+// writing one if it is absent. created reports whether this call generated a
+// new CA — the caller (main.go) logs the fingerprint at WARN exactly once,
+// on that transition, so the operator can record it.
+func LoadOrCreateCA(dir string, log *slog.Logger) (*CA, bool, error) {
+	if err := os.MkdirAll(dir, certsDirMode); err != nil {
+		return nil, false, fmt.Errorf("create certs dir %s: %w", dir, err)
+	}
+
+	certPath := filepath.Join(dir, caCertFile)
+	keyPath := filepath.Join(dir, caKeyFile)
+
+	exists, err := keypairExists(certPath, keyPath)
+	if err != nil {
+		return nil, false, err
+	}
+
+	created := false
+	if !exists {
+		if err := generateAndWriteCA(dir, log); err != nil {
+			return nil, false, err
+		}
+		created = true
+	}
+
+	ca, err := loadCA(dir)
+	if err != nil {
+		return nil, false, err
+	}
+	return ca, created, nil
+}
+
+// generateAndWriteCA creates a new self-signed CA keypair and writes it to
+// dir, using the same os.Root write discipline as ensureKeypair in store.go.
+func generateAndWriteCA(dir string, log *slog.Logger) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate CA key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), serialBits))
+	if err != nil {
+		return fmt.Errorf("generate CA certificate serial: %w", err)
+	}
+
+	now := time.Now()
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   caCommonName,
+			Organization: []string{certOrganization},
+		},
+		NotBefore:             now.Add(-time.Minute), // tolerate minor host clock skew
+		NotAfter:              now.Add(caValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		// x509 treats MaxPathLen=0 as "unset" unless MaxPathLenZero is true.
+		// Without it the CA would encode no path-length constraint at all,
+		// permitting sub-CAs it was never meant to allow.
+		MaxPathLenZero: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("create CA certificate: %w", err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("marshal CA key: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: pemTypePrivateKey, Bytes: keyDER})
+
+	// Writes go through an os.Root scoped to the certs directory, mirroring
+	// ensureKeypair in store.go: the key is written first, exclusively, at
+	// 0600, so it is never briefly world-readable.
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("open certs dir %s: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	if err := writeExclusive(root, caKeyFile, keyPEM, caKeyFileMode); err != nil {
+		return err
+	}
+	if err := writeExclusive(root, caCertFile, certPEM, caCrtFileMode); err != nil {
+		if rmErr := root.Remove(caKeyFile); rmErr != nil {
+			log.Warn("could not remove the orphaned CA key after a failed certificate write",
+				slog.Any("err", rmErr))
+		}
+		return err
+	}
+	return nil
+}
+
+// loadCA reads and parses a persisted CA keypair from dir. Reads go through
+// an os.Root scoped to the certs directory, mirroring loadServerKeypair in
+// store.go: no variable path is ever handed to a bare os call, so a path can
+// never escape the certs directory — including via a symlink planted in the
+// bind mount.
+func loadCA(dir string) (*CA, error) {
+	certPath := filepath.Join(dir, caCertFile)
+	keyPath := filepath.Join(dir, caKeyFile)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("open certs dir %s: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	certPEMBytes, err := readFileInRoot(root, caCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA certificate %s: %w", certPath, err)
+	}
+	block, _ := pem.Decode(certPEMBytes)
+	if block == nil || block.Type != pemTypeCertificate {
+		return nil, fmt.Errorf("decode CA certificate %s: not a PEM certificate", certPath)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA certificate %s: %w", certPath, err)
+	}
+
+	keyPEMBytes, err := readFileInRoot(root, caKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA key %s: %w", keyPath, err)
+	}
+	keyBlock, _ := pem.Decode(keyPEMBytes)
+	if keyBlock == nil || keyBlock.Type != pemTypePrivateKey {
+		return nil, fmt.Errorf("decode CA key %s: not a PEM private key", keyPath)
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA key %s: %w", keyPath, err)
+	}
+	key, ok := keyAny.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("CA key %s is not an ECDSA key", keyPath)
+	}
+
+	return &CA{cert: cert, key: key}, nil
+}
+
+// readFileInRoot reads name from an os.Root scoped to the certs directory,
+// the read counterpart to writeExclusive in store.go.
+func readFileInRoot(root *os.Root, name string) ([]byte, error) {
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// Fingerprint is the hex SHA-256 digest over the CA certificate's DER bytes.
+// It is the pinning anchor an Android client records at pairing time and is
+// published on GET /v1/status — publishing it is the point, and nothing else
+// about the CA may join it.
+func (c *CA) Fingerprint() string {
+	sum := sha256.Sum256(c.cert.Raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// CertPEM returns the CA certificate, PEM-encoded, for the client to pin.
+func (c *CA) CertPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: c.cert.Raw})
+}
+
+// Pool returns an x509.CertPool containing only this CA, suitable for
+// verifying either a device's client certificate or the agent's own server
+// leaf.
+func (c *CA) Pool() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(c.cert)
+	return pool
+}

--- a/internal/certs/ca_test.go
+++ b/internal/certs/ca_test.go
@@ -1,0 +1,438 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newDeviceCSR builds a PKCS#10 CSR signed by a fresh EC P-256 key, with
+// subjectCN as the (attacker-controlled) subject the agent must ignore.
+func newDeviceCSR(t *testing.T, subjectCN string) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate device key: %v", err)
+	}
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: subjectCN},
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		t.Fatalf("create device CSR: %v", err)
+	}
+	return der
+}
+
+func TestLoadOrCreateCAProperties(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+
+	// Act
+	ca, created, err := LoadOrCreateCA(dir, testLogger())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+	if !created {
+		t.Error("created = false on a fresh directory, want true")
+	}
+	if !ca.cert.IsCA {
+		t.Error("IsCA = false, want true")
+	}
+	if !ca.cert.BasicConstraintsValid {
+		t.Error("BasicConstraintsValid = false, want true")
+	}
+	if !ca.cert.MaxPathLenZero {
+		t.Error("MaxPathLenZero = false, want true (unset permits sub-CAs)")
+	}
+	if ca.cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Error("KeyUsage lacks CertSign")
+	}
+	if ca.cert.KeyUsage&x509.KeyUsageCRLSign == 0 {
+		t.Error("KeyUsage lacks CRLSign")
+	}
+	wantNotAfter := time.Now().Add(caValidity)
+	if diff := ca.cert.NotAfter.Sub(wantNotAfter); diff > time.Hour || diff < -time.Hour {
+		t.Errorf("NotAfter = %v, want ~%v (10-year CA)", ca.cert.NotAfter, wantNotAfter)
+	}
+}
+
+func TestLoadOrCreateCAIsStable(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	first, firstCreated, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("first LoadOrCreateCA() unexpected error: %v", err)
+	}
+	if !firstCreated {
+		t.Fatal("first created = false, want true")
+	}
+
+	// Act
+	second, secondCreated, err := LoadOrCreateCA(dir, testLogger())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("second LoadOrCreateCA() unexpected error: %v", err)
+	}
+	if secondCreated {
+		t.Error("second created = true, want false — a stable identity must not regenerate")
+	}
+	if first.Fingerprint() != second.Fingerprint() {
+		t.Errorf("fingerprint changed across reload: %s then %s", first.Fingerprint(), second.Fingerprint())
+	}
+}
+
+func TestIssueDeviceCertHasClientAuthEKUAndVerifiesAgainstPool(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+	csrDER := newDeviceCSR(t, "admin")
+	now := time.Now()
+
+	// Act
+	certPEM, serial, notAfter, err := ca.IssueDeviceCert(csrDER, "d3f9a1c2", now)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("IssueDeviceCert() unexpected error: %v", err)
+	}
+	if serial == "" {
+		t.Error("serial is empty, want a hex string")
+	}
+	if strings.HasPrefix(serial, "0x") || strings.ToLower(serial) != serial {
+		t.Errorf("serial = %q, want lowercase hex with no 0x prefix", serial)
+	}
+
+	block, rest := pem.Decode(certPEM)
+	if block == nil || block.Type != pemTypeCertificate {
+		t.Fatalf("certificate PEM block = %v, want %s", block, pemTypeCertificate)
+	}
+	if len(rest) != 0 {
+		t.Errorf("trailing bytes after certificate PEM: %d", len(rest))
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse issued device certificate: %v", err)
+	}
+
+	// CSR subject asked for CN=admin; the agent must ignore it entirely.
+	if leaf.Subject.CommonName != "d3f9a1c2" {
+		t.Errorf("CommonName = %q, want the supplied device ID d3f9a1c2 (CSR subject must be ignored)",
+			leaf.Subject.CommonName)
+	}
+	if leaf.IsCA {
+		t.Error("IsCA = true, want false for a device leaf")
+	}
+	if len(leaf.ExtKeyUsage) != 1 || leaf.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
+		t.Fatalf("ExtKeyUsage = %v, want [ClientAuth] — crypto/tls rejects a client leaf without it",
+			leaf.ExtKeyUsage)
+	}
+	// X.509 encodes time at one-second resolution, so compare within a
+	// tolerance rather than requiring bit-for-bit equality.
+	if diff := notAfter.Sub(leaf.NotAfter); diff > time.Second || diff < -time.Second {
+		t.Errorf("returned notAfter = %v, want ~%v (issued certificate's NotAfter)", notAfter, leaf.NotAfter)
+	}
+
+	// Assert — verifies against the CA's own pool with ClientAuth required.
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     ca.Pool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Errorf("Verify() against CA pool with ClientAuth = %v, want nil", err)
+	}
+}
+
+func TestIssueDeviceCertRejectsBrokenSignature(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+	csrDER := newDeviceCSR(t, "tamperable")
+	// Corrupt the last byte, which lands in the signature for a CSR built
+	// this way — CheckSignature must catch it rather than CreateCertificate
+	// signing over an unverified request.
+	csrDER[len(csrDER)-1] ^= 0xFF
+
+	// Act
+	_, _, _, err = ca.IssueDeviceCert(csrDER, "dev-id", time.Now())
+
+	// Assert
+	if err == nil {
+		t.Fatal("IssueDeviceCert() error = nil, want a failure on a tampered CSR signature")
+	}
+}
+
+func TestIssueDeviceCertRejectsNonECDSAKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — an RSA CSR, which the device flow never produces but a
+	// malicious client could send.
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	template := x509.CertificateRequest{Subject: pkix.Name{CommonName: "rsa-device"}}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, rsaKey)
+	if err != nil {
+		t.Fatalf("create RSA CSR: %v", err)
+	}
+
+	// Act
+	_, _, _, err = ca.IssueDeviceCert(csrDER, "dev-id", time.Now())
+
+	// Assert
+	if err == nil {
+		t.Fatal("IssueDeviceCert() error = nil, want a failure on a non-ECDSA CSR key")
+	}
+}
+
+func TestIssueDeviceCertRejectsNonP256Curve(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — an EC key on P-384, which is a supported curve but not the
+	// one the device flow uses.
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-384 key: %v", err)
+	}
+	template := x509.CertificateRequest{Subject: pkix.Name{CommonName: "p384-device"}}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		t.Fatalf("create P-384 CSR: %v", err)
+	}
+
+	// Act
+	_, _, _, err = ca.IssueDeviceCert(csrDER, "dev-id", time.Now())
+
+	// Assert
+	if err == nil {
+		t.Fatal("IssueDeviceCert() error = nil, want a failure on a non-P-256 CSR key")
+	}
+}
+
+func TestIssueServerCertChainsToCA(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+
+	// Act
+	certPEM, keyPEM, err := ca.IssueServerCert([]string{"vps.example.com"}, time.Now())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("IssueServerCert() unexpected error: %v", err)
+	}
+	if len(keyPEM) == 0 {
+		t.Fatal("keyPEM is empty")
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != pemTypeCertificate {
+		t.Fatalf("certificate PEM block = %v, want %s", block, pemTypeCertificate)
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse issued server certificate: %v", err)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     ca.Pool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Errorf("Verify() server leaf against CA pool = %v, want nil", err)
+	}
+	wantNotAfter := time.Now().Add(serverCertValidity)
+	if diff := leaf.NotAfter.Sub(wantNotAfter); diff > time.Minute || diff < -time.Minute {
+		t.Errorf("NotAfter = %v, want ~%v (398-day server leaf, not the CA validity)",
+			leaf.NotAfter, wantNotAfter)
+	}
+}
+
+func TestCAKeyIsOwnerOnly(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not modelled on Windows")
+	}
+
+	// Arrange / Act
+	dir := t.TempDir()
+	if _, _, err := LoadOrCreateCA(dir, testLogger()); err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+
+	// Assert
+	info, err := os.Stat(filepath.Join(dir, caKeyFile))
+	if err != nil {
+		t.Fatalf("stat ca.key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != caKeyFileMode {
+		t.Errorf("ca.key mode = %#o, want %#o", perm, caKeyFileMode)
+	}
+}
+
+func TestCACertPEMMatchesFingerprint(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+
+	// Act
+	certPEM := ca.CertPEM()
+
+	// Assert
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != pemTypeCertificate {
+		t.Fatalf("CertPEM() block = %v, want %s", block, pemTypeCertificate)
+	}
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse CertPEM(): %v", err)
+	}
+	if !parsed.Equal(ca.cert) {
+		t.Error("CertPEM() does not round-trip to the loaded CA certificate")
+	}
+}
+
+func TestLoadOrCreateCARejectsHalfKeypair(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — only ca.crt is present, as a partial restore would leave.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, caCertFile), []byte("stub"), 0o644); err != nil {
+		t.Fatalf("write stub CA cert: %v", err)
+	}
+
+	// Act
+	_, _, err := LoadOrCreateCA(dir, testLogger())
+
+	// Assert
+	if err == nil {
+		t.Fatal("LoadOrCreateCA() error = nil, want a failure on a half CA keypair")
+	}
+	if !strings.Contains(err.Error(), "not both present") {
+		t.Errorf("error %q does not explain the half CA keypair", err)
+	}
+}
+
+func TestLoadOrCreateCARejectsCorruptFiles(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — both files present, contents are garbage.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, caCertFile), []byte("not a cert"), 0o644); err != nil {
+		t.Fatalf("write CA cert: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, caKeyFile), []byte("not a key"), 0o600); err != nil {
+		t.Fatalf("write CA key: %v", err)
+	}
+
+	// Act
+	_, _, err := LoadOrCreateCA(dir, testLogger())
+
+	// Assert
+	if err == nil {
+		t.Fatal("LoadOrCreateCA() error = nil, want a failure on a corrupt CA certificate")
+	}
+	if !strings.Contains(err.Error(), "decode CA certificate") {
+		t.Errorf("error %q does not identify the failing step", err)
+	}
+}
+
+func TestLoadOrCreateCARejectsWrongKeyType(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a valid CA certificate paired with an RSA private key, as a
+	// corrupted or hand-edited certs directory might contain.
+	dir := t.TempDir()
+	if _, _, err := LoadOrCreateCA(dir, testLogger()); err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	rsaKeyDER, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	if err != nil {
+		t.Fatalf("marshal RSA key: %v", err)
+	}
+	rsaKeyPEM := pem.EncodeToMemory(&pem.Block{Type: pemTypePrivateKey, Bytes: rsaKeyDER})
+	if err := os.WriteFile(filepath.Join(dir, caKeyFile), rsaKeyPEM, 0o600); err != nil {
+		t.Fatalf("overwrite CA key: %v", err)
+	}
+
+	// Act
+	_, _, err = LoadOrCreateCA(dir, testLogger())
+
+	// Assert
+	if err == nil {
+		t.Fatal("LoadOrCreateCA() error = nil, want a failure on a non-ECDSA CA key")
+	}
+	if !strings.Contains(err.Error(), "not an ECDSA key") {
+		t.Errorf("error %q does not identify the wrong key type", err)
+	}
+}
+
+func TestIssueServerCertRejectsEmptySANs(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA() unexpected error: %v", err)
+	}
+
+	// Act
+	_, _, err = ca.IssueServerCert(nil, time.Now())
+
+	// Assert — a certificate with no SAN matches nothing and would fail on
+	// the phone rather than at issuance.
+	if err == nil {
+		t.Fatal("IssueServerCert(nil) error = nil, want a failure")
+	}
+}

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -5,10 +5,6 @@ import (
 	"encoding/pem"
 	"io"
 	"log/slog"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 	"time"
 )
@@ -86,128 +82,6 @@ func TestGenerateServerCertRejectsEmptySANs(t *testing.T) {
 	// phone rather than at startup.
 	if err == nil {
 		t.Fatal("GenerateServerCert(nil) error = nil, want a failure")
-	}
-}
-
-func TestLoadOrCreateServerCertIsIdempotent(t *testing.T) {
-	t.Parallel()
-
-	// Arrange
-	dir := t.TempDir()
-	sans := []string{"vps.example.com"}
-
-	// Act
-	first, drift, err := LoadOrCreateServerCert(dir, sans, testLogger())
-	if err != nil {
-		t.Fatalf("first LoadOrCreateServerCert() unexpected error: %v", err)
-	}
-	second, driftAgain, err := LoadOrCreateServerCert(dir, sans, testLogger())
-	if err != nil {
-		t.Fatalf("second LoadOrCreateServerCert() unexpected error: %v", err)
-	}
-
-	// Assert — a changed serial across restarts would mean a new identity, and
-	// from Phase 2 that unpairs every device.
-	if first.Leaf.SerialNumber.Cmp(second.Leaf.SerialNumber) != 0 {
-		t.Errorf("serial changed across reload: %v then %v",
-			first.Leaf.SerialNumber, second.Leaf.SerialNumber)
-	}
-	if drift || driftAgain {
-		t.Errorf("sanDrift = %v/%v on matching SANs, want false", drift, driftAgain)
-	}
-}
-
-func TestLoadOrCreateServerCertDetectsSANDrift(t *testing.T) {
-	t.Parallel()
-
-	// Arrange
-	dir := t.TempDir()
-	first, _, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, testLogger())
-	if err != nil {
-		t.Fatalf("first LoadOrCreateServerCert() unexpected error: %v", err)
-	}
-
-	// Act — the operator adds an address the stored certificate does not cover.
-	second, drift, err := LoadOrCreateServerCert(dir,
-		[]string{"vps.example.com", "new.example.com"}, testLogger())
-	if err != nil {
-		t.Fatalf("second LoadOrCreateServerCert() unexpected error: %v", err)
-	}
-
-	// Assert
-	if !drift {
-		t.Error("sanDrift = false after adding an uncovered address, want true")
-	}
-	if first.Leaf.SerialNumber.Cmp(second.Leaf.SerialNumber) != 0 {
-		t.Error("certificate was silently regenerated on drift; Phase 1 only reports it")
-	}
-}
-
-func TestServerKeyIsOwnerOnly(t *testing.T) {
-	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX file modes are not modelled on Windows")
-	}
-
-	// Arrange / Act
-	dir := t.TempDir()
-	if _, _, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, testLogger()); err != nil {
-		t.Fatalf("LoadOrCreateServerCert() unexpected error: %v", err)
-	}
-
-	// Assert
-	info, err := os.Stat(filepath.Join(dir, serverKeyFile))
-	if err != nil {
-		t.Fatalf("stat key: %v", err)
-	}
-	if perm := info.Mode().Perm(); perm != serverKeyFileMode {
-		t.Errorf("server.key mode = %#o, want %#o", perm, serverKeyFileMode)
-	}
-}
-
-func TestLoadOrCreateServerCertRejectsHalfKeypair(t *testing.T) {
-	t.Parallel()
-
-	// Arrange — a certificate with no key, as a partial restore would leave.
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, serverCertFile), []byte("stub"), 0o644); err != nil {
-		t.Fatalf("write stub cert: %v", err)
-	}
-
-	// Act
-	_, _, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, testLogger())
-
-	// Assert — regenerating would produce a mismatched pair, so this must be loud.
-	if err == nil {
-		t.Fatal("LoadOrCreateServerCert() error = nil, want a failure on a half keypair")
-	}
-	if !strings.Contains(err.Error(), "not both present") {
-		t.Errorf("error %q does not explain the half keypair", err)
-	}
-}
-
-func TestLoadOrCreateServerCertRejectsCorruptKey(t *testing.T) {
-	t.Parallel()
-
-	// Arrange — both files present, key is garbage.
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, serverCertFile), []byte("not a cert"), 0o644); err != nil {
-		t.Fatalf("write cert: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, serverKeyFile), []byte("not a key"), 0o600); err != nil {
-		t.Fatalf("write key: %v", err)
-	}
-
-	// Act
-	_, _, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, testLogger())
-
-	// Assert
-	if err == nil {
-		t.Fatal("LoadOrCreateServerCert() error = nil, want a load failure")
-	}
-	if !strings.Contains(err.Error(), "load server keypair") {
-		t.Errorf("error %q does not identify the failing step", err)
 	}
 }
 

--- a/internal/certs/issue.go
+++ b/internal/certs/issue.go
@@ -1,0 +1,122 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// IssueDeviceCert signs a client leaf from a device-supplied PKCS#10 CSR.
+//
+// The CSR's Subject is attacker-controlled and is ignored entirely — the
+// leaf's CommonName always comes from commonName, the agent's own record of
+// the device (its ID). A CSR asking to be CN=admin does not get it.
+//
+// now is a parameter so tests can pin the validity window, matching
+// GenerateServerCert's convention.
+func (c *CA) IssueDeviceCert(csrDER []byte, commonName string, now time.Time) (certPEM []byte, serial string, notAfter time.Time, err error) {
+	csr, err := x509.ParseCertificateRequest(csrDER)
+	if err != nil {
+		return nil, "", time.Time{}, fmt.Errorf("parse device CSR: %w", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		return nil, "", time.Time{}, fmt.Errorf("verify device CSR signature: %w", err)
+	}
+
+	pub, ok := csr.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, "", time.Time{}, fmt.Errorf("device CSR public key is not ECDSA")
+	}
+	if pub.Curve != elliptic.P256() {
+		return nil, "", time.Time{}, fmt.Errorf("device CSR public key is not P-256")
+	}
+
+	serialNum, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), serialBits))
+	if err != nil {
+		return nil, "", time.Time{}, fmt.Errorf("generate device certificate serial: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNum,
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore: now.Add(-time.Minute), // tolerate minor host clock skew
+		NotAfter:  now.Add(deviceCertValidity),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		// A leaf missing ClientAuth fails the TLS handshake with an opaque
+		// "bad certificate" alert, before any handler or middleware runs.
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, c.cert, pub, c.key)
+	if err != nil {
+		return nil, "", time.Time{}, fmt.Errorf("create device certificate: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: der})
+	return certPEM, serialNum.Text(16), template.NotAfter, nil
+}
+
+// IssueServerCert produces a CA-signed EC P-256 server leaf covering sans,
+// replacing the self-signed leaf Phase 1 generated. sans are split into DNS
+// names and IP addresses automatically.
+//
+// serverCertValidity — not caValidity — bounds this leaf: modern mobile TLS
+// stacks reject certificates longer-lived than the CA/Browser Forum maximum,
+// and clients pin the CA, not this leaf, so its short life is invisible to
+// them.
+func (c *CA) IssueServerCert(sans []string, now time.Time) (certPEM, keyPEM []byte, err error) {
+	if len(sans) == 0 {
+		return nil, nil, fmt.Errorf("issue server certificate: no subject alternative names given")
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate server key: %w", err)
+	}
+
+	serialNum, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), serialBits))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate server certificate serial: %w", err)
+	}
+
+	dnsNames, ips := splitSANs(sans)
+	template := x509.Certificate{
+		SerialNumber: serialNum,
+		Subject: pkix.Name{
+			CommonName:   certCommonName,
+			Organization: []string{certOrganization},
+		},
+		NotBefore:             now.Add(-time.Minute), // tolerate minor host clock skew
+		NotAfter:              now.Add(serverCertValidity),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		DNSNames:              dnsNames,
+		IPAddresses:           ips,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, c.cert, &key.PublicKey, c.key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create server certificate: %w", err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal server key: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: pemTypePrivateKey, Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}

--- a/internal/certs/store.go
+++ b/internal/certs/store.go
@@ -23,53 +23,77 @@ const (
 	serverCrtFileMode = 0o644
 )
 
-// LoadOrCreateServerCert returns the persisted server keypair, generating and
-// writing one if it is absent.
+// ErrIdentityIncomplete reports that the state directory holds some of the
+// agent's identity but not all of it — the signature of a partial restore or
+// a destroyed bind mount, not of a first install. See CheckIdentityConsistency.
+var ErrIdentityIncomplete = errors.New("agent identity is incomplete")
+
+// LoadOrCreateServerCert returns the persisted server keypair, issuing one
+// from ca if none is present.
 //
-// sanDrift reports that the stored certificate does not cover every address in
-// sans — typically because the VPS changed address. Phase 1 only reports it;
-// re-issuance needs the CA that arrives in Phase 2. Treating drift as fatal here
-// would make an address change unrecoverable without deleting the state
-// directory, which is the exact outcome the durability guarantee exists to
-// prevent.
-func LoadOrCreateServerCert(dir string, sans []string, log *slog.Logger) (tls.Certificate, bool, error) {
+// When the stored certificate no longer covers every address in sans —
+// typically because the VPS's address changed — it is re-issued from ca
+// automatically (D10). Clients pin the CA, not this leaf, so re-issuance is
+// invisible to them: no device has to re-pair.
+func LoadOrCreateServerCert(dir string, sans []string, ca *CA, log *slog.Logger) (tls.Certificate, error) {
 	if err := os.MkdirAll(dir, certsDirMode); err != nil {
-		return tls.Certificate{}, false, fmt.Errorf("create certs dir %s: %w", dir, err)
+		return tls.Certificate{}, fmt.Errorf("create certs dir %s: %w", dir, err)
 	}
 
 	certPath := filepath.Join(dir, serverCertFile)
 	keyPath := filepath.Join(dir, serverKeyFile)
 
-	if err := ensureKeypair(certPath, keyPath, sans, log); err != nil {
-		return tls.Certificate{}, false, err
+	if err := ensureKeypair(dir, certPath, keyPath, sans, ca, log); err != nil {
+		return tls.Certificate{}, err
 	}
 
+	pair, leaf, err := loadServerKeypair(dir, certPath, keyPath)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	if !sanDrift(leaf, sans) {
+		return pair, nil
+	}
+
+	log.Warn("server certificate does not cover every configured address",
+		slog.Any("configured", sans),
+		slog.Any("covered_dns", leaf.DNSNames),
+		slog.Any("covered_ip", ipStrings(leaf.IPAddresses)),
+	)
+
+	if err := reissueServerCert(dir, certPath, keyPath, sans, ca, log); err != nil {
+		return tls.Certificate{}, err
+	}
+
+	pair, _, err = loadServerKeypair(dir, certPath, keyPath)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	return pair, nil
+}
+
+// loadServerKeypair reads the persisted server keypair from disk and parses
+// its leaf certificate.
+func loadServerKeypair(dir, certPath, keyPath string) (tls.Certificate, *x509.Certificate, error) {
 	pair, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
-		return tls.Certificate{}, false, fmt.Errorf("load server keypair from %s: %w", dir, err)
+		return tls.Certificate{}, nil, fmt.Errorf("load server keypair from %s: %w", dir, err)
 	}
 
 	leaf, err := x509.ParseCertificate(pair.Certificate[0])
 	if err != nil {
-		return tls.Certificate{}, false, fmt.Errorf("parse server certificate in %s: %w", dir, err)
+		return tls.Certificate{}, nil, fmt.Errorf("parse server certificate in %s: %w", dir, err)
 	}
 	pair.Leaf = leaf
 
-	drift := sanDrift(leaf, sans)
-	if drift {
-		log.Warn("server certificate does not cover every configured address",
-			slog.Any("configured", sans),
-			slog.Any("covered_dns", leaf.DNSNames),
-			slog.Any("covered_ip", ipStrings(leaf.IPAddresses)),
-		)
-	}
-	return pair, drift, nil
+	return pair, leaf, nil
 }
 
-// ensureKeypair generates and writes a keypair when one is not already present.
-// An existing pair is left untouched: silently minting a new identity on every
-// start would unpair every device the moment Phase 2 lands.
-func ensureKeypair(certPath, keyPath string, sans []string, log *slog.Logger) error {
+// ensureKeypair issues and writes a keypair when one is not already present.
+// An existing pair is left untouched: silently minting a new identity on
+// every start would unpair every device.
+func ensureKeypair(dir, certPath, keyPath string, sans []string, ca *CA, log *slog.Logger) error {
 	switch exists, err := keypairExists(certPath, keyPath); {
 	case err != nil:
 		return err
@@ -77,37 +101,61 @@ func ensureKeypair(certPath, keyPath string, sans []string, log *slog.Logger) er
 		return nil
 	}
 
-	log.Warn("no server certificate found, generating self-signed",
+	log.Warn("no server certificate found, issuing one from the certificate authority",
 		slog.Any("sans", sans),
 	)
 
-	certPEM, keyPEM, err := GenerateServerCert(sans, time.Now())
+	return writeServerCert(dir, sans, ca, log)
+}
+
+// reissueServerCert replaces a server certificate that no longer covers
+// every configured address. Both files are removed before writing the new
+// pair: writeExclusive's O_EXCL fails with "file exists" against a stale
+// file, which would otherwise make an address change unrecoverable without
+// deleting the whole state directory — the exact outcome D10 exists to
+// prevent.
+func reissueServerCert(dir, certPath, keyPath string, sans []string, ca *CA, log *slog.Logger) error {
+	if err := os.Remove(certPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove stale server certificate %s: %w", certPath, err)
+	}
+	if err := os.Remove(keyPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove stale server key %s: %w", keyPath, err)
+	}
+	return writeServerCert(dir, sans, ca, log)
+}
+
+// writeServerCert issues a fresh server keypair from ca and writes it to
+// dir, replacing whatever ensureKeypair or reissueServerCert already
+// removed or found absent.
+func writeServerCert(dir string, sans []string, ca *CA, log *slog.Logger) error {
+	certPEM, keyPEM, err := ca.IssueServerCert(sans, time.Now())
 	if err != nil {
 		return err
 	}
 
-	// Writes go through an os.Root scoped to the certs directory, so a path can
-	// never escape it — including via a symlink planted in the bind mount, which
-	// is reachable by anyone with host access to the operator's state directory.
-	dir := filepath.Dir(keyPath)
+	// Writes go through an os.Root scoped to the certs directory, so a path
+	// can never escape it — including via a symlink planted in the bind
+	// mount, which is reachable by anyone with host access to the
+	// operator's state directory.
 	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return fmt.Errorf("open certs dir %s: %w", dir, err)
 	}
 	defer func() { _ = root.Close() }()
 
-	// The key is written first and exclusively. O_EXCL with mode 0600 means the
-	// file is never briefly world-readable — unlike WriteFile-then-Chmod, which
-	// leaves exactly that window and is flagged by gosec G306 — and two racing
-	// starts cannot interleave their writes.
+	// The key is written first and exclusively. O_EXCL with mode 0600 means
+	// the file is never briefly world-readable — unlike WriteFile-then-Chmod,
+	// which leaves exactly that window and is flagged by gosec G306 — and
+	// two racing starts cannot interleave their writes.
 	if err := writeExclusive(root, serverKeyFile, keyPEM, serverKeyFileMode); err != nil {
 		return err
 	}
 	if err := writeExclusive(root, serverCertFile, certPEM, serverCrtFileMode); err != nil {
 		// Leaving a key without its certificate would trip the "not both
-		// present" check on the next start, which is a safe but confusing place
-		// to land. If the cleanup itself fails, say so — that message is the
-		// only thing connecting the orphaned key to what actually happened.
+		// present" check on the next start, which is a safe but confusing
+		// place to land. If the cleanup itself fails, say so — that message
+		// is the only thing connecting the orphaned key to what actually
+		// happened.
 		if rmErr := root.Remove(serverKeyFile); rmErr != nil {
 			log.Warn("could not remove the orphaned server key after a failed certificate write",
 				slog.Any("err", rmErr))
@@ -132,7 +180,9 @@ func keypairExists(certPath, keyPath string) (bool, error) {
 		return false, fmt.Errorf("stat %s: %w", keyPath, keyErr)
 	default:
 		// Exactly one half is present. Regenerating would produce a mismatched
-		// pair, so this is a loud failure for the operator to resolve.
+		// pair, so this is a loud failure for the operator to resolve. This is
+		// a torn-write failure, distinct from ErrIdentityIncomplete below,
+		// which reports a lost directory rather than an interrupted write.
 		return false, fmt.Errorf(
 			"server certificate and key are not both present in %s; remove the remaining file to regenerate",
 			filepath.Dir(certPath))
@@ -177,4 +227,43 @@ func ipStrings(ips []net.IP) []string {
 		out = append(out, ip.String())
 	}
 	return out
+}
+
+// CheckIdentityConsistency implements D9's matrix over (state database
+// present, certificate authority present):
+//
+//   - neither present: nil — a genuine first run.
+//   - both present: nil — the normal running state.
+//   - exactly one present: ErrIdentityIncomplete, naming which half is
+//     missing. This is the signature of a partial restore or a destroyed
+//     bind mount, not of a first install, and must never be treated as one:
+//     silently minting a fresh identity here would be indistinguishable from
+//     an attacker replacing the agent's identity outright.
+//
+// certsDir is the directory holding ca.crt/ca.key (CheckIdentityConsistency
+// does not touch server.crt/server.key, which are re-derived from the CA and
+// carry no independent identity). dbExisted reports whether the state
+// database file was already on disk before this start (state.Store's
+// FirstRun, negated).
+func CheckIdentityConsistency(certsDir string, dbExisted bool) error {
+	certPath := filepath.Join(certsDir, caCertFile)
+	keyPath := filepath.Join(certsDir, caKeyFile)
+
+	caExists, err := keypairExists(certPath, keyPath)
+	if err != nil {
+		return err
+	}
+
+	const reissueGuidance = "if you proceed by clearing the state directory, every paired device must re-pair"
+
+	switch {
+	case dbExisted == caExists:
+		return nil
+	case dbExisted && !caExists:
+		return fmt.Errorf("%w: the state database exists but the certificate authority in %s does not; %s",
+			ErrIdentityIncomplete, certsDir, reissueGuidance)
+	default: // !dbExisted && caExists
+		return fmt.Errorf("%w: the certificate authority in %s exists but the state database does not; %s",
+			ErrIdentityIncomplete, certsDir, reissueGuidance)
+	}
 }

--- a/internal/certs/store_test.go
+++ b/internal/certs/store_test.go
@@ -1,0 +1,243 @@
+package certs
+
+import (
+	"crypto/x509"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// serverVerifyOptions returns the x509.VerifyOptions a client uses to check
+// a server leaf against the pinned CA.
+func serverVerifyOptions(ca *CA) x509.VerifyOptions {
+	return x509.VerifyOptions{
+		Roots:     ca.Pool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+}
+
+// testCA returns a freshly created CA rooted at dir, for tests that only
+// care about the server-certificate half of the package.
+func testCA(t *testing.T, dir string) *CA {
+	t.Helper()
+	ca, _, err := LoadOrCreateCA(dir, testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA(%s) unexpected error: %v", dir, err)
+	}
+	return ca
+}
+
+func TestLoadOrCreateServerCertChainsToCA(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca := testCA(t, dir)
+
+	// Act
+	pair, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, ca, testLogger())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("LoadOrCreateServerCert() unexpected error: %v", err)
+	}
+	if _, err := pair.Leaf.Verify(serverVerifyOptions(ca)); err != nil {
+		t.Errorf("server leaf does not chain to the CA: %v", err)
+	}
+}
+
+func TestLoadOrCreateServerCertIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca := testCA(t, dir)
+	sans := []string{"vps.example.com"}
+
+	// Act
+	first, err := LoadOrCreateServerCert(dir, sans, ca, testLogger())
+	if err != nil {
+		t.Fatalf("first LoadOrCreateServerCert() unexpected error: %v", err)
+	}
+	second, err := LoadOrCreateServerCert(dir, sans, ca, testLogger())
+	if err != nil {
+		t.Fatalf("second LoadOrCreateServerCert() unexpected error: %v", err)
+	}
+
+	// Assert — a changed serial across restarts would mean a new identity,
+	// which unpairs every device.
+	if first.Leaf.SerialNumber.Cmp(second.Leaf.SerialNumber) != 0 {
+		t.Errorf("serial changed across reload: %v then %v",
+			first.Leaf.SerialNumber, second.Leaf.SerialNumber)
+	}
+}
+
+func TestLoadOrCreateServerCertReissuesOnSANDrift(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	ca := testCA(t, dir)
+	first, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, ca, testLogger())
+	if err != nil {
+		t.Fatalf("first LoadOrCreateServerCert() unexpected error: %v", err)
+	}
+
+	// Act — the operator adds an address the stored certificate does not cover.
+	newSANs := []string{"vps.example.com", "new.example.com"}
+	second, err := LoadOrCreateServerCert(dir, newSANs, ca, testLogger())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("second LoadOrCreateServerCert() unexpected error: %v", err)
+	}
+	if first.Leaf.SerialNumber.Cmp(second.Leaf.SerialNumber) == 0 {
+		t.Error("serial unchanged after SAN drift, want re-issuance")
+	}
+	if err := second.Leaf.VerifyHostname("new.example.com"); err != nil {
+		t.Errorf("re-issued leaf does not cover new.example.com: %v", err)
+	}
+	if err := second.Leaf.VerifyHostname("vps.example.com"); err != nil {
+		t.Errorf("re-issued leaf does not cover vps.example.com: %v", err)
+	}
+	if _, err := second.Leaf.Verify(serverVerifyOptions(ca)); err != nil {
+		t.Errorf("re-issued leaf does not chain to the CA: %v", err)
+	}
+}
+
+func TestServerKeyIsOwnerOnly(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not modelled on Windows")
+	}
+
+	// Arrange / Act
+	dir := t.TempDir()
+	ca := testCA(t, dir)
+	if _, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, ca, testLogger()); err != nil {
+		t.Fatalf("LoadOrCreateServerCert() unexpected error: %v", err)
+	}
+
+	// Assert
+	info, err := os.Stat(filepath.Join(dir, serverKeyFile))
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != serverKeyFileMode {
+		t.Errorf("server.key mode = %#o, want %#o", perm, serverKeyFileMode)
+	}
+}
+
+func TestLoadOrCreateServerCertRejectsHalfKeypair(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a certificate with no key, as a partial restore would leave.
+	dir := t.TempDir()
+	ca := testCA(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, serverCertFile), []byte("stub"), 0o644); err != nil {
+		t.Fatalf("write stub cert: %v", err)
+	}
+
+	// Act
+	_, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, ca, testLogger())
+
+	// Assert — regenerating would produce a mismatched pair, so this must be loud.
+	if err == nil {
+		t.Fatal("LoadOrCreateServerCert() error = nil, want a failure on a half keypair")
+	}
+	if !strings.Contains(err.Error(), "not both present") {
+		t.Errorf("error %q does not explain the half keypair", err)
+	}
+}
+
+func TestLoadOrCreateServerCertRejectsCorruptKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — both files present, key is garbage.
+	dir := t.TempDir()
+	ca := testCA(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, serverCertFile), []byte("not a cert"), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, serverKeyFile), []byte("not a key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	// Act
+	_, err := LoadOrCreateServerCert(dir, []string{"vps.example.com"}, ca, testLogger())
+
+	// Assert
+	if err == nil {
+		t.Fatal("LoadOrCreateServerCert() error = nil, want a load failure")
+	}
+	if !strings.Contains(err.Error(), "load server keypair") {
+		t.Errorf("error %q does not identify the failing step", err)
+	}
+}
+
+func TestCheckIdentityConsistency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		dbExisted     bool
+		createCA      bool
+		wantErr       error
+		wantErrSubstr string
+	}{
+		{
+			name:      "no database and no CA is a genuine first run",
+			dbExisted: false,
+			createCA:  false,
+			wantErr:   nil,
+		},
+		{
+			name:      "database and CA both present is the normal running state",
+			dbExisted: true,
+			createCA:  true,
+			wantErr:   nil,
+		},
+		{
+			name:          "database present without a CA is a partial restore",
+			dbExisted:     true,
+			createCA:      false,
+			wantErr:       ErrIdentityIncomplete,
+			wantErrSubstr: "certificate authority",
+		},
+		{
+			name:          "CA present without a database is a partial restore",
+			dbExisted:     false,
+			createCA:      true,
+			wantErr:       ErrIdentityIncomplete,
+			wantErrSubstr: "state database",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			dir := t.TempDir()
+			if tt.createCA {
+				testCA(t, dir)
+			}
+
+			// Act
+			err := CheckIdentityConsistency(dir, tt.dbExisted)
+
+			// Assert
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("CheckIdentityConsistency(dbExisted=%v, caPresent=%v) error = %v, want errors.Is match for %v",
+					tt.dbExisted, tt.createCA, err, tt.wantErr)
+			}
+			if tt.wantErrSubstr != "" && !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Errorf("error %q does not name which half is missing (want substring %q)", err, tt.wantErrSubstr)
+			}
+		})
+	}
+}

--- a/internal/httpapi/device.go
+++ b/internal/httpapi/device.go
@@ -1,0 +1,146 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Limits and messages for the two routes an already-paired device uses on
+// itself: renewing its own certificate and giving up its own access. Both
+// sit behind requireDevice, so the caller is always an authenticated,
+// active device acting on its own identity — never another device's.
+const (
+	// maxRenewBodyBytes bounds the renewal request body. The route sits
+	// behind requireDevice, so it is not the open-internet vector
+	// maxPairBodyBytes guards against, but a JSON body is still bounded on
+	// every route as a matter of course.
+	maxRenewBodyBytes = 8 << 10
+
+	// msgRenewFailed is the terse rejection served for every reason a
+	// renewal fails: a malformed CSR or an issuance error. The client must
+	// not be able to tell which.
+	msgRenewFailed = "renewal failed"
+
+	// msgDeviceInternalError covers an unexpected failure recording or
+	// superseding a certificate, or revoking the caller's own device.
+	msgDeviceInternalError = "internal error"
+)
+
+type renewRequest struct {
+	CSRPEM string `json:"csr_pem"`
+}
+
+type renewResponse struct {
+	CertificatePEM string `json:"certificate_pem"`
+	NotAfter       string `json:"not_after"` // RFC3339
+}
+
+// handleRenew issues a fresh certificate for the calling device's own
+// identity. The device ID comes only from DeviceFrom — never from the
+// request body or a path parameter — so a device can renew only itself.
+func (s *Server) handleRenew(w http.ResponseWriter, r *http.Request) {
+	device, ok := DeviceFrom(r.Context())
+	if !ok {
+		// requireDevice always injects a device before this handler runs;
+		// this branch exists only to fail closed if that ever changes.
+		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
+		return
+	}
+
+	req, ok := s.decodeRenewRequest(w, r)
+	if !ok {
+		return
+	}
+
+	csrDER, ok := decodeCSRPEM(req.CSRPEM)
+	if !ok {
+		s.writeError(w, http.StatusUnauthorized, msgRenewFailed)
+		return
+	}
+
+	resp, err := s.renewDevice(r.Context(), device.ID, csrDER)
+	if err != nil {
+		s.log.Error("renew device certificate",
+			slog.String("device_id", device.ID),
+			slog.Any("err", err),
+		)
+		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// decodeRenewRequest reads and bounds the request body, reporting 413 for an
+// oversized body and 400 for anything else that fails to decode.
+func (s *Server) decodeRenewRequest(w http.ResponseWriter, r *http.Request) (renewRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRenewBodyBytes)
+
+	var req renewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			s.writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return renewRequest{}, false
+		}
+		s.writeError(w, http.StatusBadRequest, "malformed request body")
+		return renewRequest{}, false
+	}
+	return req, true
+}
+
+// renewDevice issues a new certificate for deviceID, records it, and marks
+// every certificate the device held before as superseded (D6). The prior
+// certificate is never deleted and its validity is never shortened: it
+// keeps working until its own not_after, so a lost renewal response cannot
+// strand the device.
+func (s *Server) renewDevice(ctx context.Context, deviceID string, csrDER []byte) (renewResponse, error) {
+	now := time.Now()
+	certPEM, serial, notAfter, err := s.ca.IssueDeviceCert(csrDER, deviceID, now)
+	if err != nil {
+		return renewResponse{}, fmt.Errorf("issue renewed certificate for device %s: %w", deviceID, err)
+	}
+
+	if err := s.st.RecordDeviceCert(ctx, deviceID, serial, now, notAfter); err != nil {
+		return renewResponse{}, fmt.Errorf("record renewed certificate for device %s: %w", deviceID, err)
+	}
+
+	if err := s.st.SupersedePriorCerts(ctx, deviceID, serial); err != nil {
+		return renewResponse{}, fmt.Errorf("supersede prior certificates for device %s: %w", deviceID, err)
+	}
+
+	return renewResponse{
+		CertificatePEM: string(certPEM),
+		NotAfter:       notAfter.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// handleUnpairSelf revokes the calling device's own access and returns 204
+// with no body. Self-unpair is permitted under every policy mode: giving up
+// your own access is not a privileged act, so this is never gated by
+// policy.Mode.Allows.
+func (s *Server) handleUnpairSelf(w http.ResponseWriter, r *http.Request) {
+	device, ok := DeviceFrom(r.Context())
+	if !ok {
+		// requireDevice always injects a device before this handler runs;
+		// this branch exists only to fail closed if that ever changes.
+		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
+		return
+	}
+
+	if err := s.st.RevokeDevice(r.Context(), device.ID); err != nil {
+		s.log.Error("revoke self",
+			slog.String("device_id", device.ID),
+			slog.Any("err", err),
+		)
+		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/httpapi/device_test.go
+++ b/internal/httpapi/device_test.go
@@ -1,0 +1,287 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/certs"
+	"github.com/scnplt/devmon-agent/internal/policy"
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// pairedDevice is a device already paired against a live *state.Store and
+// *certs.CA, plus the serial of the certificate that currently authenticates
+// it. It exists so device.go tests can drive requireDevice without a real
+// TLS handshake.
+type pairedDevice struct {
+	device state.Device
+	serial *big.Int
+}
+
+// pairDeviceForTest issues a certificate for a fresh device and records it,
+// mirroring what handlePair does, without going through the HTTP layer.
+func pairDeviceForTest(t *testing.T, ctx context.Context, st *state.Store, ca *certs.CA, name string) pairedDevice {
+	t.Helper()
+
+	device, err := st.CreateDevice(ctx, name)
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+
+	csrPEM := generateCSRPEM(t, "irrelevant")
+	csrDER, ok := decodeCSRPEM(csrPEM)
+	if !ok {
+		t.Fatalf("decodeCSRPEM: failed to decode generated CSR")
+	}
+
+	now := time.Now()
+	certPEM, serialHex, notAfter, err := ca.IssueDeviceCert(csrDER, device.ID, now)
+	if err != nil {
+		t.Fatalf("IssueDeviceCert: %v", err)
+	}
+	if err := st.RecordDeviceCert(ctx, device.ID, serialHex, now, notAfter); err != nil {
+		t.Fatalf("RecordDeviceCert: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(certPEMBytes(t, certPEM))
+	if err != nil {
+		t.Fatalf("parse issued certificate: %v", err)
+	}
+
+	return pairedDevice{device: device, serial: leaf.SerialNumber}
+}
+
+// certPEMBytes extracts the DER bytes from a PEM-encoded certificate, for
+// tests that need to inspect the parsed certificate rather than its PEM
+// text.
+func certPEMBytes(t *testing.T, certPEM []byte) []byte {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatalf("certificate is not a PEM block: %q", certPEM)
+	}
+	return block.Bytes
+}
+
+// requestWithPeerSerial builds a guarded request carrying a single peer
+// certificate whose serial number is serial.
+func requestWithPeerSerial(method, path string, body []byte, serial *big.Int) *http.Request {
+	var req *http.Request
+	if body == nil {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.TLS = peerCertWithSerial(serial)
+	return req
+}
+
+func TestHandleRenewIssuesNewerCertificateAndKeepsOldSerialValid(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+	oldDevice, err := st.DeviceByCertSerial(ctx, paired.serial.Text(16))
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial(old): %v", err)
+	}
+
+	body, err := json.Marshal(renewRequest{CSRPEM: generateCSRPEM(t, "irrelevant")})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", body, paired.serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp renewResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	block, err := x509.ParseCertificate(certPEMBytes(t, []byte(resp.CertificatePEM)))
+	if err != nil {
+		t.Fatalf("parse renewed certificate: %v", err)
+	}
+	newSerial := block.SerialNumber
+	if newSerial.Cmp(paired.serial) == 0 {
+		t.Error("renewed certificate has the same serial as the original")
+	}
+
+	notAfter, err := time.Parse(time.RFC3339, resp.NotAfter)
+	if err != nil {
+		t.Fatalf("not_after %q is not RFC3339: %v", resp.NotAfter, err)
+	}
+	if !notAfter.After(oldDevice.PairedAt) {
+		t.Errorf("renewed not_after %v is not after paired_at %v", notAfter, oldDevice.PairedAt)
+	}
+
+	// Both the old and the new serial must still resolve to the same
+	// device (D6): a lost renewal response must not strand the caller.
+	fromOld, err := st.DeviceByCertSerial(ctx, paired.serial.Text(16))
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial(old serial after renewal): %v", err)
+	}
+	if fromOld.ID != paired.device.ID {
+		t.Errorf("old serial resolves to device %q, want %q", fromOld.ID, paired.device.ID)
+	}
+	fromNew, err := st.DeviceByCertSerial(ctx, newSerial.Text(16))
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial(new serial): %v", err)
+	}
+	if fromNew.ID != paired.device.ID {
+		t.Errorf("new serial resolves to device %q, want %q", fromNew.ID, paired.device.ID)
+	}
+}
+
+func TestHandleRenewSucceedsUnderReadOnlyPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	s.cfg.PolicyMode = policy.ModeReadOnly
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+
+	body, err := json.Marshal(renewRequest{CSRPEM: generateCSRPEM(t, "irrelevant")})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", body, paired.serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert — renewal is never gated by policy mode: it is not a
+	// privileged operation.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 under read-only policy; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRenewRejectsMalformedCSR(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+
+	body, err := json.Marshal(renewRequest{CSRPEM: "not a pem csr"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", body, paired.serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleUnpairSelfRevokesAndBlocksSubsequentRequests(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+
+	unpairReq := requestWithPeerSerial(http.MethodDelete, "/v1/device/self", nil, paired.serial)
+	unpairRec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(unpairRec, unpairReq)
+
+	// Assert — 204 with no body.
+	if unpairRec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", unpairRec.Code, unpairRec.Body.String())
+	}
+	if unpairRec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", unpairRec.Body.String())
+	}
+
+	device, err := st.DeviceByCertSerial(ctx, paired.serial.Text(16))
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial after unpair: %v", err)
+	}
+	if !device.IsRevoked() {
+		t.Error("device is not revoked after self-unpair")
+	}
+
+	// Act — the device's very next guarded request.
+	nextReq := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", mustMarshalRenew(t), paired.serial)
+	nextRec := httptest.NewRecorder()
+	s.routes().ServeHTTP(nextRec, nextReq)
+
+	// Assert
+	if nextRec.Code != http.StatusUnauthorized {
+		t.Fatalf("status after revocation = %d, want 401; body: %s", nextRec.Code, nextRec.Body.String())
+	}
+}
+
+func TestHandleUnpairSelfSucceedsUnderEveryPolicyMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode policy.Mode
+	}{
+		{name: "read-only", mode: policy.ModeReadOnly},
+		{name: "default", mode: policy.ModeDefault},
+		{name: "full", mode: policy.ModeFull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s, st, ca := testServerForPairing(t)
+			s.cfg.PolicyMode = tt.mode
+			ctx := context.Background()
+			paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+			req := requestWithPeerSerial(http.MethodDelete, "/v1/device/self", nil, paired.serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert — self-unpair is never gated by policy mode.
+			if rec.Code != http.StatusNoContent {
+				t.Errorf("status = %d, want 204 under %s policy; body: %s", rec.Code, tt.mode, rec.Body.String())
+			}
+		})
+	}
+}
+
+func mustMarshalRenew(t *testing.T) []byte {
+	t.Helper()
+	body, err := json.Marshal(renewRequest{CSRPEM: generateCSRPEM(t, "irrelevant")})
+	if err != nil {
+		t.Fatalf("marshal renew request: %v", err)
+	}
+	return body
+}

--- a/internal/httpapi/middleware.go
+++ b/internal/httpapi/middleware.go
@@ -1,36 +1,86 @@
 package httpapi
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/scnplt/devmon-agent/internal/state"
 )
 
 // msgClientCertRequired is the terse rejection served to any unauthenticated
 // caller on a guarded route. It says nothing about why.
 const msgClientCertRequired = "client certificate required"
 
-// requireDevice rejects any request without a verified client certificate.
+// deviceCtxKey is the context key under which requireDevice stores the
+// resolved Device. An empty struct type, not a string: a string key can
+// collide with another package's context value, an empty struct type cannot.
+type deviceCtxKey struct{}
+
+// DeviceFrom returns the Device requireDevice resolved for this request, if
+// any. Handlers behind requireDevice may call this without a second lookup.
+func DeviceFrom(ctx context.Context) (state.Device, bool) {
+	device, ok := ctx.Value(deviceCtxKey{}).(state.Device)
+	return device, ok
+}
+
+// requireDevice rejects any request without a verified client certificate
+// belonging to an active, registered device.
 //
 // This is the other half of the single-port design: because the listener uses
 // VerifyClientCertIfGiven rather than RequireAndVerifyClientCert (see
 // internal/tlsconf), a connection with no client certificate reaches HTTP. This
 // middleware is what stops it from reaching a protected route.
 //
-// Phase 1 has no CA, so every request is rejected — and no route is wrapped in
-// it yet, because none exists. Phase 2 fills in the device lookup against
-// state.Store and starts guarding real handlers.
+// Every rejection reason — no certificate, unknown serial, revoked device —
+// answers with the identical msgClientCertRequired body and 401 status. The
+// real reason is logged for the operator; a scanner probing the port learns
+// nothing that distinguishes the cases.
 func (s *Server) requireDevice(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 			s.writeError(w, http.StatusUnauthorized, msgClientCertRequired)
 			return
 		}
-		// Phase 2: resolve r.TLS.PeerCertificates[0] to a non-revoked device and
-		// call next. Until then a presented certificate cannot be verified
-		// against anything, so it fails closed.
-		_ = next
-		s.writeError(w, http.StatusUnauthorized, msgClientCertRequired)
+
+		serial := r.TLS.PeerCertificates[0].SerialNumber.Text(16)
+
+		device, err := s.st.DeviceByCertSerial(r.Context(), serial)
+		if err != nil {
+			if !errors.Is(err, state.ErrDeviceNotFound) {
+				s.log.Error("resolve device by certificate serial",
+					slog.String("serial", serial),
+					slog.Any("err", err),
+				)
+			} else {
+				s.log.Warn("rejected request with unknown certificate serial",
+					slog.String("serial", serial),
+				)
+			}
+			s.writeError(w, http.StatusUnauthorized, msgClientCertRequired)
+			return
+		}
+		if device.IsRevoked() {
+			s.log.Warn("rejected request from revoked device",
+				slog.String("device_id", device.ID),
+			)
+			s.writeError(w, http.StatusUnauthorized, msgClientCertRequired)
+			return
+		}
+
+		// A failed last-seen write is bookkeeping, not authorisation — it must
+		// never fail the request.
+		if err := s.st.TouchDevice(r.Context(), device.ID); err != nil {
+			s.log.Warn("touch device last seen",
+				slog.String("device_id", device.ID),
+				slog.Any("err", err),
+			)
+		}
+
+		ctx := context.WithValue(r.Context(), deviceCtxKey{}, device)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/internal/httpapi/pair.go
+++ b/internal/httpapi/pair.go
@@ -1,0 +1,170 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// Limits and messages for the one route reachable without a client
+// certificate. Every value here is a security decision, not a tunable.
+const (
+	// maxPairBodyBytes bounds the pairing request body. This route has no
+	// client certificate to gate it and there is no rate limiting until
+	// Phase 6, so an unbounded JSON body is a trivial memory-exhaustion
+	// vector.
+	maxPairBodyBytes = 8 << 10
+
+	// msgPairFailed is the terse rejection served for every reason a pairing
+	// attempt fails: an unknown, expired, or already-used code, or a
+	// malformed CSR. The client must never be able to tell which.
+	msgPairFailed = "pairing failed"
+
+	// msgPairInternalError covers the case where the operator's code was
+	// already spent but the agent could not finish minting a certificate.
+	msgPairInternalError = "internal error"
+
+	// pendingDeviceName is the placeholder recorded when the device row is
+	// created, before its pairing code is redeemed. RedeemPairingCode
+	// returns the operator-chosen name, which replaces this placeholder: the
+	// device row must exist before redemption (RedeemPairingCode needs its
+	// ID), but the request body must never be the source of the name.
+	pendingDeviceName = "pending"
+
+	// pemTypeCertificateRequest is the PEM block type of a PKCS#10 CSR.
+	pemTypeCertificateRequest = "CERTIFICATE REQUEST"
+)
+
+type pairRequest struct {
+	PairingCode string `json:"pairing_code"`
+	CSRPEM      string `json:"csr_pem"`
+}
+
+type pairResponse struct {
+	DeviceID       string `json:"device_id"`
+	CertificatePEM string `json:"certificate_pem"`
+	CACertificate  string `json:"ca_certificate_pem"`
+	NotAfter       string `json:"not_after"` // RFC3339
+}
+
+// handlePair issues a device certificate against a one-time, operator-minted
+// pairing code. It is the only route reachable without a client certificate
+// (D2 in the Phase 2 plan): the device has none yet, so the code itself is
+// what authenticates the call.
+func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	req, ok := s.decodePairRequest(w, r)
+	if !ok {
+		return
+	}
+
+	csrDER, ok := decodeCSRPEM(req.CSRPEM)
+	if !ok {
+		s.writeError(w, http.StatusUnauthorized, msgPairFailed)
+		return
+	}
+
+	resp, err := s.pairDevice(r.Context(), req.PairingCode, csrDER)
+	if err != nil {
+		if errors.Is(err, state.ErrPairingCodeInvalid) {
+			s.writeError(w, http.StatusUnauthorized, msgPairFailed)
+			return
+		}
+		s.log.Error("pair device", slog.Any("err", err))
+		s.writeError(w, http.StatusInternalServerError, msgPairInternalError)
+		return
+	}
+
+	s.writeJSON(w, http.StatusCreated, resp)
+}
+
+// decodePairRequest reads and bounds the request body, reporting 413 for an
+// oversized body and 400 for anything else that fails to decode.
+func (s *Server) decodePairRequest(w http.ResponseWriter, r *http.Request) (pairRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxPairBodyBytes)
+
+	var req pairRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			s.writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return pairRequest{}, false
+		}
+		s.writeError(w, http.StatusBadRequest, "malformed request body")
+		return pairRequest{}, false
+	}
+	return req, true
+}
+
+// decodeCSRPEM extracts the raw DER bytes of a PEM-encoded PKCS#10 CSR,
+// rejecting anything that is not a well-formed "CERTIFICATE REQUEST" block
+// before the operator's pairing code is ever touched.
+func decodeCSRPEM(csrPEM string) ([]byte, bool) {
+	block, _ := pem.Decode([]byte(csrPEM))
+	if block == nil || block.Type != pemTypeCertificateRequest {
+		return nil, false
+	}
+	return block.Bytes, true
+}
+
+// pairDevice runs the pairing sequence in the order that keeps a failure
+// from wasting the operator's code for nothing: create the device row first,
+// redeem the code second, issue the certificate third. Any failure after the
+// row was created deletes it — RedeemPairingCode failing means the code was
+// never actually spent, so the deletion is bookkeeping rather than a
+// rollback of a granted credential, but it is identical either way from the
+// caller's point of view: no orphan device row survives.
+func (s *Server) pairDevice(ctx context.Context, code string, csrDER []byte) (pairResponse, error) {
+	device, err := s.st.CreateDevice(ctx, pendingDeviceName)
+	if err != nil {
+		return pairResponse{}, fmt.Errorf("create device for pairing: %w", err)
+	}
+
+	deviceName, err := s.st.RedeemPairingCode(ctx, code, device.ID)
+	if err != nil {
+		s.deleteOrphanedDevice(ctx, device.ID)
+		return pairResponse{}, fmt.Errorf("redeem pairing code: %w", err)
+	}
+
+	if err := s.st.RenameDevice(ctx, device.ID, deviceName); err != nil {
+		s.deleteOrphanedDevice(ctx, device.ID)
+		return pairResponse{}, fmt.Errorf("rename paired device: %w", err)
+	}
+
+	now := time.Now()
+	certPEM, serial, notAfter, err := s.ca.IssueDeviceCert(csrDER, device.ID, now)
+	if err != nil {
+		s.deleteOrphanedDevice(ctx, device.ID)
+		return pairResponse{}, fmt.Errorf("issue device certificate: %w", err)
+	}
+
+	if err := s.st.RecordDeviceCert(ctx, device.ID, serial, now, notAfter); err != nil {
+		s.deleteOrphanedDevice(ctx, device.ID)
+		return pairResponse{}, fmt.Errorf("record device certificate: %w", err)
+	}
+
+	return pairResponse{
+		DeviceID:       device.ID,
+		CertificatePEM: string(certPEM),
+		CACertificate:  string(s.ca.CertPEM()),
+		NotAfter:       notAfter.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// deleteOrphanedDevice removes a device row left behind by a failed pairing
+// attempt. The original failure is logged by the caller; this logs only a
+// second failure, if the cleanup itself does not succeed.
+func (s *Server) deleteOrphanedDevice(ctx context.Context, deviceID string) {
+	if err := s.st.DeleteDevice(ctx, deviceID); err != nil {
+		s.log.Error("delete orphaned device after failed pairing",
+			slog.String("device_id", deviceID),
+			slog.Any("err", err),
+		)
+	}
+}

--- a/internal/httpapi/pair_test.go
+++ b/internal/httpapi/pair_test.go
@@ -1,0 +1,212 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scnplt/devmon-agent/internal/certs"
+	"github.com/scnplt/devmon-agent/internal/config"
+	"github.com/scnplt/devmon-agent/internal/policy"
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// testServerForPairing is a fourth Server helper, additive to testServer,
+// testServerWithCA, and testServerWithStore: handlePair needs both a real
+// *state.Store and a real *certs.CA, and no existing helper carries both.
+func testServerForPairing(t *testing.T) (*Server, *state.Store, *certs.CA) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Config{StateDir: dir, ListenAddr: ":8443", PolicyMode: policy.ModeDefault}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), testLogger())
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ca, _, err := certs.LoadOrCreateCA(t.TempDir(), testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA: %v", err)
+	}
+	return NewServer(cfg, st, ca, nil, testLogger()), st, ca
+}
+
+// generateCSRPEM builds a PEM-encoded PKCS#10 CSR from a fresh EC P-256 key,
+// with a Subject the caller controls — used to prove the CN is ignored.
+func generateCSRPEM(t *testing.T, subjectCN string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CSR key: %v", err)
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: subjectCN},
+	}, key)
+	if err != nil {
+		t.Fatalf("create CSR: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der}))
+}
+
+func postPair(s *Server, body []byte) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/pair", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.routes().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandlePairSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	body, err := json.Marshal(pairRequest{
+		PairingCode: code,
+		CSRPEM:      generateCSRPEM(t, "attacker-controlled"),
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// Act
+	rec := postPair(s, body)
+
+	// Assert
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp pairResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.DeviceID == "" {
+		t.Error("device_id is empty")
+	}
+	if resp.CACertificate != string(ca.CertPEM()) {
+		t.Error("ca_certificate_pem does not match ca.CertPEM()")
+	}
+
+	block, _ := pem.Decode([]byte(resp.CertificatePEM))
+	if block == nil {
+		t.Fatalf("certificate_pem is not a PEM block: %q", resp.CertificatePEM)
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse issued certificate: %v", err)
+	}
+	if leaf.Subject.CommonName != resp.DeviceID {
+		t.Errorf("issued certificate CN = %q, want device_id %q (CSR subject must be ignored)",
+			leaf.Subject.CommonName, resp.DeviceID)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     ca.Pool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Errorf("issued certificate does not verify against the CA pool: %v", err)
+	}
+}
+
+func TestHandlePairCodeReusedFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, _ := testServerForPairing(t)
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	firstBody, err := json.Marshal(pairRequest{PairingCode: code, CSRPEM: generateCSRPEM(t, "first")})
+	if err != nil {
+		t.Fatalf("marshal first request: %v", err)
+	}
+	if rec := postPair(s, firstBody); rec.Code != http.StatusCreated {
+		t.Fatalf("first pairing status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+	}
+
+	secondBody, err := json.Marshal(pairRequest{PairingCode: code, CSRPEM: generateCSRPEM(t, "second")})
+	if err != nil {
+		t.Fatalf("marshal second request: %v", err)
+	}
+
+	// Act
+	rec := postPair(s, secondBody)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("second pairing status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.Error != msgPairFailed {
+		t.Errorf("error = %q, want the terse %q", body.Error, msgPairFailed)
+	}
+}
+
+func TestHandlePairMalformedCSRFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, _ := testServerForPairing(t)
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	body, err := json.Marshal(pairRequest{PairingCode: code, CSRPEM: "not a pem csr"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// Act
+	rec := postPair(s, body)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+	}
+	var respBody errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&respBody); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if respBody.Error != msgPairFailed {
+		t.Errorf("error = %q, want the terse %q", respBody.Error, msgPairFailed)
+	}
+}
+
+func TestHandlePairOversizedBodyFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, _, _ := testServerForPairing(t)
+	body, err := json.Marshal(pairRequest{
+		PairingCode: "irrelevant",
+		CSRPEM:      strings.Repeat("x", maxPairBodyBytes+1024),
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// Act
+	rec := postPair(s, body)
+
+	// Assert
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/scnplt/devmon-agent/internal/certs"
 	"github.com/scnplt/devmon-agent/internal/config"
 	"github.com/scnplt/devmon-agent/internal/state"
 )
@@ -37,14 +38,20 @@ const (
 type Server struct {
 	cfg  config.Config
 	st   *state.Store
+	ca   *certs.CA
 	log  *slog.Logger
 	http *http.Server
 }
 
 // NewServer wires the API. tlsCfg carries the server certificate, so the
-// listener never re-reads it from disk.
-func NewServer(cfg config.Config, st *state.Store, tlsCfg *tls.Config, log *slog.Logger) *Server {
-	s := &Server{cfg: cfg, st: st, log: log}
+// listener never re-reads it from disk. ca is retained on Server — not just
+// its fingerprint — because guarded routes added in a later phase issue and
+// renew device certificates from it; the status handler derives the public
+// fingerprint from it on each call. ca may be nil in tests that do not
+// exercise certificate issuance; handleStatus tolerates that by serving an
+// empty fingerprint.
+func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, tlsCfg *tls.Config, log *slog.Logger) *Server {
+	s := &Server{cfg: cfg, st: st, ca: ca, log: log}
 
 	s.http = &http.Server{
 		Addr:              cfg.ListenAddr,
@@ -70,6 +77,15 @@ func (s *Server) routes() http.Handler {
 	// The Go 1.22+ method pattern matters. Registering "/v1/status" alone would
 	// also match POST, DELETE, and everything else.
 	mux.HandleFunc("GET /v1/status", s.handleStatus)
+
+	// Unauthenticated by design (D2): the device has no certificate yet, so
+	// the pairing code itself is what authenticates this one call.
+	mux.HandleFunc("POST /v1/pair", s.handlePair)
+
+	// Guarded: both act on the calling device's own identity, resolved by
+	// requireDevice from its client certificate — never from the request.
+	mux.Handle("POST /v1/device/renew", s.requireDevice(http.HandlerFunc(s.handleRenew)))
+	mux.Handle("DELETE /v1/device/self", s.requireDevice(http.HandlerFunc(s.handleUnpairSelf)))
 
 	return s.withRecovery(s.withRequestLog(mux))
 }

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -28,7 +28,7 @@ func testTLSConfig(t *testing.T) *tls.Config {
 func runnableServer(t *testing.T, addr string) *Server {
 	t.Helper()
 	cfg := config.Config{StateDir: t.TempDir(), ListenAddr: addr, PolicyMode: policy.ModeDefault}
-	return NewServer(cfg, nil, testTLSConfig(t), testLogger())
+	return NewServer(cfg, nil, nil, testTLSConfig(t), testLogger())
 }
 
 // TestRunShutsDownCleanly is the graceful-shutdown contract: SIGTERM cancels the

--- a/internal/httpapi/status.go
+++ b/internal/httpapi/status.go
@@ -14,27 +14,38 @@ const APIVersion = "v1"
 
 // statusResponse is the ONLY payload served without a client certificate.
 //
-// Its fields are a strict allowlist: version, policy, server time — and, from
-// Phase 2, the CA fingerprint. This endpoint may inform, never issue. It must
-// never carry host, container, credential, or configuration detail, because
-// anything here is readable by every scanner that finds the port.
+// Its fields are a strict allowlist: version, policy, server time, and the CA
+// fingerprint. This endpoint may inform, never issue. It must never carry
+// host, container, credential, or configuration detail, because anything
+// here is readable by every scanner that finds the port. The fingerprint is
+// deliberately public — it is the pinning anchor a client checks against —
+// but nothing else about the CA may ever join this struct.
 type statusResponse struct {
-	APIVersion   string `json:"api_version"`
-	AgentVersion string `json:"agent_version"`
-	PolicyMode   string `json:"policy_mode"`
-	ServerTime   string `json:"server_time"`
+	APIVersion    string `json:"api_version"`
+	AgentVersion  string `json:"agent_version"`
+	PolicyMode    string `json:"policy_mode"`
+	ServerTime    string `json:"server_time"`
+	CAFingerprint string `json:"ca_fingerprint"`
 }
 
 // handleStatus serves the unauthenticated status payload.
 //
 // Advertising the policy mode is deliberate: it lets a client tell "the agent
 // refuses to restart containers" apart from "the agent is broken" without
-// needing a credential.
+// needing a credential. The CA fingerprint lets a client distinguish "my
+// credential expired" from "this server's identity changed" without needing
+// one either.
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	var fingerprint string
+	if s.ca != nil {
+		fingerprint = s.ca.Fingerprint()
+	}
+
 	s.writeJSON(w, http.StatusOK, statusResponse{
-		APIVersion:   APIVersion,
-		AgentVersion: version.Version,
-		PolicyMode:   s.cfg.PolicyMode.String(),
-		ServerTime:   time.Now().UTC().Format(time.RFC3339),
+		APIVersion:    APIVersion,
+		AgentVersion:  version.Version,
+		PolicyMode:    s.cfg.PolicyMode.String(),
+		ServerTime:    time.Now().UTC().Format(time.RFC3339),
+		CAFingerprint: fingerprint,
 	})
 }

--- a/internal/httpapi/status_test.go
+++ b/internal/httpapi/status_test.go
@@ -1,19 +1,24 @@
 package httpapi
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"io"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/scnplt/devmon-agent/internal/certs"
 	"github.com/scnplt/devmon-agent/internal/config"
 	"github.com/scnplt/devmon-agent/internal/policy"
+	"github.com/scnplt/devmon-agent/internal/state"
 	"github.com/scnplt/devmon-agent/internal/version"
 )
 
@@ -24,14 +29,53 @@ func testLogger() *slog.Logger {
 func testServer(t *testing.T, mode policy.Mode) *Server {
 	t.Helper()
 	cfg := config.Config{StateDir: t.TempDir(), ListenAddr: ":8443", PolicyMode: mode}
-	return NewServer(cfg, nil, nil, testLogger())
+	return NewServer(cfg, nil, nil, nil, testLogger())
+}
+
+// testServerWithCA is a second helper, additive to testServer, for tests that
+// need a real CA to exercise handleStatus's fingerprint derivation. Several
+// passing tests rely on testServer constructing a Server with a nil CA, so
+// that helper stays unchanged rather than being widened.
+func testServerWithCA(t *testing.T, mode policy.Mode) (*Server, *certs.CA) {
+	t.Helper()
+	cfg := config.Config{StateDir: t.TempDir(), ListenAddr: ":8443", PolicyMode: mode}
+	ca, _, err := certs.LoadOrCreateCA(t.TempDir(), testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA: %v", err)
+	}
+	return NewServer(cfg, nil, ca, nil, testLogger()), ca
+}
+
+// testServerWithStore is a third helper, additive to testServer and
+// testServerWithCA, for tests that exercise requireDevice's live lookup
+// against a real *state.Store. testServer keeps passing nil, which several
+// passing tests rely on.
+func testServerWithStore(t *testing.T) (*Server, *state.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Config{StateDir: dir, ListenAddr: ":8443", PolicyMode: policy.ModeDefault}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), testLogger())
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return NewServer(cfg, st, nil, nil, testLogger()), st
+}
+
+// peerCertWithSerial builds a *tls.ConnectionState carrying a single peer
+// certificate whose serial number is serial, for driving requireDevice
+// without a real TLS handshake.
+func peerCertWithSerial(serial *big.Int) *tls.ConnectionState {
+	return &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{SerialNumber: serial}},
+	}
 }
 
 // TestStatusFieldCount is the guard that stops a later phase from quietly
-// widening a pre-authentication surface. Asserting only that the four expected
-// keys are PRESENT would let a fifth slip in unnoticed; asserting the exact
+// widening a pre-authentication surface. Asserting only that the five expected
+// keys are PRESENT would let a sixth slip in unnoticed; asserting the exact
 // count forces any addition through a deliberate edit of this test. Phase 2
-// changes 4 to 5 when ca_fingerprint lands.
+// added ca_fingerprint, changing the count from 4 to 5.
 func TestStatusFieldCount(t *testing.T) {
 	t.Parallel()
 
@@ -51,12 +95,43 @@ func TestStatusFieldCount(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if len(body) != 4 {
-		t.Fatalf("status payload has %d keys (%v), want exactly 4", len(body), keysOf(body))
+	if len(body) != 5 {
+		t.Fatalf("status payload has %d keys (%v), want exactly 5", len(body), keysOf(body))
 	}
-	for _, key := range []string{"api_version", "agent_version", "policy_mode", "server_time"} {
+	for _, key := range []string{"api_version", "agent_version", "policy_mode", "server_time", "ca_fingerprint"} {
 		if _, ok := body[key]; !ok {
 			t.Errorf("status payload is missing %q", key)
+		}
+	}
+}
+
+// TestStatusCAFingerprint asserts the fingerprint is the real pinning anchor:
+// 64 lowercase hex characters, equal to ca.Fingerprint().
+func TestStatusCAFingerprint(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, ca := testServerWithCA(t, policy.ModeDefault)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+
+	// Assert
+	var body statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.CAFingerprint != ca.Fingerprint() {
+		t.Errorf("ca_fingerprint = %q, want %q", body.CAFingerprint, ca.Fingerprint())
+	}
+	if len(body.CAFingerprint) != 64 {
+		t.Errorf("ca_fingerprint length = %d, want 64", len(body.CAFingerprint))
+	}
+	for _, r := range body.CAFingerprint {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			t.Errorf("ca_fingerprint = %q, contains non-lowercase-hex rune %q", body.CAFingerprint, r)
+			break
 		}
 	}
 }
@@ -185,6 +260,11 @@ func TestUnknownPathLeaksNothing(t *testing.T) {
 	}
 }
 
+// TestRequireDeviceRejectsWithoutCertificate covers the cases requireDevice
+// rejects before it ever needs a store lookup, so testServer's nil store is
+// safe to use here. The case of a presented certificate whose serial must be
+// resolved against a real registry — unknown, revoked, or active — lives in
+// TestRequireDeviceResolvesRealDevice, which uses testServerWithStore.
 func TestRequireDeviceRejectsWithoutCertificate(t *testing.T) {
 	t.Parallel()
 
@@ -194,10 +274,6 @@ func TestRequireDeviceRejectsWithoutCertificate(t *testing.T) {
 	}{
 		{name: "plain connection", tlsS: nil},
 		{name: "tls with no peer certificates", tlsS: &tls.ConnectionState{}},
-		{
-			name: "tls with a peer certificate but no CA to verify it",
-			tlsS: &tls.ConnectionState{PeerCertificates: []*x509.Certificate{{}}},
-		},
 	}
 
 	for _, tt := range tests {
@@ -207,7 +283,7 @@ func TestRequireDeviceRejectsWithoutCertificate(t *testing.T) {
 			// Arrange
 			s := testServer(t, policy.ModeDefault)
 			guarded := s.requireDevice(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				t.Error("guarded handler ran; Phase 1 must reject every request")
+				t.Error("guarded handler ran; no client certificate was presented")
 				w.WriteHeader(http.StatusOK)
 			}))
 			req := httptest.NewRequest(http.MethodGet, "/v1/protected", nil)
@@ -229,6 +305,115 @@ func TestRequireDeviceRejectsWithoutCertificate(t *testing.T) {
 				t.Errorf("error = %q, want the terse %q", body.Error, msgClientCertRequired)
 			}
 		})
+	}
+}
+
+// TestRequireDeviceResolvesRealDevice extends the requireDevice table above
+// with cases that need a live *state.Store: an unknown serial and a revoked
+// device must both fail with the identical terse 401 the no-certificate case
+// produces, while an active device's certificate must let the wrapped
+// handler run and hand it the resolved Device via DeviceFrom.
+func TestRequireDeviceResolvesRealDevice(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a store with one active and one revoked device, each with a
+	// certificate serial recorded against it.
+	s, st := testServerWithStore(t)
+	ctx := context.Background()
+
+	active, err := st.CreateDevice(ctx, "active device")
+	if err != nil {
+		t.Fatalf("CreateDevice(active): %v", err)
+	}
+	activeSerial := big.NewInt(101)
+	notBefore := time.Now()
+	notAfter := notBefore.Add(90 * 24 * time.Hour)
+	if err := st.RecordDeviceCert(ctx, active.ID, activeSerial.Text(16), notBefore, notAfter); err != nil {
+		t.Fatalf("RecordDeviceCert(active): %v", err)
+	}
+
+	revoked, err := st.CreateDevice(ctx, "revoked device")
+	if err != nil {
+		t.Fatalf("CreateDevice(revoked): %v", err)
+	}
+	revokedSerial := big.NewInt(202)
+	if err := st.RecordDeviceCert(ctx, revoked.ID, revokedSerial.Text(16), notBefore, notAfter); err != nil {
+		t.Fatalf("RecordDeviceCert(revoked): %v", err)
+	}
+	if err := st.RevokeDevice(ctx, revoked.ID); err != nil {
+		t.Fatalf("RevokeDevice: %v", err)
+	}
+
+	unknownSerial := big.NewInt(303)
+
+	tests := []struct {
+		name       string
+		tlsS       *tls.ConnectionState
+		wantStatus int
+		wantRun    bool
+	}{
+		{name: "no client certificate", tlsS: nil, wantStatus: http.StatusUnauthorized},
+		{name: "unknown certificate serial", tlsS: peerCertWithSerial(unknownSerial), wantStatus: http.StatusUnauthorized},
+		{name: "revoked device", tlsS: peerCertWithSerial(revokedSerial), wantStatus: http.StatusUnauthorized},
+		{name: "active device", tlsS: peerCertWithSerial(activeSerial), wantStatus: http.StatusOK, wantRun: true},
+	}
+
+	var rejectionBodies []string
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Not run in parallel: rejectionBodies is collected across cases.
+
+			// Arrange
+			var ran bool
+			var gotDevice state.Device
+			var gotOK bool
+			guarded := s.requireDevice(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ran = true
+				gotDevice, gotOK = DeviceFrom(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/v1/protected", nil)
+			req.TLS = tt.tlsS
+			rec := httptest.NewRecorder()
+
+			// Act
+			guarded.ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if ran != tt.wantRun {
+				t.Errorf("handler ran = %v, want %v", ran, tt.wantRun)
+			}
+			if tt.wantRun {
+				if !gotOK {
+					t.Error("DeviceFrom returned ok=false for a guarded handler behind an active device")
+				}
+				if gotDevice.ID != active.ID {
+					t.Errorf("DeviceFrom device id = %q, want %q", gotDevice.ID, active.ID)
+				}
+			} else {
+				var body errorBody
+				if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				if body.Error != msgClientCertRequired {
+					t.Errorf("error = %q, want the terse %q", body.Error, msgClientCertRequired)
+				}
+				rejectionBodies = append(rejectionBodies, rec.Body.String())
+			}
+		})
+	}
+
+	// Assert — every rejection reason must be byte-identical: the client
+	// cannot distinguish "no certificate" from "unknown serial" from
+	// "revoked device".
+	for i := 1; i < len(rejectionBodies); i++ {
+		if rejectionBodies[i] != rejectionBodies[0] {
+			t.Errorf("rejection body %d = %q, want byte-identical to %q", i, rejectionBodies[i], rejectionBodies[0])
+		}
 	}
 }
 

--- a/internal/state/devices.go
+++ b/internal/state/devices.go
@@ -1,0 +1,239 @@
+package state
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// deviceIDBytes is the amount of randomness behind a device ID: 8 bytes hex
+// encode to 16 lowercase hex characters, matching the schema comment.
+const deviceIDBytes = 8
+
+// lastSeenResolution is the minimum gap between two last_seen_at writes for
+// the same device (D11). Writing on every request, against a pool capped at
+// MaxOpenConns(1), would serialise reads behind a write for no operational
+// benefit.
+const lastSeenResolution = 60 * time.Second
+
+// Device is one paired client. Certificates live in a separate table so a
+// renewal is an INSERT, not a destructive UPDATE (see D6 in the Phase 2 plan).
+type Device struct {
+	ID         string
+	Name       string
+	PairedAt   time.Time
+	LastSeenAt time.Time // zero when never seen
+	RevokedAt  time.Time // zero when active
+}
+
+// IsRevoked reports whether the device's access has been withdrawn.
+func (d Device) IsRevoked() bool {
+	return !d.RevokedAt.IsZero()
+}
+
+// CreateDevice registers a new device and returns its record. The ID is 8
+// random bytes hex-encoded via crypto/rand — never math/rand, which is not
+// safe for identifiers an attacker might try to predict or collide.
+func (s *Store) CreateDevice(ctx context.Context, name string) (Device, error) {
+	raw := make([]byte, deviceIDBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return Device{}, fmt.Errorf("generate device id: %w", err)
+	}
+	id := hex.EncodeToString(raw)
+	pairedAt := time.Now()
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO devices (id, name, paired_at) VALUES (?, ?, ?)`,
+		id, name, pairedAt.Unix(),
+	)
+	if err != nil {
+		return Device{}, fmt.Errorf("create device %s: %w", id, err)
+	}
+
+	return Device{ID: id, Name: name, PairedAt: pairedAt.UTC()}, nil
+}
+
+// RenameDevice updates a device's display name.
+//
+// It exists for the pairing flow (see internal/httpapi/pair.go): a device
+// row must exist before its pairing code can be redeemed, because
+// RedeemPairingCode needs the device's ID, but the code — never the
+// request — is the only legitimate source of the device's name. The row is
+// created with a placeholder name and renamed once RedeemPairingCode returns
+// the real one.
+func (s *Store) RenameDevice(ctx context.Context, id, name string) error {
+	res, err := s.db.ExecContext(ctx, `UPDATE devices SET name = ? WHERE id = ?`, name, id)
+	if err != nil {
+		return fmt.Errorf("rename device %s: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rename device %s: rows affected: %w", id, err)
+	}
+	if n == 0 {
+		return ErrDeviceNotFound
+	}
+	return nil
+}
+
+// DeleteDevice removes a device and, via ON DELETE CASCADE, every certificate
+// issued to it. It exists only for the pairing rollback path: when issuance
+// fails after the device row was created, the orphan must not persist.
+func (s *Store) DeleteDevice(ctx context.Context, id string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM devices WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete device %s: %w", id, err)
+	}
+	return nil
+}
+
+// RecordDeviceCert stores a newly issued certificate against its owning
+// device.
+func (s *Store) RecordDeviceCert(ctx context.Context, deviceID, serial string, notBefore, notAfter time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO device_certs (serial, device_id, not_before, not_after, issued_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		serial, deviceID, notBefore.Unix(), notAfter.Unix(), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("record certificate %s for device %s: %w", serial, deviceID, err)
+	}
+	return nil
+}
+
+// SupersedePriorCerts marks every certificate the device holds, other than
+// keepSerial, as superseded. It never deletes rows or shortens validity (D6):
+// a superseded certificate stays valid until its own not_after, so a lost
+// renewal response cannot strand the device.
+func (s *Store) SupersedePriorCerts(ctx context.Context, deviceID, keepSerial string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE device_certs SET superseded_at = ?
+		 WHERE device_id = ? AND serial != ? AND superseded_at IS NULL`,
+		time.Now().Unix(), deviceID, keepSerial,
+	)
+	if err != nil {
+		return fmt.Errorf("supersede prior certificates for device %s: %w", deviceID, err)
+	}
+	return nil
+}
+
+// DeviceByCertSerial resolves the device that owns a certificate serial. It
+// returns the device even when revoked, so the caller can distinguish
+// "unknown serial" from "revoked device" and log precisely which happened.
+func (s *Store) DeviceByCertSerial(ctx context.Context, serial string) (Device, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT d.id, d.name, d.paired_at, d.last_seen_at, d.revoked_at
+		 FROM device_certs c JOIN devices d ON d.id = c.device_id
+		 WHERE c.serial = ?`,
+		serial,
+	)
+	device, err := scanDevice(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Device{}, ErrDeviceNotFound
+	}
+	if err != nil {
+		return Device{}, fmt.Errorf("look up device by certificate serial %s: %w", serial, err)
+	}
+	return device, nil
+}
+
+// ListDevices returns every registered device, most recently paired first.
+func (s *Store) ListDevices(ctx context.Context) ([]Device, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, paired_at, last_seen_at, revoked_at
+		 FROM devices ORDER BY paired_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list devices: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var devices []Device
+	for rows.Next() {
+		device, err := scanDevice(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan device row: %w", err)
+		}
+		devices = append(devices, device)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list devices: %w", err)
+	}
+	return devices, nil
+}
+
+// RevokeDevice withdraws a device's access. It is idempotent: revoking an
+// already-revoked device succeeds without changing its revoked_at.
+func (s *Store) RevokeDevice(ctx context.Context, id string) error {
+	var exists bool
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM devices WHERE id = ?)`, id,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("check device %s exists: %w", id, err)
+	}
+	if !exists {
+		return ErrDeviceNotFound
+	}
+
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE devices SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
+		time.Now().Unix(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke device %s: %w", id, err)
+	}
+	return nil
+}
+
+// TouchDevice records that a device was just seen, but only when the stored
+// value is older than lastSeenResolution (D11), so a burst of requests costs
+// at most one write per resolution window.
+func (s *Store) TouchDevice(ctx context.Context, id string) error {
+	now := time.Now()
+	threshold := now.Add(-lastSeenResolution).Unix()
+
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE devices SET last_seen_at = ?
+		 WHERE id = ? AND (last_seen_at IS NULL OR last_seen_at < ?)`,
+		now.Unix(), id, threshold,
+	)
+	if err != nil {
+		return fmt.Errorf("touch device %s: %w", id, err)
+	}
+	return nil
+}
+
+// rowScanner abstracts over *sql.Row and *sql.Rows, both of which implement
+// Scan with an identical signature.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanDevice reads one devices row, converting the nullable Unix-second
+// columns into zero-valued time.Time when absent.
+func scanDevice(row rowScanner) (Device, error) {
+	var (
+		id, name              string
+		pairedAt              int64
+		lastSeenAt, revokedAt sql.NullInt64
+	)
+	if err := row.Scan(&id, &name, &pairedAt, &lastSeenAt, &revokedAt); err != nil {
+		return Device{}, err
+	}
+
+	device := Device{
+		ID:       id,
+		Name:     name,
+		PairedAt: time.Unix(pairedAt, 0).UTC(),
+	}
+	if lastSeenAt.Valid {
+		device.LastSeenAt = time.Unix(lastSeenAt.Int64, 0).UTC()
+	}
+	if revokedAt.Valid {
+		device.RevokedAt = time.Unix(revokedAt.Int64, 0).UTC()
+	}
+	return device, nil
+}

--- a/internal/state/devices_test.go
+++ b/internal/state/devices_test.go
@@ -1,0 +1,339 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCreateDeviceThenLookupBySerial(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	notBefore := time.Now()
+	notAfter := notBefore.Add(90 * 24 * time.Hour)
+	if err := s.RecordDeviceCert(ctx, device.ID, "abc123", notBefore, notAfter); err != nil {
+		t.Fatalf("RecordDeviceCert() unexpected error: %v", err)
+	}
+
+	// Act
+	found, err := s.DeviceByCertSerial(ctx, "abc123")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial() unexpected error: %v", err)
+	}
+	if found.ID != device.ID {
+		t.Errorf("DeviceByCertSerial() ID = %q, want %q", found.ID, device.ID)
+	}
+	if found.Name != "Pixel 9" {
+		t.Errorf("DeviceByCertSerial() Name = %q, want %q", found.Name, "Pixel 9")
+	}
+	if found.IsRevoked() {
+		t.Error("IsRevoked() = true for a freshly paired device, want false")
+	}
+}
+
+func TestDeviceByCertSerialReturnsRevokedDevice(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a revoked device's certificate must still resolve, so the
+	// caller (requireDevice) can distinguish "revoked" from "unknown" and log
+	// which one happened.
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Lost Phone")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	notBefore := time.Now()
+	if err := s.RecordDeviceCert(ctx, device.ID, "revoked-serial", notBefore, notBefore.Add(time.Hour)); err != nil {
+		t.Fatalf("RecordDeviceCert() unexpected error: %v", err)
+	}
+	if err := s.RevokeDevice(ctx, device.ID); err != nil {
+		t.Fatalf("RevokeDevice() unexpected error: %v", err)
+	}
+
+	// Act
+	found, err := s.DeviceByCertSerial(ctx, "revoked-serial")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial() unexpected error: %v", err)
+	}
+	if !found.IsRevoked() {
+		t.Error("IsRevoked() = false for a revoked device, want true")
+	}
+}
+
+func TestDeviceByCertSerialUnknownReturnsErrDeviceNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+
+	// Act
+	_, err := s.DeviceByCertSerial(context.Background(), "never-issued")
+
+	// Assert
+	if !errors.Is(err, ErrDeviceNotFound) {
+		t.Fatalf("DeviceByCertSerial() error = %v, want ErrDeviceNotFound", err)
+	}
+}
+
+func TestRevokeDeviceIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	if err := s.RevokeDevice(ctx, device.ID); err != nil {
+		t.Fatalf("first RevokeDevice() unexpected error: %v", err)
+	}
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	firstRevokedAt := devices[0].RevokedAt
+
+	// Act — revoke again; revoked_at must not move.
+	if err := s.RevokeDevice(ctx, device.ID); err != nil {
+		t.Fatalf("second RevokeDevice() unexpected error: %v", err)
+	}
+
+	// Assert
+	devices, err = s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	if !devices[0].RevokedAt.Equal(firstRevokedAt) {
+		t.Errorf("RevokedAt changed on a second revoke: %v -> %v", firstRevokedAt, devices[0].RevokedAt)
+	}
+}
+
+func TestRevokeDeviceUnknownIDReturnsErrDeviceNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+
+	// Act
+	err := s.RevokeDevice(context.Background(), "0123456789abcdef")
+
+	// Assert
+	if !errors.Is(err, ErrDeviceNotFound) {
+		t.Fatalf("RevokeDevice() error = %v, want ErrDeviceNotFound", err)
+	}
+}
+
+func TestRenameDeviceUpdatesName(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "pending")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+
+	// Act
+	if err := s.RenameDevice(ctx, device.ID, "Pixel 9"); err != nil {
+		t.Fatalf("RenameDevice() unexpected error: %v", err)
+	}
+
+	// Assert
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	if devices[0].Name != "Pixel 9" {
+		t.Errorf("Name = %q, want %q", devices[0].Name, "Pixel 9")
+	}
+}
+
+func TestRenameDeviceUnknownIDReturnsErrDeviceNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+
+	// Act
+	err := s.RenameDevice(context.Background(), "0123456789abcdef", "anything")
+
+	// Assert
+	if !errors.Is(err, ErrDeviceNotFound) {
+		t.Fatalf("RenameDevice() error = %v, want ErrDeviceNotFound", err)
+	}
+}
+
+func TestDeleteDeviceRemovesRow(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Rollback Candidate")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+
+	// Act
+	if err := s.DeleteDevice(ctx, device.ID); err != nil {
+		t.Fatalf("DeleteDevice() unexpected error: %v", err)
+	}
+
+	// Assert
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	for _, d := range devices {
+		if d.ID == device.ID {
+			t.Errorf("device %s still present after DeleteDevice()", device.ID)
+		}
+	}
+}
+
+func TestSupersedePriorCertsKeepsRowsValid(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — two certificates for the same device, mirroring a renewal.
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Renewing Phone")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	now := time.Now()
+	if err := s.RecordDeviceCert(ctx, device.ID, "old-serial", now, now.Add(90*24*time.Hour)); err != nil {
+		t.Fatalf("RecordDeviceCert(old) unexpected error: %v", err)
+	}
+	if err := s.RecordDeviceCert(ctx, device.ID, "new-serial", now, now.Add(180*24*time.Hour)); err != nil {
+		t.Fatalf("RecordDeviceCert(new) unexpected error: %v", err)
+	}
+
+	// Act
+	if err := s.SupersedePriorCerts(ctx, device.ID, "new-serial"); err != nil {
+		t.Fatalf("SupersedePriorCerts() unexpected error: %v", err)
+	}
+
+	// Assert — the old certificate must still resolve to the device (D6): a
+	// lost renewal response must not strand it.
+	old, err := s.DeviceByCertSerial(ctx, "old-serial")
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial(old) unexpected error: %v", err)
+	}
+	if old.ID != device.ID {
+		t.Errorf("DeviceByCertSerial(old) ID = %q, want %q", old.ID, device.ID)
+	}
+	current, err := s.DeviceByCertSerial(ctx, "new-serial")
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial(new) unexpected error: %v", err)
+	}
+	if current.ID != device.ID {
+		t.Errorf("DeviceByCertSerial(new) ID = %q, want %q", current.ID, device.ID)
+	}
+}
+
+func TestTouchDeviceThrottlesWithinResolutionWindow(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	if err := s.TouchDevice(ctx, device.ID); err != nil {
+		t.Fatalf("first TouchDevice() unexpected error: %v", err)
+	}
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	firstSeenAt := devices[0].LastSeenAt
+	if firstSeenAt.IsZero() {
+		t.Fatal("LastSeenAt is zero after TouchDevice(), want a timestamp")
+	}
+
+	// Act — a second touch immediately after must be a no-op: the stored
+	// value is not older than lastSeenResolution, so exactly one write
+	// (the first) should have happened.
+	if err := s.TouchDevice(ctx, device.ID); err != nil {
+		t.Fatalf("second TouchDevice() unexpected error: %v", err)
+	}
+
+	// Assert
+	devices, err = s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	if !devices[0].LastSeenAt.Equal(firstSeenAt) {
+		t.Errorf("LastSeenAt changed on a second touch within %s: %v -> %v",
+			lastSeenResolution, firstSeenAt, devices[0].LastSeenAt)
+	}
+}
+
+func TestTouchDeviceWritesAgainAfterResolutionWindow(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — seed last_seen_at directly, older than the resolution window,
+	// rather than sleeping the test for 60 real seconds.
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	device, err := s.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	stale := time.Now().Add(-2 * lastSeenResolution)
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE devices SET last_seen_at = ? WHERE id = ?`, stale.Unix(), device.ID,
+	); err != nil {
+		t.Fatalf("seed stale last_seen_at: %v", err)
+	}
+
+	// Act
+	if err := s.TouchDevice(ctx, device.ID); err != nil {
+		t.Fatalf("TouchDevice() unexpected error: %v", err)
+	}
+
+	// Assert
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	if devices[0].LastSeenAt.Unix() == stale.Unix() {
+		t.Error("LastSeenAt unchanged after the resolution window elapsed, want a refreshed timestamp")
+	}
+}
+
+func TestListDevicesEmptyStore(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+
+	// Act
+	devices, err := s.ListDevices(context.Background())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ListDevices() unexpected error: %v", err)
+	}
+	if len(devices) != 0 {
+		t.Errorf("ListDevices() = %d devices on an empty store, want 0", len(devices))
+	}
+}

--- a/internal/state/pairing.go
+++ b/internal/state/pairing.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// pairingCodeTTL bounds how long a minted pairing code stays redeemable.
+// Ten minutes is long enough for an operator to read the code aloud or type
+// it on a phone, short enough that a leaked, unused code stops mattering
+// quickly — rate limiting is Phase 6, so the code's own lifetime is part of
+// what keeps it safe until then (D3).
+const pairingCodeTTL = 10 * time.Minute
+
+// MintPairingCode generates a single-use pairing code for deviceName and
+// persists only its hex SHA-256 (D4) — the plaintext is never written to
+// disk and is unrecoverable once this call returns. The caller must show it
+// to the operator once and never log it.
+func (s *Store) MintPairingCode(ctx context.Context, deviceName string) (string, time.Time, error) {
+	code := rand.Text()
+	hash := sha256.Sum256([]byte(code))
+	codeHash := hex.EncodeToString(hash[:])
+
+	now := time.Now()
+	expiresAt := now.Add(pairingCodeTTL)
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO pairing_codes (code_hash, device_name, created_at, expires_at)
+		 VALUES (?, ?, ?, ?)`,
+		codeHash, deviceName, now.Unix(), expiresAt.Unix(),
+	)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("mint pairing code: %w", err)
+	}
+
+	return code, expiresAt.UTC(), nil
+}
+
+// RedeemPairingCode atomically marks code as used by deviceID and returns
+// the device name it was minted for.
+//
+// The single-use guarantee lives entirely in this one conditional UPDATE,
+// not in a read-then-write pair: a SELECT followed by an UPDATE is a TOCTOU
+// race that two simultaneous redemptions of a leaked code would win. The
+// DSN's _txlock=immediate (store.go) plus the used_at IS NULL predicate is
+// what makes this atomic. RETURNING folds the "read the name" and "mark it
+// used" steps into a single statement, so there is no window between them
+// for a second caller to observe the code as still unused.
+func (s *Store) RedeemPairingCode(ctx context.Context, code, deviceID string) (string, error) {
+	hash := sha256.Sum256([]byte(code))
+	codeHash := hex.EncodeToString(hash[:])
+	now := time.Now().Unix()
+
+	var deviceName string
+	err := s.db.QueryRowContext(ctx,
+		`UPDATE pairing_codes SET used_at = ?, used_by = ?
+		 WHERE code_hash = ? AND used_at IS NULL AND expires_at > ?
+		 RETURNING device_name`,
+		now, deviceID, codeHash, now,
+	).Scan(&deviceName)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Unknown, expired, and already-used codes are indistinguishable here
+		// on purpose: separate errors would let a caller enumerate code state.
+		return "", ErrPairingCodeInvalid
+	}
+	if err != nil {
+		return "", fmt.Errorf("redeem pairing code: %w", err)
+	}
+
+	return deviceName, nil
+}
+
+// PrunePairingCodes removes expired pairing codes and returns the number of
+// rows deleted. It runs independently of whether the code was ever
+// redeemed — an expired, unused code is just as unwanted as an expired,
+// used one.
+func (s *Store) PrunePairingCodes(ctx context.Context) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM pairing_codes WHERE expires_at < ?`, time.Now().Unix(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("prune pairing codes: %w", err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune pairing codes: rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/internal/state/pairing_test.go
+++ b/internal/state/pairing_test.go
@@ -1,0 +1,178 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMintPairingCodeThenRedeemSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	code, expiresAt, err := s.MintPairingCode(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	if expiresAt.Before(time.Now()) {
+		t.Fatalf("MintPairingCode() expiresAt = %v, want a time in the future", expiresAt)
+	}
+
+	// Act
+	name, err := s.RedeemPairingCode(ctx, code, "device-1")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("RedeemPairingCode() unexpected error: %v", err)
+	}
+	if name != "Pixel 9" {
+		t.Errorf("RedeemPairingCode() deviceName = %q, want %q", name, "Pixel 9")
+	}
+}
+
+func TestRedeemPairingCodeTwiceFailsSecondTime(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	code, _, err := s.MintPairingCode(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	if _, err := s.RedeemPairingCode(ctx, code, "device-1"); err != nil {
+		t.Fatalf("first RedeemPairingCode() unexpected error: %v", err)
+	}
+
+	// Act
+	_, err = s.RedeemPairingCode(ctx, code, "device-2")
+
+	// Assert
+	if !errors.Is(err, ErrPairingCodeInvalid) {
+		t.Fatalf("second RedeemPairingCode() error = %v, want ErrPairingCodeInvalid", err)
+	}
+}
+
+func TestRedeemPairingCodeUnknownFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+
+	// Act
+	_, err := s.RedeemPairingCode(context.Background(), "never-minted-code", "device-1")
+
+	// Assert
+	if !errors.Is(err, ErrPairingCodeInvalid) {
+		t.Fatalf("RedeemPairingCode() error = %v, want ErrPairingCodeInvalid", err)
+	}
+}
+
+func TestRedeemPairingCodeExpiredFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — mint, then push expires_at into the past directly, since
+	// there is no way to observe a code expiring through the public API
+	// alone within a fast test.
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	code, _, err := s.MintPairingCode(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE pairing_codes SET expires_at = ?`, time.Now().Add(-time.Minute).Unix(),
+	); err != nil {
+		t.Fatalf("seed expired pairing code: %v", err)
+	}
+
+	// Act
+	_, err = s.RedeemPairingCode(ctx, code, "device-1")
+
+	// Assert
+	if !errors.Is(err, ErrPairingCodeInvalid) {
+		t.Fatalf("RedeemPairingCode() error = %v, want ErrPairingCodeInvalid", err)
+	}
+}
+
+func TestRedeemPairingCodeConcurrentProducesExactlyOneSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — this test is the whole justification for the conditional
+	// UPDATE ... RETURNING in RedeemPairingCode: a read-then-write pair
+	// would let more than one goroutine observe the code as unused.
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	code, _, err := s.MintPairingCode(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+
+	const goroutines = 10
+	var (
+		successes int64
+		failures  int64
+		wg        sync.WaitGroup
+	)
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(n int) {
+			defer wg.Done()
+			deviceID := "device-" + string(rune('a'+n))
+			_, err := s.RedeemPairingCode(ctx, code, deviceID)
+			switch {
+			case err == nil:
+				atomic.AddInt64(&successes, 1)
+			case errors.Is(err, ErrPairingCodeInvalid):
+				atomic.AddInt64(&failures, 1)
+			default:
+				t.Errorf("RedeemPairingCode() unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Assert
+	if successes != 1 {
+		t.Errorf("RedeemPairingCode() successes = %d, want exactly 1", successes)
+	}
+	if failures != goroutines-1 {
+		t.Errorf("RedeemPairingCode() failures = %d, want %d", failures, goroutines-1)
+	}
+}
+
+func TestPrunePairingCodesRemovesExpiredRows(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	if _, _, err := s.MintPairingCode(ctx, "Expired Phone"); err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	if _, _, err := s.MintPairingCode(ctx, "Active Phone"); err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE pairing_codes SET expires_at = ? WHERE device_name = ?`,
+		time.Now().Add(-time.Minute).Unix(), "Expired Phone",
+	); err != nil {
+		t.Fatalf("seed expired pairing code: %v", err)
+	}
+
+	// Act
+	pruned, err := s.PrunePairingCodes(ctx)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("PrunePairingCodes() unexpected error: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("PrunePairingCodes() pruned = %d, want 1", pruned)
+	}
+}

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -3,23 +3,31 @@ package state
 // currentSchemaVersion is the schema this build understands. A store reporting a
 // higher number was written by a newer agent and must not be opened: a downgrade
 // that silently ignored unknown columns would corrupt the device registry.
-const currentSchemaVersion = 1
+const currentSchemaVersion = 2
 
 // schemaVersionKey is the schema_meta row holding the version number.
 const schemaVersionKey = "version"
 
-// schemaV1 is the complete v1 schema.
-//
-// The devices and audit tables are created now even though nothing writes to
-// them until Phases 2 and 5. Creating them here means those phases add rows, not
-// migrations, and the whole retention story stays validated in one place.
-const schemaV1 = `
+// schemaMetaTableSQL creates the version-tracking table used by the migration
+// ladder. It runs once, ahead of every migration, so the ladder can read a
+// version even on a brand-new file where no migration has run yet.
+const schemaMetaTableSQL = `
 CREATE TABLE IF NOT EXISTS schema_meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+`
 
--- Populated in Phase 2 (pairing). Created now so Phase 2 needs no migration.
+// schemaV1 is the complete v1 schema.
+//
+// The devices and audit tables were created here even though nothing wrote to
+// them until Phase 2. That bet only half paid off: v2 (below) has to DROP and
+// recreate devices because its cert_serial/cert_not_after columns did not
+// survive contact with the real design (certificates now live in their own
+// table so a renewal is an INSERT, not a destructive UPDATE — see D6 in the
+// Phase 2 plan). audit, which Phase 5 still owns unmodified, needed no
+// migration at all — so the bet was half right, not wrong.
+const schemaV1 = `
 CREATE TABLE IF NOT EXISTS devices (
     id             TEXT PRIMARY KEY,
     name           TEXT NOT NULL,
@@ -46,3 +54,63 @@ CREATE TABLE IF NOT EXISTS audit (
 );
 CREATE INDEX IF NOT EXISTS idx_audit_occurred ON audit(occurred_at);
 `
+
+// schemaV2 replaces devices with the Phase 2 design and adds the certificate
+// and pairing-code registries.
+//
+// devices is dropped and recreated rather than ALTERed. That is safe, and is
+// the only time it will be: v1 never wrote a device row (pairing did not
+// exist yet), so every real deployment's table is provably empty at this
+// point. Preserving data that cannot exist is complexity for nothing.
+const schemaV2 = `
+DROP TABLE IF EXISTS devices;
+
+CREATE TABLE devices (
+    id           TEXT PRIMARY KEY,   -- 16 lowercase hex chars
+    name         TEXT NOT NULL,
+    paired_at    INTEGER NOT NULL,
+    last_seen_at INTEGER,
+    revoked_at   INTEGER             -- NULL = active
+);
+CREATE INDEX idx_devices_revoked ON devices(revoked_at);
+
+-- device_certs: every certificate ever issued to a device. Auth resolves the
+-- peer's serial here, then checks the owning device is not revoked.
+CREATE TABLE device_certs (
+    serial        TEXT PRIMARY KEY,  -- big.Int.Text(16), lowercase, no 0x
+    device_id     TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    not_before    INTEGER NOT NULL,
+    not_after     INTEGER NOT NULL,
+    issued_at     INTEGER NOT NULL,
+    superseded_at INTEGER             -- set on renewal; the cert stays valid (D6)
+);
+CREATE INDEX idx_device_certs_device ON device_certs(device_id);
+
+-- pairing_codes: pending single-use codes. The code is never stored in
+-- plaintext (D4); only its hash is persisted.
+CREATE TABLE pairing_codes (
+    code_hash   TEXT PRIMARY KEY,    -- hex SHA-256 of the code
+    device_name TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    expires_at  INTEGER NOT NULL,
+    used_at     INTEGER,             -- NULL = unused; set atomically on redemption
+    used_by     TEXT                 -- device id, once redeemed
+);
+CREATE INDEX idx_pairing_codes_expires ON pairing_codes(expires_at);
+`
+
+// migrationStep is one rung of the migration ladder: the schema statements
+// that bring the store from the previous version to version.
+type migrationStep struct {
+	version int
+	sql     string
+}
+
+// migrations lists every migration in order. verifyAndMigrate applies every
+// step whose version exceeds the store's current version, each in its own
+// transaction that also stamps schema_meta.version — so a fresh store walks
+// v1 then v2, and a v1 store on disk walks only v2.
+var migrations = []migrationStep{
+	{version: 1, sql: schemaV1},
+	{version: 2, sql: schemaV2},
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -30,6 +30,15 @@ var (
 	ErrStateCorrupt = errors.New("state store is unreadable or corrupt")
 	// ErrSchemaTooNew means the store was written by a newer agent version.
 	ErrSchemaTooNew = errors.New("state store was written by a newer agent version")
+	// ErrDeviceNotFound means no device matches the given id or certificate
+	// serial. Callers branch on this to distinguish "unknown" from other
+	// failures; it never reveals whether the caller has ever seen that id.
+	ErrDeviceNotFound = errors.New("device not found")
+	// ErrPairingCodeInvalid covers every reason a pairing code cannot be
+	// redeemed — unknown, expired, or already used. It is deliberately one
+	// error: distinguishing those cases to a caller would let it enumerate
+	// code state.
+	ErrPairingCodeInvalid = errors.New("pairing code is invalid or expired")
 )
 
 // dbFileMode keeps the database owner-only. SQLite creates it 0644 by default,
@@ -144,34 +153,81 @@ func (s *Store) verifyAndMigrate(ctx context.Context, path string) error {
 		return fmt.Errorf("%w: %s: integrity_check=%q", ErrStateCorrupt, path, result)
 	}
 
-	if _, err := s.db.ExecContext(ctx, schemaV1); err != nil {
-		return fmt.Errorf("apply schema to %s: %w", path, err)
-	}
-	return s.reconcileVersion(ctx, path)
+	return s.migrate(ctx, path)
 }
 
-// reconcileVersion stamps the version on a fresh store and refuses to open one
-// written by a newer build.
-func (s *Store) reconcileVersion(ctx context.Context, path string) error {
-	version, err := s.SchemaVersion(ctx)
-	switch {
-	case errors.Is(err, sql.ErrNoRows):
-		_, err := s.db.ExecContext(ctx,
-			`INSERT INTO schema_meta (key, value) VALUES (?, ?)`,
-			schemaVersionKey, strconv.Itoa(currentSchemaVersion),
-		)
-		if err != nil {
-			return fmt.Errorf("stamp schema version on %s: %w", path, err)
-		}
-		return nil
-	case err != nil:
+// migrate walks the migration ladder, applying every step whose version
+// exceeds the store's current one, in order.
+//
+// schema_meta is created unconditionally first so its version can be read
+// even on a brand-new file where no migration has run yet; every table each
+// migration owns is created inside that migration's own step.
+func (s *Store) migrate(ctx context.Context, path string) error {
+	if _, err := s.db.ExecContext(ctx, schemaMetaTableSQL); err != nil {
+		return fmt.Errorf("create schema_meta table in %s: %w", path, err)
+	}
+
+	version, err := s.currentVersionOrZero(ctx)
+	if err != nil {
 		return err
-	case version > currentSchemaVersion:
+	}
+	if version > currentSchemaVersion {
 		return fmt.Errorf("%w: %s: found v%d, this build understands v%d",
 			ErrSchemaTooNew, path, version, currentSchemaVersion)
-	default:
-		return nil
 	}
+
+	for _, step := range migrations {
+		if step.version <= version {
+			continue
+		}
+		if err := s.applyMigration(ctx, path, step); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// currentVersionOrZero reads the stamped schema version, treating an absent
+// schema_meta row (a genuinely fresh store) as version 0 rather than an error.
+func (s *Store) currentVersionOrZero(ctx context.Context) (int, error) {
+	version, err := s.SchemaVersion(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+// applyMigration runs one migration step's schema statements and stamps its
+// version in the same transaction, mirroring the PruneAudit pattern: a
+// deferred rollback before commit, so a failed statement or a failed stamp
+// leaves the store at its prior, consistent version.
+func (s *Store) applyMigration(ctx context.Context, path string, step migrationStep) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin migration to v%d on %s: %w", step.version, path, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, step.sql); err != nil {
+		return fmt.Errorf("apply schema v%d to %s: %w", step.version, path, err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO schema_meta (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		schemaVersionKey, strconv.Itoa(step.version),
+	)
+	if err != nil {
+		return fmt.Errorf("stamp schema version v%d on %s: %w", step.version, path, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit migration to v%d on %s: %w", step.version, path, err)
+	}
+	return nil
 }
 
 // SchemaVersion returns the schema version recorded in the store.

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -53,7 +54,7 @@ func TestOpenFirstRunCreatesSchema(t *testing.T) {
 	if version != currentSchemaVersion {
 		t.Errorf("SchemaVersion() = %d, want %d", version, currentSchemaVersion)
 	}
-	for _, table := range []string{"schema_meta", "devices", "audit"} {
+	for _, table := range []string{"schema_meta", "devices", "device_certs", "pairing_codes", "audit"} {
 		var name string
 		err := s.db.QueryRow(
 			`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table,
@@ -122,6 +123,93 @@ func TestOpenSchemaTooNew(t *testing.T) {
 		t.Fatalf("seed Open() unexpected error: %v", err)
 	}
 	_, err = seed.db.Exec(`UPDATE schema_meta SET value = '99' WHERE key = ?`, schemaVersionKey)
+	if err != nil {
+		t.Fatalf("bump version: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("Close() unexpected error: %v", err)
+	}
+
+	// Act
+	_, err = Open(context.Background(), path, testLogger())
+
+	// Assert
+	if !errors.Is(err, ErrSchemaTooNew) {
+		t.Fatalf("Open() error = %v, want ErrSchemaTooNew", err)
+	}
+}
+
+func TestOpenMigratesV1StoreToV2(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — build a v1 store by hand, exec'ing schemaV1 directly and
+	// stamping version 1, bypassing Open's own migration ladder entirely.
+	path := tempDBPath(t)
+	raw, err := sql.Open("sqlite", dsn(path))
+	if err != nil {
+		t.Fatalf("sql.Open(%s) unexpected error: %v", path, err)
+	}
+	if _, err := raw.Exec(schemaMetaTableSQL); err != nil {
+		t.Fatalf("create schema_meta: %v", err)
+	}
+	if _, err := raw.Exec(schemaV1); err != nil {
+		t.Fatalf("apply schemaV1: %v", err)
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO schema_meta (key, value) VALUES (?, ?)`, schemaVersionKey, "1",
+	); err != nil {
+		t.Fatalf("stamp version 1: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close seed connection: %v", err)
+	}
+
+	// Act
+	s := openStore(t, path)
+	version, err := s.SchemaVersion(context.Background())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("SchemaVersion() unexpected error: %v", err)
+	}
+	if version != currentSchemaVersion {
+		t.Errorf("SchemaVersion() = %d, want %d after migrating a v1 store", version, currentSchemaVersion)
+	}
+	for _, table := range []string{"schema_meta", "devices", "device_certs", "pairing_codes", "audit"} {
+		var name string
+		err := s.db.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table,
+		).Scan(&name)
+		if err != nil {
+			t.Errorf("table %q missing after migration: %v", table, err)
+		}
+	}
+
+	// The schema_meta row itself must survive the migration, not just be
+	// re-created — a fresh INSERT with an unchanged value would hide a
+	// migration that failed to actually stamp anything.
+	var stamped string
+	if err := s.db.QueryRow(
+		`SELECT value FROM schema_meta WHERE key = ?`, schemaVersionKey,
+	).Scan(&stamped); err != nil {
+		t.Fatalf("read stamped version: %v", err)
+	}
+	if stamped != strconv.Itoa(currentSchemaVersion) {
+		t.Errorf("stamped schema_meta value = %q, want %q", stamped, strconv.Itoa(currentSchemaVersion))
+	}
+}
+
+func TestOpenSchemaVersionThreeIsTooNew(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a store one version ahead of what this build understands,
+	// distinct from the far-future TestOpenSchemaTooNew case above.
+	path := tempDBPath(t)
+	seed, err := Open(context.Background(), path, testLogger())
+	if err != nil {
+		t.Fatalf("seed Open() unexpected error: %v", err)
+	}
+	_, err = seed.db.Exec(`UPDATE schema_meta SET value = '3' WHERE key = ?`, schemaVersionKey)
 	if err != nil {
 		t.Fatalf("bump version: %v", err)
 	}

--- a/internal/tlsconf/tlsconf.go
+++ b/internal/tlsconf/tlsconf.go
@@ -9,8 +9,9 @@ import (
 
 // Build returns the TLS config for the agent's single listening port.
 //
-// clientCAs is nil in Phase 1, because no CA exists yet, and non-nil from
-// Phase 2 onward.
+// clientCAs is the agent's own certificate authority pool (internal/certs),
+// used to verify a device's client certificate at the handshake. It is nil
+// only in tests that do not exercise mTLS.
 //
 // When clientCAs is non-nil the mode is VerifyClientCertIfGiven, deliberately
 // NOT RequireAndVerifyClientCert. ClientAuth is a property of the LISTENER,


### PR DESCRIPTION
Implements **PRD Phase 2 — identity, pairing & revocation**.

The agent becomes its own certificate authority and authenticates every guarded request against a client certificate it issued itself. An operator mints a single-use pairing code on the host; the device generates its own keypair and exchanges a PKCS#10 CSR for a 90-day client certificate over the one route that requires no client certificate. **The agent never sees a device private key.**

## What changed

| Area | Change |
|---|---|
| `internal/state` | Schema v1 → v2 via a versioned migration ladder; device + certificate registry; pairing-code mint and redemption |
| `internal/certs` | CA creation and retention; device certificate issuance; server certificate now CA-issued and re-issued on SAN drift; identity consistency check |
| `internal/httpapi` | `requireDevice` middleware; `POST /v1/pair`; `POST /v1/device/renew`; `DELETE /v1/device/self`; `ca_fingerprint` on `/v1/status` |
| `cmd/devmon-agent` | Host-side `device list \| revoke \| pair-code` subcommands |
| `README.md` | Pairing walkthrough, `device` CLI reference, fingerprint-recording guidance, `ca.key`-at-rest warning |

## Design decisions worth reviewing

- **No in-memory device cache.** Every authenticated request costs one indexed lookup. That is the mechanism behind immediate revocation — `device revoke` is a single `UPDATE` and the next request is already rejected.
- **Renewal overlaps.** The prior certificate stays valid until its own `not_after`; the row is kept with `superseded_at` set. A half-failed renewal cannot lock a device out.
- **Revocation marks the device, not a certificate**, so it covers a certificate issued seconds earlier by a renewal.
- **Uniform 401.** Every `requireDevice` rejection returns an identical terse body; the reason goes only to the log.
- **The CSR subject is ignored.** The device name comes from the operator-minted code — the subject is the one field an attacker fully controls.
- **`VerifyClientCertIfGiven` is unchanged.** `RequireAndVerifyClientCert` would break `/v1/pair`, which by design serves clients that have no certificate yet.
- **Pairing codes are stored as hex SHA-256 only** and printed to stdout, never to the rotated log file.

## Validation

| Gate | Result |
|---|---|
| `go vet ./...` | Silent |
| `golangci-lint run ./...` | **0 issues** |
| `gosec ./...` | No findings |
| `go test ./internal/... -race` | 117 tests, all green |
| `make cover` | **80.8%** (floor 80%) |
| `go build` / `docker build` | Static binary and image both build |

Verified against a live binary: schema version 2 on disk, correct table set, and grepping a freshly minted code across the state directory returns no match — only its hash is stored. The `device` CLI creates neither `logs/` nor `certs/`.

<details>
<summary>Note on <code>gofmt -l</code></summary>

It lists 23 files on a Windows checkout, including Phase 1 files this branch never touched. The cause is `core.autocrlf=true` (CRLF working tree, LF in git), not formatting drift — every file is clean once normalized to LF. The committed content is correctly formatted.
</details>

## Test plan

- [x] Unit + integration tests under `-race`, coverage above floor
- [x] Live check: pairing-code mint, `device list`, on-disk schema, code-not-stored-in-plaintext
- [ ] **Manual sweep on a real VPS** — first-run CA creation, pairing from the Android client, fingerprint match, revoke-then-request
- [ ] Security review of the auth and crypto paths (`ecc:security-reviewer`)

## Follow-ups (not in this PR's scope)

- `certs.GenerateServerCert` (Phase 1 self-signed path) is now referenced only by tests in `httpapi` and `tlsconf`, and the `selfsigned.go` package comment still describes Phase 2 as future work. Worth a cleanup pass — left alone here to keep the diff inside the plan's scope.
- Rate limiting on `/v1/pair` is deliberately Phase 6. The 26-character `crypto/rand.Text()` code carries ~130 bits, so it is safe independently of rate limiting.
- `ca.key` is unencrypted at rest, a PRD-accepted risk now documented in the README along with its backup and snapshot implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
