### PR TITLE
feat: container, image, network and volume read endpoints

### DIFF
--- a/.claude/PRPs/plans/completed/read-operations.plan.md
+++ b/.claude/PRPs/plans/completed/read-operations.plan.md
@@ -1,0 +1,951 @@
+# Plan: Read Operations (DevMon Agent Phase 3)
+
+## Summary
+
+Give a paired device full read visibility into the host's Docker objects: list and inspect for
+containers, images, networks, and volumes. Eight new mTLS-guarded `GET` routes, backed by a new
+read-only surface on `internal/dockerx`, projecting Docker Engine responses through **explicit
+allowlisted DTOs** rather than forwarding raw Engine JSON.
+
+This is the first phase where host data leaves the agent. The entire security weight of the phase
+sits in one decision: what a response is *allowed* to contain. Forwarding `container.InspectResponse`
+verbatim would put `Config.Env` — every database password, API key, and token the operator baked
+into a container — onto a phone over a channel the PRD never budgeted for carrying secrets.
+
+## User Story
+
+As an operator diagnosing a problem from my phone,
+I want to see every container, image, network, and volume on the host and drill into any one of them,
+so that I can identify what is broken before I act on it.
+
+## Problem → Solution
+
+A paired device today can do exactly three things: read `/v1/status`, renew its own certificate, and
+unpair itself. It cannot see a single container. → A paired device can enumerate and inspect all four
+Docker object types over the authenticated channel, receiving a stable, versioned, secret-free
+projection of the Engine's data.
+
+## Metadata
+
+- **Complexity**: Medium–Large (18 files, 10 tasks; ~900 lines of production Go plus tests)
+- **Source PRD**: `.claude/PRPs/prds/devmon-agent.prd.md`
+- **PRD Phase**: 3 — Read operations
+- **Depends on**: Phase 2 (complete)
+- **Parallel with**: Phase 4 (Logs & live streaming) — they share no code beyond `dockerx.Client`
+- **Estimated Files**: 18 changed (12 created, 6 updated)
+
+---
+
+## Decisions Settled Before Planning
+
+Each has a plausible-looking wrong answer. Settled here so implementation never re-litigates them.
+
+| # | Decision | Choice | Why not the alternative |
+|---|---|---|---|
+| D1 | Response shape | **Explicit DTOs in `internal/dockerx`, field-by-field allowlist**, snake_case JSON | Forwarding `container.InspectResponse` (or its `Raw json.RawMessage`) leaks `Config.Env` — every secret the operator passed to a container — to the phone, and couples the versioned API contract to whatever the Engine changes next release. The PRD's whole premise is "a deliberate subset of Docker's surface"; the response body is part of that surface. |
+| D2 | Environment variables | **Never returned, at any level.** `Config.Env` has no DTO field | Redacting values (`FOO=***`) still discloses which secrets exist and their names. Omission is the only version of this that cannot leak. An operator who needs env vars has host access. |
+| D3 | Command and entrypoint | **Returned.** `command`, `entrypoint`, `args` are in the inspect DTO | Unlike `Env` these are what identifies a misconfigured container, and they are already visible in `docker ps` output the operator sees on the host. Documented in the threat model as a deliberate, bounded disclosure — a credential passed on a command line is already visible in the host's process table. |
+| D4 | Where the DTOs live | **`internal/dockerx`** returns DTOs; `internal/httpapi` serialises them unchanged | Putting the mapping in `httpapi` would force `httpapi` to import `moby/api/types/...`, and Phase 5's audit code and Phase 4's log code would each need their own copy. `dockerx` owning the projection is what keeps "the agent never proxies arbitrary Docker" a structural property rather than a convention. |
+| D5 | Testability of the Docker surface | **Four small interfaces** (`ContainerReader`, `ImageReader`, `NetworkReader`, `VolumeReader`) declared in `httpapi`, composed into `DockerReader`; `*dockerx.Client` satisfies it | Handlers must be testable without a live daemon (see `dockerx/client_test.go`: "a live daemon is deliberately not required"). Declaring the interfaces in the consumer, not the producer, is the repo's stated Go rule. Four 2-method interfaces rather than one 8-method one keeps each within the ≤3-method guideline. |
+| D6 | Object reference validation | **Validated against `^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$` before it reaches the SDK**; anything else is 400 | The moby client interpolates the ID directly into the request URL path. `net/http.ServeMux` already refuses a `/` inside a `{id}` wildcard and cleans `..` segments, but relying on two layers of framework behaviour to keep `../../info` out of an Engine URL is exactly the kind of assumption that breaks on a dependency bump. Validate at the boundary, as the coding rules require. |
+| D7 | Not-found mapping | `cerrdefs.IsNotFound(err)` → **404 with a terse fixed body**; every other Engine failure → **502** | The Engine is an upstream dependency of this agent, so its failures are gateway failures, not agent bugs — 502 says that accurately and keeps 500 meaning "the agent broke". A 404 is safe to distinguish here because the caller is already an authenticated device; the anti-enumeration reasoning that makes `/v1/pair` uniform does not apply behind `requireDevice`. |
+| D8 | List bounds | **Hard server-side cap of 500 items**, plus a `truncated` boolean in the envelope | A host with thousands of images would otherwise produce a multi-megabyte body inside the server's 30s `WriteTimeout`, on a phone's mobile connection. A cap the client cannot raise is consistent with "startup configuration is the security boundary". `truncated` exists so the app can say "showing the first 500" rather than silently lying. |
+| D9 | Response envelope | Lists return `{"items": [...], "truncated": bool}`; inspects return the object directly | A bare top-level JSON array cannot gain a field later without breaking every client. `truncated` needs somewhere to live from day one. |
+| D10 | Policy gating | A `requireOp(policy.OpRead)` middleware wraps all eight routes now, even though `OpRead` is permitted by **every** mode | Zero behavioural change today, and it means Phase 5 adds tiers to existing plumbing rather than retrofitting a gate onto eight already-shipped routes. `policy.Allows` already fails closed on unregistered operations — this is what connects that guarantee to an actual route. |
+| D11 | Per-call Engine timeout | **15s**, applied inside `dockerx` on every call | The server's `WriteTimeout` is 30s. A wedged Engine must surface as a 502 the agent controls, not as a connection the client sees die mid-body. 15s leaves headroom for the response write. |
+| D12 | `all` parameter | `GET /v1/containers?all=true` only; images/networks/volumes take no parameters | Stopped containers are the ones an operator is looking for during an incident, so it must be reachable. `ImageListOptions.All` returns intermediate layers — noise on a phone, and not something the PRD asks for. Unknown query parameters are ignored, not rejected. |
+| D13 | Agent self-marking (`protected: true` in listings) | **Not in this phase** | The PRD assigns self-exclusion to Phase 5. Marking requires the agent to resolve its own container ID (`/proc/self/cgroup` parsing, or `HOSTNAME` matching, neither reliable alone), which is a design problem that belongs with the enforcement that consumes it. |
+
+---
+
+## UX Design
+
+### Before
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Phone (paired, holding a valid client certificate)         │
+│    GET  /v1/status          ──►  200 {version, policy, …}   │
+│    POST /v1/device/renew    ──►  200 {cert, not_after}      │
+│    DEL  /v1/device/self     ──►  204                        │
+│    GET  /v1/containers      ──►  404   (no such route)      │
+│                                                             │
+│  The device is authenticated and can see nothing.           │
+└────────────────────────────────────────────────────────────┘
+```
+
+### After
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Phone (paired)                                                       │
+│    GET /v1/containers?all=true                                        │
+│      ◄── 200 {"items":[{"id":"a1b2…","names":["/api"],                │
+│                         "image":"myapp:1.4","state":"exited",         │
+│                         "status":"Exited (1) 3 minutes ago",          │
+│                         "health":"unhealthy","ports":[…]}],           │
+│                "truncated":false}                                     │
+│                                                                       │
+│    GET /v1/containers/a1b2c3                                          │
+│      ◄── 200 {"id":"a1b2c3…","name":"/api","state":"exited",          │
+│               "command":"/app/server","args":["--port","8080"],       │
+│               "mounts":[…],"networks":[…],"restart_count":5}          │
+│               ── no "env" field exists, at any depth ──               │
+│                                                                       │
+│    GET /v1/images   /v1/images/{id}                                   │
+│    GET /v1/networks /v1/networks/{id}                                 │
+│    GET /v1/volumes  /v1/volumes/{name}                                │
+│                                                                       │
+│    GET /v1/containers/does-not-exist  ◄── 404 {"error":"not found"}   │
+│    GET /v1/containers/%2e%2e         ◄── 400 {"error":"invalid …"}    │
+│    (no client certificate)            ◄── 401 {"error":"client …"}    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Interaction Changes
+
+| Touchpoint | Before | After | Notes |
+|---|---|---|---|
+| App home screen | Empty — nothing to show | Container list with state and health | The entry point for every diagnostic path |
+| Container detail | Does not exist | Inspect projection: state, mounts, networks, ports, restart count | No env vars, by design (D2) |
+| Images / networks / volumes tabs | Do not exist | List + detail | Explicit PRD "Must" requirements |
+| Unknown object | n/a | 404 with a fixed terse body | Distinguishable from 401 and 502 |
+| Engine down | n/a | 502 with a fixed terse body | The app can say "the host's Docker is not responding" rather than "the agent is broken" |
+| Host with 900 images | n/a | First 500 items, `truncated:true` | App shows a "list truncated" affordance |
+
+---
+
+## Mandatory Reading
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| P0 | `internal/httpapi/server.go` | 37–91 | `Server` struct, `NewServer` signature, `routes()` — all three change |
+| P0 | `internal/httpapi/respond.go` | 1–47 | `writeJSON` / `writeError` are the only response exits; every new handler uses them |
+| P0 | `internal/httpapi/middleware.go` | 29–85 | `requireDevice` and `DeviceFrom` — the guard every new route sits behind |
+| P0 | `internal/dockerx/client.go` | all (72) | The package doc explicitly reserves reads for this phase; `Client.api` is the handle to extend |
+| P0 | `internal/policy/mode.go` | 28–65 | `Operation`, `OpRead`, `Mode.Allows` — the gate `requireOp` calls |
+| P1 | `internal/httpapi/device.go` | 43–95 | The canonical guarded-handler shape: resolve device, do work, map error, write |
+| P1 | `internal/httpapi/pair.go` | 16–43, 61–85 | Constant-block conventions for limits/messages; error → status mapping |
+| P1 | `internal/httpapi/status_test.go` | 25–72 | `testLogger`, `testServer`, `testServerWithCA`, `testServerWithStore`, `peerCertWithSerial` — the helpers that need the new `NewServer` argument |
+| P1 | `cmd/devmon-agent/main.go` | 113–174 | `serve` construction order; `dc` exists at line 155 and must reach `NewServer` at line 164 |
+| P2 | `internal/dockerx/client_test.go` | all (61) | Test conventions for this package: `t.Parallel`, AAA comments, no live daemon |
+| P2 | `internal/httpapi/status_test.go` | 74–106 | `TestStatusFieldCount` — the "field allowlist enforced by exact count" pattern this phase reuses for DTOs |
+| P2 | `README.md` | 192–220 | The API table this phase extends |
+| P2 | `Makefile` | 28–58 | The exact gate commands (`test-race`, `cover`, `lint`, `sec`) |
+
+## External Documentation
+
+| Topic | Source | Key Takeaway |
+|---|---|---|
+| moby client v29 read methods | `go doc github.com/moby/moby/client` (module `github.com/moby/moby/client v0.5.1`) | Every method takes an options struct and returns a `*Result` struct, not a bare slice. Verified signatures are transcribed below — do not write these from memory. |
+| Engine API version | `client.MaxAPIVersion = "1.55"`, `MinAPIVersion = "1.40"` | Negotiated already at `dockerx.New` via `PingOptions{NegotiateAPIVersion: true}`. Nothing further needed. |
+| Error classification | `github.com/containerd/errdefs` | `errdefs.IsNotFound(err)` is the supported way to detect a missing object. Currently an **indirect** dependency in `go.mod` — this phase promotes it to direct. |
+| `net/http.ServeMux` wildcards (Go 1.22+) | stdlib | `mux.HandleFunc("GET /v1/containers/{id}", …)` + `r.PathValue("id")`. A `{id}` segment never matches a `/`. Method-prefixed patterns are already the repo convention (`server.go:79`). |
+
+### Verified SDK signatures — transcribe exactly
+
+```go
+// github.com/moby/moby/client (v29 API)
+func (cli *Client) ContainerList(ctx context.Context, options ContainerListOptions) (ContainerListResult, error)
+func (cli *Client) ContainerInspect(ctx context.Context, containerID string, options ContainerInspectOptions) (ContainerInspectResult, error)
+func (cli *Client) ImageList(ctx context.Context, options ImageListOptions) (ImageListResult, error)
+func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts ...ImageInspectOption) (ImageInspectResult, error)  // variadic, NOT an options struct
+func (cli *Client) NetworkList(ctx context.Context, options NetworkListOptions) (NetworkListResult, error)
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options NetworkInspectOptions) (NetworkInspectResult, error)
+func (cli *Client) VolumeList(ctx context.Context, options VolumeListOptions) (VolumeListResult, error)
+func (cli *Client) VolumeInspect(ctx context.Context, volumeID string, options VolumeInspectOptions) (VolumeInspectResult, error)
+
+type ContainerListResult    struct { Items []container.Summary }
+type ContainerInspectResult struct { Container container.InspectResponse; Raw json.RawMessage }
+type ImageListResult        struct { Items []image.Summary }
+type ImageInspectResult     struct { image.InspectResponse }              // EMBEDDED, no named field
+type NetworkListResult      struct { Items []network.Summary }            // network.Summary embeds network.Network
+type NetworkInspectResult   struct { Network network.Inspect; Raw json.RawMessage }
+type VolumeListResult       struct { Items []volume.Volume; Warnings []string }
+type VolumeInspectResult    struct { Volume volume.Volume; Raw json.RawMessage }
+
+type ContainerListOptions    struct { Size bool; All bool; Limit int; Filters Filters; /* + deprecated fields */ }
+type ContainerInspectOptions struct { Size bool }
+type ImageListOptions        struct { All bool; Filters Filters; SharedSize bool; Manifests bool; Identity bool }
+type NetworkListOptions      struct { Filters Filters }
+type NetworkInspectOptions   struct { Scope string; Verbose bool }
+type VolumeListOptions       struct { Filters Filters }
+type VolumeInspectOptions    struct { }
+```
+
+### Verified field types that will not compile if guessed
+
+```go
+container.Summary.State                       // container.ContainerState (a string type) — needs string(...)
+container.Summary.Created                     // int64 Unix SECONDS — needs time.Unix(n, 0).UTC()
+container.Summary.Health                      // *container.HealthSummary — NIL on containers with no healthcheck
+container.Summary.Health.Status               // container.HealthStatus (string type)
+container.Summary.NetworkSettings             // *container.NetworkSettingsSummary — CAN BE NIL
+container.Summary.NetworkSettings.Networks    // map[string]*network.EndpointSettings (values can be nil)
+container.Summary.Ports[i].IP                 // netip.Addr, NOT string — use .IsValid() then .String()
+container.Summary.Ports[i].Type               // "tcp"/"udp"/"sctp" — the field is Type; there is no Protocol field
+container.InspectResponse.State               // *container.State — CAN BE NIL
+container.InspectResponse.Config              // *container.Config — CAN BE NIL; holds Env (never map it)
+container.InspectResponse.HostConfig          // *container.HostConfig — CAN BE NIL
+container.InspectResponse.Created             // string (RFC3339Nano), unlike Summary.Created's int64
+container.InspectResponse.SizeRw / SizeRootFs // *int64 — CAN BE NIL
+network.Network.Created                       // timeext.Time, NOT time.Time
+network.EndpointSettings.Gateway/IPAddress    // netip.Addr, NOT string
+image.Summary.Created                         // int64 Unix seconds
+image.InspectResponse.Created                 // string, and `json:",omitempty"` — CAN BE EMPTY
+image.InspectResponse.Config                  // *dockerspec.DockerOCIImageConfig — holds the image's baked-in Env
+volume.Volume.CreatedAt                       // string (RFC3339), already formatted
+volume.Volume.UsageData                       // *volume.UsageData — CAN BE NIL
+```
+
+---
+
+## Patterns to Mirror
+
+### NAMING_CONVENTION
+```go
+// SOURCE: internal/httpapi/pair.go:16-43
+// Grouped const block, doc comment on the block explaining WHY the values exist,
+// then per-constant comments. Message constants are msg<Thing><Outcome>.
+const (
+	// maxPairBodyBytes bounds the pairing request body. This route has no
+	// client certificate to gate it and there is no rate limiting until
+	// Phase 6, so an unbounded JSON body is a trivial memory-exhaustion
+	// vector.
+	maxPairBodyBytes = 8 << 10
+
+	// msgPairFailed is the terse rejection served for every reason a pairing
+	// attempt fails: an unknown, expired, or already-used code, or a
+	// malformed CSR. The client must never be able to tell which.
+	msgPairFailed = "pairing failed"
+)
+```
+
+### ERROR_HANDLING
+```go
+// SOURCE: internal/httpapi/pair.go:73-84
+// Sentinel check first, then log-with-context + terse client body for everything else.
+resp, err := s.pairDevice(r.Context(), req.PairingCode, csrDER)
+if err != nil {
+	if errors.Is(err, state.ErrPairingCodeInvalid) {
+		s.writeError(w, http.StatusUnauthorized, msgPairFailed)
+		return
+	}
+	s.log.Error("pair device", slog.Any("err", err))
+	s.writeError(w, http.StatusInternalServerError, msgPairInternalError)
+	return
+}
+s.writeJSON(w, http.StatusCreated, resp)
+```
+
+```go
+// SOURCE: internal/dockerx/client.go:43-45
+// Every error wrapped with %w and enough context to name the failing input.
+if err != nil {
+	return nil, fmt.Errorf("create docker client for %s: %w", host, err)
+}
+```
+
+### LOGGING_PATTERN
+```go
+// SOURCE: internal/httpapi/device.go:68-71
+// slog with typed attrs; slog.Any("err", err) for the error; never a formatted string.
+s.log.Error("renew device certificate",
+	slog.String("device_id", device.ID),
+	slog.Any("err", err),
+)
+```
+
+### SERVICE_PATTERN
+```go
+// SOURCE: internal/dockerx/client.go:24-28, 66-71
+// Struct holds the SDK handle and a logger; methods are on *Client and wrap errors.
+type Client struct {
+	api *client.Client
+	log *slog.Logger
+}
+
+func (c *Client) Close() error {
+	if err := c.api.Close(); err != nil {
+		return fmt.Errorf("close docker client: %w", err)
+	}
+	return nil
+}
+```
+
+### HTTP_HANDLER_PATTERN
+```go
+// SOURCE: internal/httpapi/device.go:46-77
+// Handler = resolve inputs, call a private method that returns (dto, error),
+// map the error, write. No business logic inside the handler body.
+func (s *Server) handleRenew(w http.ResponseWriter, r *http.Request) {
+	device, ok := DeviceFrom(r.Context())
+	if !ok {
+		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
+		return
+	}
+	resp, err := s.renewDevice(r.Context(), device.ID, csrDER)
+	if err != nil { /* … map … */ }
+	s.writeJSON(w, http.StatusOK, resp)
+}
+```
+
+### ROUTE_REGISTRATION
+```go
+// SOURCE: internal/httpapi/server.go:74-91
+// Method-prefixed patterns (Go 1.22+); guarded routes wrapped in requireDevice;
+// no catch-all "/" so unmatched paths get ServeMux's bare 404.
+mux.HandleFunc("GET /v1/status", s.handleStatus)
+mux.Handle("POST /v1/device/renew", s.requireDevice(http.HandlerFunc(s.handleRenew)))
+return s.withRecovery(s.withRequestLog(mux))
+```
+
+### MIDDLEWARE_PATTERN
+```go
+// SOURCE: internal/httpapi/middleware.go:41-47
+func (s *Server) requireDevice(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			s.writeError(w, http.StatusUnauthorized, msgClientCertRequired)
+			return
+		}
+		// …
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+```
+
+### TEST_STRUCTURE
+```go
+// SOURCE: internal/dockerx/client_test.go:18-48
+// t.Parallel at both levels, table of named cases, explicit // Arrange // Act // Assert,
+// failure messages in the form: got = X, want Y.
+func TestNewUnreachableEngine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+	}{
+		{name: "missing unix socket", host: "unix:///nonexistent/docker.sock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			c, err := New(context.Background(), tt.host, testLogger())
+
+			// Assert
+			if err == nil {
+				_ = c.Close()
+				t.Fatalf("New(%q) error = nil, want an unreachable-engine failure", tt.host)
+			}
+		})
+	}
+}
+```
+
+### FIELD_ALLOWLIST_GUARD
+```go
+// SOURCE: internal/httpapi/status_test.go:74-105
+// Asserting the EXACT key count, not just presence, so a later phase cannot
+// widen a payload silently. This phase reuses the pattern for every read DTO.
+if len(body) != 5 {
+	t.Fatalf("status payload has %d keys (%v), want exactly 5", len(body), keysOf(body))
+}
+```
+
+---
+
+## API Contract (after this phase)
+
+| Route | Auth | Policy op | Success | Body |
+|---|---|---|---|---|
+| `GET /v1/containers?all=<bool>` | client cert | `read` | 200 | `{"items":[ContainerSummary],"truncated":bool}` |
+| `GET /v1/containers/{id}` | client cert | `read` | 200 | `ContainerDetail` |
+| `GET /v1/images` | client cert | `read` | 200 | `{"items":[ImageSummary],"truncated":bool}` |
+| `GET /v1/images/{id}` | client cert | `read` | 200 | `ImageDetail` |
+| `GET /v1/networks` | client cert | `read` | 200 | `{"items":[NetworkSummary],"truncated":bool}` |
+| `GET /v1/networks/{id}` | client cert | `read` | 200 | `NetworkDetail` |
+| `GET /v1/volumes` | client cert | `read` | 200 | `{"items":[VolumeSummary],"truncated":bool}` |
+| `GET /v1/volumes/{name}` | client cert | `read` | 200 | `VolumeDetail` |
+
+Shared failure modes on all eight:
+
+| Condition | Status | Body |
+|---|---|---|
+| No / unknown / revoked client certificate | 401 | `{"error":"client certificate required"}` |
+| Policy mode forbids the operation | 403 | `{"error":"operation not permitted by host policy"}` |
+| Reference fails D6 validation | 400 | `{"error":"invalid object reference"}` |
+| Object does not exist | 404 | `{"error":"not found"}` |
+| Engine unreachable, timed out, or any other Engine error | 502 | `{"error":"docker engine unavailable"}` |
+| Wrong method on a known path | 405 | ServeMux default |
+
+### DTO field allowlists
+
+These structs are the complete, exhaustive set. Adding a field is a deliberate act that must also
+update the corresponding `*FieldCount` test in Task 9.
+
+```go
+// internal/dockerx/types.go
+
+type ListResult[T any] struct {          // Go generics; the module is on Go 1.26
+	Items     []T  `json:"items"`
+	Truncated bool `json:"truncated"`
+}
+
+type Port struct {
+	IP          string `json:"ip,omitempty"`      // from netip.Addr; "" when !IsValid()
+	PrivatePort uint16 `json:"private_port"`
+	PublicPort  uint16 `json:"public_port,omitempty"`
+	Protocol    string `json:"protocol"`          // from PortSummary.Type
+}
+
+type Mount struct {
+	Type        string `json:"type"`
+	Name        string `json:"name,omitempty"`
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	ReadWrite   bool   `json:"read_write"`
+}
+
+type EndpointSummary struct {
+	NetworkName string   `json:"network_name"`
+	NetworkID   string   `json:"network_id"`
+	IPAddress   string   `json:"ip_address,omitempty"`
+	Gateway     string   `json:"gateway,omitempty"`
+	MACAddress  string   `json:"mac_address,omitempty"`
+	Aliases     []string `json:"aliases,omitempty"`
+}
+
+type ContainerSummary struct {            // 11 fields
+	ID        string            `json:"id"`
+	Names     []string          `json:"names"`
+	Image     string            `json:"image"`
+	ImageID   string            `json:"image_id"`
+	Command   string            `json:"command"`
+	CreatedAt string            `json:"created_at"`         // RFC3339 UTC
+	State     string            `json:"state"`
+	Status    string            `json:"status"`
+	Health    string            `json:"health,omitempty"`   // "" when Health is nil
+	Labels    map[string]string `json:"labels"`
+	Ports     []Port            `json:"ports"`
+}
+
+type ContainerDetail struct {             // 24 fields. NO env. NO raw.
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Image         string            `json:"image"`
+	CreatedAt     string            `json:"created_at"`      // RFC3339 UTC
+	State         string            `json:"state"`
+	Running       bool              `json:"running"`
+	Paused        bool              `json:"paused"`
+	Restarting    bool              `json:"restarting"`
+	ExitCode      int               `json:"exit_code"`
+	StartedAt     string            `json:"started_at,omitempty"`
+	FinishedAt    string            `json:"finished_at,omitempty"`
+	Health        string            `json:"health,omitempty"`
+	RestartCount  int               `json:"restart_count"`
+	RestartPolicy string            `json:"restart_policy,omitempty"`
+	Platform      string            `json:"platform"`
+	Labels        map[string]string `json:"labels"`
+	Command       string            `json:"command"`         // InspectResponse.Path
+	Args          []string          `json:"args"`
+	Entrypoint    []string          `json:"entrypoint,omitempty"`
+	WorkingDir    string            `json:"working_dir,omitempty"`
+	User          string            `json:"user,omitempty"`
+	Mounts        []Mount           `json:"mounts"`
+	Networks      []EndpointSummary `json:"networks"`
+	Ports         []Port            `json:"ports"`
+}
+
+type ImageSummary struct {                // 8 fields
+	ID          string            `json:"id"`
+	ParentID    string            `json:"parent_id,omitempty"`
+	RepoTags    []string          `json:"repo_tags"`
+	RepoDigests []string          `json:"repo_digests"`
+	CreatedAt   string            `json:"created_at"`        // RFC3339 UTC from int64
+	Size        int64             `json:"size"`
+	Containers  int64             `json:"containers"`        // -1 means "not calculated"
+	Labels      map[string]string `json:"labels"`
+}
+
+type ImageDetail struct {                 // 9 fields
+	ID           string   `json:"id"`
+	RepoTags     []string `json:"repo_tags"`
+	RepoDigests  []string `json:"repo_digests"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	Size         int64    `json:"size"`
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	Author       string   `json:"author,omitempty"`
+	Comment      string   `json:"comment,omitempty"`
+}
+// image.InspectResponse.Config carries the image's baked-in Env.
+// It is NOT mapped. D2 applies to images too.
+
+type NetworkSummary struct {              // 8 fields
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Scope      string            `json:"scope"`
+	CreatedAt  string            `json:"created_at"`
+	Internal   bool              `json:"internal"`
+	EnableIPv6 bool              `json:"enable_ipv6"`
+	Labels     map[string]string `json:"labels"`
+}
+
+type NetworkDetail struct {               // NetworkSummary + attached endpoints
+	NetworkSummary
+	Containers []NetworkEndpoint `json:"containers"`
+}
+
+type NetworkEndpoint struct {
+	ContainerID string `json:"container_id"`
+	Name        string `json:"name"`
+	IPv4Address string `json:"ipv4_address,omitempty"`
+	IPv6Address string `json:"ipv6_address,omitempty"`
+}
+
+type VolumeSummary struct {               // 7 fields; VolumeDetail = VolumeSummary
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Mountpoint string            `json:"mountpoint"`
+	CreatedAt  string            `json:"created_at,omitempty"`
+	Scope      string            `json:"scope"`
+	Labels     map[string]string `json:"labels"`
+	SizeBytes  *int64            `json:"size_bytes,omitempty"` // from UsageData.Size when non-nil
+}
+```
+
+`volume.Volume.Options` is **not** mapped: for `tmpfs` and CIFS/NFS volumes it routinely contains
+credentials (`o=username=…,password=…`). D2's reasoning applies verbatim.
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|---|---|---|
+| `internal/dockerx/types.go` | CREATE | The DTO allowlist (D1) plus the generic `ListResult` envelope |
+| `internal/dockerx/types_test.go` | CREATE | JSON tag / field-count guards for every DTO |
+| `internal/dockerx/errors.go` | CREATE | `ErrNotFound`, `ErrInvalidRef`, and `classify(err)` wrapping `cerrdefs.IsNotFound` |
+| `internal/dockerx/errors_test.go` | CREATE | `classify` maps not-found, passes everything else through |
+| `internal/dockerx/ref.go` | CREATE | `ValidateRef` (D6) — the boundary check |
+| `internal/dockerx/ref_test.go` | CREATE | Traversal, empty, over-length, and valid-form cases |
+| `internal/dockerx/containers.go` | CREATE | `ListContainers` / `InspectContainer` + mappers |
+| `internal/dockerx/containers_test.go` | CREATE | Mapper tests over synthetic values, including all nil-pointer branches |
+| `internal/dockerx/images.go` | CREATE | `ListImages` / `InspectImage` + mappers |
+| `internal/dockerx/networks.go` | CREATE | `ListNetworks` / `InspectNetwork` + mappers |
+| `internal/dockerx/volumes.go` | CREATE | `ListVolumes` / `InspectVolume` + mappers |
+| `internal/dockerx/objects_test.go` | CREATE | Mapper tests for images, networks, volumes |
+| `internal/httpapi/reads.go` | CREATE | The eight handlers plus `DockerReader` and its four sub-interfaces |
+| `internal/httpapi/reads_test.go` | CREATE | Handler tests against a fake `DockerReader` |
+| `internal/httpapi/policygate.go` | CREATE | `requireOp` middleware (D10) |
+| `internal/httpapi/policygate_test.go` | CREATE | Allowed / denied per mode |
+| `internal/httpapi/server.go` | UPDATE | `Server.dc` field, `NewServer` gains a `DockerReader`, eight routes registered |
+| `internal/httpapi/server_test.go` | UPDATE | `runnableServer` passes the new argument |
+| `internal/httpapi/status_test.go` | UPDATE | Three helpers pass the new argument; one probe path changes |
+| `cmd/devmon-agent/main.go` | UPDATE | Pass `dc` into `NewServer` |
+| `go.mod` / `go.sum` | UPDATE | Promote `github.com/containerd/errdefs` from indirect to direct |
+| `README.md` | UPDATE | API table gains eight rows; a short section on why responses are projections |
+
+## NOT Building
+
+- **Container resource stats (CPU/memory)** — PRD "Could", not "Must". A separate Engine endpoint with a streaming shape of its own.
+- **Container logs** — Phase 4, running in parallel with this one.
+- **Any lifecycle operation** (start/restart/stop/kill/delete) — Phase 5.
+- **Audit-logging read operations** — the PRD scopes the audit log to *mutating* calls. Reads are recorded by `withRequestLog` at Debug and nowhere else.
+- **The agent's `protected: true` marker in listings** — D13; belongs with Phase 5's self-exclusion enforcement.
+- **Server-side filtering or search** (`?name=`, `?label=`) — the client can filter 500 items locally. Passing filter strings through to `client.Filters` widens the enumerated surface with no PRD requirement behind it.
+- **Pagination cursors** — D8's hard cap plus `truncated` is the MVP answer. Cursors are a contract commitment to revisit only if a real host exceeds the cap.
+- **Prune, disk-usage, or system-info endpoints** — not in the enumerated operation set.
+- **Rate limiting on the new routes** — Phase 6, and these are behind `requireDevice`.
+- **Caching Engine responses** — an operator watching a container come back up needs the current state; a cache turns "restarted successfully" into a lie.
+
+---
+
+## Step-by-Step Tasks
+
+### Task 1: DTO types and the list envelope
+- **ACTION**: Create `internal/dockerx/types.go`.
+- **IMPLEMENT**: Every struct from the "DTO field allowlists" section above, verbatim, with `ListResult[T any]`. Doc comment on the block stating D1 and D2: these types are an allowlist; `Config.Env` and `volume.Options` have no field here and must never gain one.
+- **MIRROR**: NAMING_CONVENTION — the doc comment explains *why* the allowlist exists, not what the fields are.
+- **IMPORTS**: none beyond stdlib (this file is pure type declarations).
+- **GOTCHA**: JSON tags are snake_case, matching the existing `statusResponse` / `pairResponse` convention (`ca_fingerprint`, `certificate_pem`), **not** Docker's PascalCase.
+- **VALIDATE**: `go build ./internal/dockerx/`; `gofmt -l internal/dockerx` prints nothing.
+
+### Task 2: Error classification
+- **ACTION**: Create `internal/dockerx/errors.go` and `errors_test.go`.
+- **IMPLEMENT**:
+  ```go
+  // ErrNotFound is returned when the Engine reports no such object. It is the
+  // only Engine failure the API distinguishes: the caller is an authenticated
+  // device, so telling it "that container is gone" is information it is
+  // entitled to, while every other Engine fault is an upstream problem the
+  // client can only retry.
+  var ErrNotFound = errors.New("docker object not found")
+
+  // ErrInvalidRef is returned by ValidateRef. It never reaches the Engine.
+  var ErrInvalidRef = errors.New("invalid docker object reference")
+
+  func classify(op string, err error) error {
+      if err == nil {
+          return nil
+      }
+      if cerrdefs.IsNotFound(err) {
+          return fmt.Errorf("%s: %w", op, ErrNotFound)
+      }
+      return fmt.Errorf("%s: %w", op, err)
+  }
+  ```
+- **MIRROR**: ERROR_HANDLING (`fmt.Errorf` with `%w`); sentinel style from `state.ErrDeviceNotFound` / `state.ErrPairingCodeInvalid`.
+- **IMPORTS**: `errors`, `fmt`, `cerrdefs "github.com/containerd/errdefs"`.
+- **GOTCHA**: `errdefs` is currently an **indirect** requirement. Run `go get github.com/containerd/errdefs@v1.0.0`, then `go mod tidy`. Skipping this leaves a build that works locally and fails in a clean module cache.
+- **VALIDATE**: `go test ./internal/dockerx/ -race -run TestClassify`; `go mod tidy` then confirm errdefs sits in the direct require block.
+
+### Task 3: Object reference validation
+- **ACTION**: Create `internal/dockerx/ref.go` and `ref_test.go`.
+- **IMPLEMENT**: `ValidateRef(ref string) error` returning `ErrInvalidRef` unless `ref` matches `^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$`. Compile the regexp once at package level with `regexp.MustCompile`.
+- **MIRROR**: `config.isValidDNSName` (`internal/config/config.go:308-336`) — boundary validation as a small pure function whose doc comment names the attack it prevents.
+- **IMPORTS**: `regexp`.
+- **GOTCHA**: The pattern must reject a leading `-` and a leading `.`; both are excluded by the first character class. `..` therefore fails on its first character. Do **not** use `strings.Contains(ref, "..")` as the check — it misses `/` entirely and gives a false sense of coverage.
+- **GOTCHA**: `sha256:abc…` must **fail**. Digest references are not accepted on these routes; the test asserts this explicitly so nobody "fixes" it later by widening the pattern to include `:`.
+- **VALIDATE**: table test over `""`, `".."`, `"../../info"`, `"a/b"`, `"-abc"`, a 129-char string, `"sha256:ab"` (all → `ErrInvalidRef`) and `"a1b2c3d4e5f6"`, `"my_app-1.2"` (→ nil).
+
+### Task 4: Container reads
+- **ACTION**: Create `internal/dockerx/containers.go` and `containers_test.go`.
+- **IMPLEMENT**:
+  ```go
+  // callTimeout bounds every Engine call. The HTTP server's WriteTimeout is 30s;
+  // a wedged Engine must become a 502 the agent controls rather than a response
+  // that dies mid-body on the client.
+  const callTimeout = 15 * time.Second
+
+  // maxListItems caps every list response. A host with thousands of images would
+  // otherwise produce a body no phone should receive. The cap is server-side and
+  // not client-adjustable, consistent with the agent's configuration boundary.
+  const maxListItems = 500
+
+  func (c *Client) ListContainers(ctx context.Context, all bool) (ListResult[ContainerSummary], error)
+  func (c *Client) InspectContainer(ctx context.Context, ref string) (ContainerDetail, error)
+
+  func toContainerSummary(s container.Summary) ContainerSummary
+  func toContainerDetail(r container.InspectResponse) ContainerDetail
+  ```
+  `ListContainers` derives a timeout context, calls `ContainerList(ctx, client.ContainerListOptions{All: all})`, `classify`s the error, then maps and truncates. `InspectContainer` calls `ValidateRef` **first**, then `ContainerInspect(ctx, ref, client.ContainerInspectOptions{})` — `Size: false`, because size calculation walks the filesystem.
+- **MIRROR**: SERVICE_PATTERN; ERROR_HANDLING.
+- **IMPORTS**: `context`, `time`, `github.com/moby/moby/client`, `github.com/moby/moby/api/types/container`.
+- **GOTCHA**: Every nil-pointer field listed in "Verified field types" must be guarded. `Health`, `NetworkSettings`, `State`, `Config`, and `HostConfig` are all nil in ordinary cases — a container with no healthcheck, a `--network=none` container, an image with no config. A nil deref here is a panic caught by `withRecovery` and served as 500: a bug that only appears on the operator's real host, never in a test written against a fully-populated fixture. **Write the fixtures with the pointers nil.**
+- **GOTCHA**: `container.Summary.Created` is Unix **seconds** (`time.Unix(n, 0).UTC().Format(time.RFC3339)`), while `InspectResponse.Created` is already an RFC3339Nano **string**. Two different conversions in two adjacent mappers.
+- **GOTCHA**: Initialise every slice with `make([]T, 0, n)`, never a nil slice — a nil slice marshals to `null`, and the app would have to handle both `null` and `[]`.
+- **GOTCHA**: Truncate after mapping: `if len(items) > maxListItems { items, truncated = items[:maxListItems], true }`, so `Truncated` reflects the Engine's real count.
+- **VALIDATE**: `go test ./internal/dockerx/ -race -run 'TestContainer'`; assert a zero-valued `container.Summary` maps without panicking and yields `health == ""`.
+
+### Task 5: Image, network, and volume reads
+- **ACTION**: Create `internal/dockerx/images.go`, `networks.go`, `volumes.go`, and `objects_test.go`.
+- **IMPLEMENT**: `ListImages`/`InspectImage`, `ListNetworks`/`InspectNetwork`, `ListVolumes`/`InspectVolume`, each following Task 4's shape exactly (timeout, classify, validate-ref-first, map, truncate).
+- **MIRROR**: Task 4's file, function for function.
+- **IMPORTS**: add `github.com/moby/moby/api/types/image`, `.../network`, `.../volume`.
+- **GOTCHA**: `ImageInspect` is **variadic** (`inspectOpts ...ImageInspectOption`), not an options struct — call it as `c.api.ImageInspect(ctx, ref)`. Writing `client.ImageInspectOptions{}` will not compile; that type does not exist.
+- **GOTCHA**: `ImageInspectResult` **embeds** `image.InspectResponse`; there is no `.Image` field. Access as `res.ID`, `res.RepoTags`, and so on.
+- **GOTCHA**: `network.Network.Created` is `timeext.Time`, not `time.Time`. Verify the conversion compiles before writing the mapper — try `time.Time(n.Created)`, and fall back to its `.String()` method if the direct conversion is rejected.
+- **GOTCHA**: `network.Summary` embeds `network.Network`, so one mapper written against `network.Network` serves both list and inspect. `network.Inspect` embeds it too and adds `Containers map[string]EndpointResource`.
+- **GOTCHA**: `VolumeListResult` carries `Warnings []string`. Log them at Warn; they do **not** go in the response — they can name driver-internal host paths.
+- **VALIDATE**: `go test ./internal/dockerx/ -race`; package coverage ≥ 80%.
+
+### Task 6: The `requireOp` policy gate
+- **ACTION**: Create `internal/httpapi/policygate.go` and `policygate_test.go`.
+- **IMPLEMENT**:
+  ```go
+  // msgPolicyForbidden is served when the host's startup policy does not permit
+  // the operation. Unlike the terse authentication rejections, this one is
+  // deliberately specific: the caller is an authenticated device, and the whole
+  // point of advertising the policy mode is that a client can tell "the host
+  // forbids this" apart from "the agent is broken".
+  const msgPolicyForbidden = "operation not permitted by host policy"
+
+  func (s *Server) requireOp(op policy.Operation, next http.Handler) http.Handler
+  ```
+  Reject with 403 when `!s.cfg.PolicyMode.Allows(op)`, logging the device ID (best-effort via `DeviceFrom`) and the operation at Warn.
+- **MIRROR**: MIDDLEWARE_PATTERN.
+- **IMPORTS**: `net/http`, `log/slog`, `github.com/scnplt/devmon-agent/internal/policy`.
+- **GOTCHA**: Order matters — `requireDevice(s.requireOp(op, handler))`, so the policy check runs **after** authentication. Inverting it would let an unauthenticated scanner probe the host's policy tier by observing 403 vs 401.
+- **GOTCHA**: `policy.OpRead` is permitted by all three modes, so this task changes no observable behaviour today. That is intended (D10). Do not "simplify" it away.
+- **VALIDATE**: table test over `ModeReadOnly`/`ModeDefault`/`ModeFull` × `OpRead`/`OpDelete`, asserting 200 vs 403 and the exact `msgPolicyForbidden` body.
+
+### Task 7: The `DockerReader` interfaces and the eight handlers
+- **ACTION**: Create `internal/httpapi/reads.go`.
+- **IMPLEMENT**:
+  ```go
+  // Four small interfaces, declared here rather than in dockerx, because the
+  // consumer owns the contract (repo rule: accept interfaces, return structs).
+  // Splitting by object type keeps each within the 1-3 method guideline and
+  // lets Phase 4 and Phase 5 add their own without widening this one.
+  type ContainerReader interface {
+      ListContainers(ctx context.Context, all bool) (dockerx.ListResult[dockerx.ContainerSummary], error)
+      InspectContainer(ctx context.Context, ref string) (dockerx.ContainerDetail, error)
+  }
+  type ImageReader interface   { /* ListImages, InspectImage */ }
+  type NetworkReader interface { /* ListNetworks, InspectNetwork */ }
+  type VolumeReader interface  { /* ListVolumes, InspectVolume */ }
+
+  type DockerReader interface {
+      ContainerReader
+      ImageReader
+      NetworkReader
+      VolumeReader
+  }
+
+  // Compile-time proof the concrete client still satisfies the contract.
+  var _ DockerReader = (*dockerx.Client)(nil)
+  ```
+  Then eight handlers, plus one shared error mapper so the mapping cannot drift:
+  ```go
+  // writeDockerError maps a dockerx failure onto a status code. ErrInvalidRef is
+  // a client mistake (400), ErrNotFound is an answer (404), and everything else
+  // is the Engine failing upstream of us (502) — never 500, which must keep
+  // meaning "the agent itself broke".
+  func (s *Server) writeDockerError(w http.ResponseWriter, op string, err error) {
+      switch {
+      case errors.Is(err, dockerx.ErrInvalidRef):
+          s.writeError(w, http.StatusBadRequest, msgInvalidRef)
+      case errors.Is(err, dockerx.ErrNotFound):
+          s.writeError(w, http.StatusNotFound, msgNotFound)
+      default:
+          s.log.Error(op, slog.Any("err", err))
+          s.writeError(w, http.StatusBadGateway, msgEngineUnavailable)
+      }
+  }
+  ```
+- **MIRROR**: HTTP_HANDLER_PATTERN; ERROR_HANDLING; NAMING_CONVENTION for the `msg*` constants.
+- **IMPORTS**: `context`, `errors`, `log/slog`, `net/http`, `strconv`, `github.com/scnplt/devmon-agent/internal/dockerx`.
+- **GOTCHA**: Parse `?all=` with `strconv.ParseBool`; on a parse error default to `false` rather than 400. `?all=` with no value and `?all=yes` are "the app sent something odd", not an attack, and failing the request would strand a client over a query-string typo.
+- **GOTCHA**: The reference comes from `r.PathValue("id")` (`"name"` for volumes) — never from a query parameter or a body.
+- **GOTCHA**: Every handler must tolerate `s.dc == nil`. The existing test helpers construct servers with nil dependencies deliberately, and the routes are registered unconditionally. Guard once in the handler prologue and answer 502; do not make `routes()` conditional.
+- **VALIDATE**: `go build ./...`.
+
+### Task 8: Wire the routes and the dependency
+- **ACTION**: Update `internal/httpapi/server.go`, `cmd/devmon-agent/main.go`, `internal/httpapi/server_test.go`, `internal/httpapi/status_test.go`.
+- **IMPLEMENT**:
+  - `Server` gains `dc DockerReader`.
+  - `NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger)` — `dc` inserted after `ca`, before `tlsCfg`, so the dependency order still reads state → identity → docker → transport → logging. Extend the existing doc comment to say `dc` may be nil in tests, mirroring what it already says about `ca`.
+  - In `routes()`, after the existing device routes:
+    ```go
+    // Read operations. Every one is guarded twice: requireDevice proves who is
+    // calling, requireOp proves the host's startup policy permits it.
+    read := func(pattern string, h http.HandlerFunc) {
+        mux.Handle(pattern, s.requireDevice(s.requireOp(policy.OpRead, h)))
+    }
+    read("GET /v1/containers", s.handleListContainers)
+    read("GET /v1/containers/{id}", s.handleInspectContainer)
+    read("GET /v1/images", s.handleListImages)
+    read("GET /v1/images/{id}", s.handleInspectImage)
+    read("GET /v1/networks", s.handleListNetworks)
+    read("GET /v1/networks/{id}", s.handleInspectNetwork)
+    read("GET /v1/volumes", s.handleListVolumes)
+    read("GET /v1/volumes/{name}", s.handleInspectVolume)
+    ```
+  - `main.go:164` becomes `httpapi.NewServer(cfg, st, ca, dc, tlsCfg, log)`. `dc` already exists at line 155.
+  - Test helpers gain a `nil` in the new position: `runnableServer` (`server_test.go:31`), `testServer` (`status_test.go:32`), `testServerWithCA` (`status_test.go:46`), `testServerWithStore` (`status_test.go:62`).
+- **MIRROR**: ROUTE_REGISTRATION.
+- **GOTCHA**: `status_test.go:250` — `TestUnknownPathLeaksNothing` requests `GET /v1/containers` and asserts **404**. That route now exists. Change the probe path to something still unrouted (`/v1/system/info`) rather than deleting the test; it guards a real property.
+- **GOTCHA**: The `var _ DockerReader = (*dockerx.Client)(nil)` assertion from Task 7 is what turns a signature mismatch into an error in the package that owns the contract instead of a confusing one at the `main.go` call site.
+- **VALIDATE**: `go build ./... && go test ./internal/... -race` — all pre-existing tests still pass.
+
+### Task 9: Handler and DTO tests
+- **ACTION**: Create `internal/httpapi/reads_test.go` and `internal/dockerx/types_test.go`.
+- **IMPLEMENT**:
+  - A `fakeDocker` implementing `DockerReader`, with per-method function fields so each test injects its own behaviour (including returning `dockerx.ErrNotFound` and a generic error).
+  - A `testServerWithDocker(t, mode, dc)` helper, **additive** alongside the three existing helpers — do not widen `testServer`, which several passing tests depend on.
+  - Per-route tests: 200 with the expected body, 404 on `ErrNotFound`, 502 on a generic error, 400 on `ErrInvalidRef`, 401 with no client certificate, 405 on `POST`.
+  - `Test<DTO>FieldCount` for each of the eight DTOs, in the exact shape of `TestStatusFieldCount`.
+  - `TestContainerDetailNeverCarriesEnv`: map an `InspectResponse` whose `Config.Env` holds `"DB_PASSWORD=hunter2"`, marshal the DTO, and assert the JSON contains neither `"env"` nor `"hunter2"`. Same for `ImageDetail`, and for `volume.Volume.Options` → `VolumeSummary`.
+- **MIRROR**: TEST_STRUCTURE; FIELD_ALLOWLIST_GUARD.
+- **GOTCHA**: Requests to guarded routes need `req.TLS` set and a matching device in a real store — reuse `testServerWithStore` + `peerCertWithSerial` (`status_test.go:53-72`) rather than inventing a second mechanism.
+- **GOTCHA**: The secret-leak tests are the highest-value tests in this phase. They must assert on the **marshalled JSON string**, not on struct fields — a future embedded struct or a removed `json:"-"` would slip past a field-level assertion.
+- **VALIDATE**: `make cover` — `./internal/...` total ≥ 80%.
+
+### Task 10: Docs and the manual sweep
+- **ACTION**: Update `README.md`.
+- **IMPLEMENT**: Eight rows in the API table (`README.md:194-199`). Below it, a short subsection — *Why responses are projections* — stating D1/D2/D3: responses are an explicit allowlist; environment variables and volume driver options are never returned at any level; command lines are returned deliberately and noted in the threat model; lists are capped at 500 with a `truncated` flag. Add the 400/404/502 rows to a failure-mode table.
+- **MIRROR**: The existing README voice — each statement carries its reason, as in the `/v1/status` paragraph at `README.md:201-206`.
+- **GOTCHA**: English only, per CLAUDE.md.
+- **VALIDATE**: The full gate sweep plus the manual checklist below.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test | Input | Expected Output | Edge Case? |
+|---|---|---|---|
+| `TestValidateRef` | `""`, `".."`, `"../../info"`, `"a/b"`, `"-x"`, 129 chars, `"sha256:ab"` | `ErrInvalidRef` for each | yes |
+| `TestValidateRef` | `"a1b2c3"`, `"my_app-1.2"` | nil | no |
+| `TestClassify` | an error satisfying `cerrdefs.IsNotFound` | `errors.Is(got, ErrNotFound)` true | no |
+| `TestClassify` | a plain `errors.New` | not `ErrNotFound`; original wrapped | no |
+| `TestToContainerSummaryZeroValue` | `container.Summary{}` (all pointers nil) | no panic; `health == ""`; `ports` empty | **yes** |
+| `TestToContainerDetailNilState` | `InspectResponse{State: nil, Config: nil, HostConfig: nil}` | no panic; zero-valued fields | **yes** |
+| `TestToContainerSummaryCreatedAt` | `Created: 1700000000` | `"2023-11-14T22:13:20Z"` | no |
+| `TestPortIPInvalidAddr` | `PortSummary{IP: netip.Addr{}}` | `ip` omitted from JSON | yes |
+| `TestListTruncation` | 501 summaries | 500 items, `truncated == true` | **yes** |
+| `TestListTruncation` | 500 summaries | 500 items, `truncated == false` | boundary |
+| `TestEmptyListMarshalsAsArray` | 0 summaries | `"items":[]`, never `"items":null` | yes |
+| `TestVolumeWarningsNotInResponse` | `VolumeListResult{Warnings: ["/var/lib/…"]}` | response body contains no warning text | yes |
+| `TestContainerDetailNeverCarriesEnv` | `Config.Env: ["DB_PASSWORD=hunter2"]` | marshalled JSON has no `env`, no `hunter2` | **yes** |
+| `TestImageDetailNeverCarriesEnv` | image config with env | same | **yes** |
+| `TestVolumeSummaryNeverCarriesOptions` | `Options: {"o":"password=x"}` | no `options`, no `password=x` | **yes** |
+| `Test<DTO>FieldCount` × 8 | marshalled DTO | exact expected key count | guard |
+| `TestReadRouteRequiresDevice` × 8 | no `req.TLS` | 401, `msgClientCertRequired` | yes |
+| `TestReadRouteRejectsOtherMethods` | `POST /v1/containers` | 405 | yes |
+| `TestInspectNotFound` | fake returns `ErrNotFound` | 404, `{"error":"not found"}` | yes |
+| `TestInspectEngineFailure` | fake returns a generic error | 502, `msgEngineUnavailable`; error logged, not returned | yes |
+| `TestInspectInvalidRef` | fake returns `ErrInvalidRef` | 400 | yes |
+| `TestListAllParameter` | `?all=true`, `?all=false`, `?all=`, absent | fake sees `true,false,false,false` | yes |
+| `TestNilDockerReader` | `s.dc == nil` | 502, no panic | **yes** |
+| `TestRequireOp` | 3 modes × `OpRead`/`OpDelete` | 200 / 403 | no |
+| `TestErrorBodiesLeakNothing` | every failure path | body contains no `StateDir`, `docker.sock`, `devmon.db` | **yes** |
+
+### Edge Cases Checklist
+- [ ] Empty host — no containers, images, networks, or volumes → `{"items":[],"truncated":false}`
+- [ ] Container with no healthcheck (`Health` nil)
+- [ ] Container on no network (`NetworkSettings` nil)
+- [ ] Container never started (`State.StartedAt` zero-valued)
+- [ ] Image with no tags (`RepoTags` nil → `[]`)
+- [ ] Volume with no `UsageData` → `size_bytes` omitted
+- [ ] 501 objects → truncation at exactly 500
+- [ ] Reference containing a traversal attempt → 400 before any Engine call
+- [ ] Engine socket removed while the agent runs → 502, agent stays up
+- [ ] Engine hangs → `callTimeout` fires at 15s → 502, not a client-visible timeout
+- [ ] Revoked device → 401 on every read route
+- [ ] `read-only` policy mode → all eight routes still 200
+
+---
+
+## Validation Commands
+
+### Static Analysis
+```bash
+gofmt -l .
+go vet ./...
+```
+EXPECT: both print nothing.
+
+### Lint
+```bash
+make lint
+```
+EXPECT: clean (or the "golangci-lint not installed" notice, with `gofmt`/`vet` clean).
+
+### Security Scan
+```bash
+gosec ./...
+```
+EXPECT: no findings. Watch for G104 (unhandled errors) in the new mappers.
+
+### Unit Tests
+```bash
+go test ./internal/dockerx/ ./internal/httpapi/ -race -v
+```
+EXPECT: all pass.
+
+### Full Test Suite with Coverage
+```bash
+make cover
+```
+EXPECT: all packages pass; the total line is ≥ 80%.
+
+### Build Verification
+```bash
+make build
+CGO_ENABLED=0 go build ./...
+make image
+```
+EXPECT: static binary; image builds.
+
+### Module Hygiene
+```bash
+go mod tidy
+git diff go.mod
+```
+EXPECT: `github.com/containerd/errdefs` appears in the direct require block and nowhere in the indirect block.
+
+### End-to-End Validation (real host with real workloads)
+```bash
+# With a paired device's cert/key from the Phase 2 README flow:
+curl --cacert ca.pem --cert device.pem --key device.key \
+     "https://$HOST:8443/v1/containers?all=true" | jq '.items | length, .truncated'
+
+curl --cacert ca.pem --cert device.pem --key device.key \
+     "https://$HOST:8443/v1/containers/$(docker ps -q | head -1)" | jq 'keys'
+# Assert: the key list contains no "env".
+
+curl -o /dev/null -w '%{http_code}\n' --cacert ca.pem --cert device.pem --key device.key \
+     "https://$HOST:8443/v1/containers/nonexistent"          # 404
+curl -o /dev/null -w '%{http_code}\n' --cacert ca.pem --cert device.pem --key device.key \
+     "https://$HOST:8443/v1/volumes/%2e%2e"                   # 400
+curl -o /dev/null -w '%{http_code}\n' --cacert ca.pem \
+     "https://$HOST:8443/v1/containers"                       # 401
+```
+
+### Manual Validation
+- [ ] Start a container with `-e DB_PASSWORD=hunter2`; inspect it through the API and confirm the string `hunter2` appears nowhere in the response.
+- [ ] Inspect an image built with `ENV API_KEY=…`; confirm the same.
+- [ ] Create a `tmpfs` volume with driver options; confirm `options` is absent from the response.
+- [ ] Stop a container; confirm it is absent from `/v1/containers` and present in `/v1/containers?all=true` with `state: "exited"`.
+- [ ] Run a container with a failing healthcheck; confirm `health: "unhealthy"` in the list response.
+- [ ] `docker network create` and `docker volume create`; confirm both appear immediately (no caching).
+- [ ] Stop the Docker daemon; confirm every read route answers 502 and the agent container stays up.
+- [ ] Restart the daemon; confirm reads recover without restarting the agent.
+- [ ] Start the agent with `DEVMON_POLICY_MODE=read-only`; confirm all eight routes still answer 200.
+- [ ] Revoke the device from the host; confirm the next read is 401 with no agent restart.
+- [ ] Check `agent.log`: request lines carry method/path/status/duration only — no container names, no reference values.
+
+---
+
+## Acceptance Criteria
+- [ ] All 10 tasks complete
+- [ ] Eight routes registered, each behind `requireDevice` **and** `requireOp(policy.OpRead)`
+- [ ] No response DTO carries environment variables or volume driver options, at any nesting depth, proven by tests asserting on marshalled JSON
+- [ ] `ErrNotFound` → 404, `ErrInvalidRef` → 400, every other Engine failure → 502; 500 is never returned by a read route
+- [ ] Lists are capped at 500 with an honest `truncated` flag, and an empty list marshals as `[]`
+- [ ] `gofmt`, `go vet`, `golangci-lint`, `gosec` all clean
+- [ ] `./internal/...` coverage ≥ 80%
+- [ ] A paired client retrieves accurate data for all four object types on a host with real workloads (PRD Phase 3 success signal)
+
+## Completion Checklist
+- [ ] Code follows the patterns captured above
+- [ ] Errors wrapped with `%w` and named context
+- [ ] Logging uses `slog` typed attrs; failures logged with context, returned terse
+- [ ] Tests are table-driven, `t.Parallel`, AAA-commented
+- [ ] No hardcoded values — `callTimeout`,cle `maxListItems`, and every `msg*` are named constants
+- [ ] README API table and projection rationale updated
+- [ ] `go.mod` tidy, errdefs promoted to direct
+- [ ] PRD Phase 3 row moved to `complete` with links to this plan and its report
+- [ ] No scope beyond the eight read routes
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| A response leaks environment variables — DB passwords, API keys — to the phone | M | **CRITICAL** | D1/D2: explicit allowlist DTOs, no raw passthrough, no `Raw json.RawMessage`; dedicated marshalled-JSON tests; `*FieldCount` guards so a later phase cannot widen silently |
+| Volume driver options leak NFS/CIFS credentials | M | HIGH | `Options` has no DTO field; explicit test |
+| Nil-pointer panic on a real host that no fixture reproduced | **H** | HIGH | Every pointer field enumerated in this plan; fixtures written with nils; `withRecovery` is the backstop, not the plan |
+| Object reference reaches the Engine URL unvalidated | L | HIGH | D6 boundary check before any SDK call, plus ServeMux's own segment rule; tests assert traversal forms are rejected |
+| Code written from the pre-v29 Docker SDK does not compile | **H** | MEDIUM | Verified signatures transcribed above; `ImageInspect`'s variadic shape and the embedded `ImageInspectResult` are the two that differ most from memory |
+| `errdefs` left indirect; build fails in a clean module cache | M | MEDIUM | Task 2 promotes it; `go mod tidy` in the gate |
+| `NewServer` signature change breaks four existing test helpers | **H** | LOW | Enumerated by file and line in Task 8 |
+| `TestUnknownPathLeaksNothing` starts failing because `/v1/containers` now exists | **H** | LOW | Task 8 calls it out with the replacement probe path |
+| A large host produces an unusable response on a mobile connection | M | MEDIUM | D8's 500-item cap plus `truncated` |
+| Read routes get audit entries and drown the audit log | L | MEDIUM | Explicitly out of scope; the PRD scopes audit to mutating calls |
+
+## Notes
+
+- **This phase is parallel with Phase 4.** Both extend `internal/dockerx` and `internal/httpapi`. If they are implemented concurrently, the collision points are `routes()`, the `NewServer` signature, and the `DockerReader` interface set. Phase 4 should compose its own `LogReader` interface rather than adding methods to `DockerReader`, and both should take the `NewServer` signature change from whichever lands first.
+- **`ContainerDetail` is the one DTO worth arguing about.** It is larger than the others because it is the screen an operator actually stares at during an incident. Every field earns its place by answering "why is this container not working": state and exit code, restart count and policy, mounts, networks, ports, and the command it was told to run. Anything that does not answer that question was left out.
+- **`ListResult[T]` uses generics.** The module is on Go 1.26 and no existing code uses type parameters — this is the first. The alternative, four near-identical envelope structs, is the repetition the DRY rule exists to prevent, and the type parameter costs nothing at runtime.
+- **502, not 500, for Engine failures.** A small decision with a real operational payoff: once Phase 6's monitoring exists, "the agent is broken" and "the host's Docker is broken" are different pages, and the status code is the cheapest place to encode the difference.
+- Deferred to Phase 5, recorded here so it is not lost: once the agent can identify its own container, the container list should mark it `protected: true`. That field will be an **addition** to `ContainerSummary`, so `TestContainerSummaryFieldCount` will need its count bumped deliberately — which is exactly the intended friction.

--- a/.claude/PRPs/prds/devmon-agent.prd.md
+++ b/.claude/PRPs/prds/devmon-agent.prd.md
@@ -206,7 +206,7 @@ Every operation requested maps directly onto a well-documented Docker Engine API
 |---|-------|-------------|--------|----------|---------|----------|
 | 1 | Secure foundation & persistence | Agent runs as a container, serves TLS, talks to the Docker socket, exposes a health/version check, and persists state and its own logs across restarts | complete | - | - | [secure-foundation-and-persistence.plan.md](../plans/completed/secure-foundation-and-persistence.plan.md) · [report](../reports/secure-foundation-and-persistence-report.md) |
 | 2 | Identity, pairing & revocation | Agent CA, pairing codes, per-device credentials, device registry, renewal, self-unpair, host-side device commands, missing-state handling | complete | - | 1 | [identity-pairing-and-revocation.plan.md](../plans/completed/identity-pairing-and-revocation.plan.md) · [report](../reports/identity-pairing-and-revocation-report.md) |
-| 3 | Read operations | Container/image/network/volume list and inspect | pending | with 4 | 2 | - |
+| 3 | Read operations | Container/image/network/volume list and inspect | complete | with 4 | 2 | [read-operations.plan.md](../plans/completed/read-operations.plan.md) · [report](../reports/read-operations-report.md) |
 | 4 | Logs & live streaming | Historical logs plus a resilient live stream channel | pending | with 3 | 2 | - |
 | 5 | Lifecycle, policy & audit | start/restart/stop/kill/delete, server-side mode enforcement, agent self-exclusion, audit logging | pending | - | 3 | - |
 | 6 | Hardening & OSS release | Rate limiting, security review, automated installer, threat-model docs, AGPL-3.0 release | pending | - | 4, 5 | - |

--- a/.claude/PRPs/reports/read-operations-report.md
+++ b/.claude/PRPs/reports/read-operations-report.md
@@ -43,7 +43,7 @@ at any nesting depth.
 | Unit tests | Pass | `go test ./internal/... -race` all green |
 | Coverage | Pass | 85.4% on `./internal/...`, floor is 80% |
 | Build | Pass | `CGO_ENABLED=0` static binary, 18.9 MB |
-| Integration / E2E | **Not run** | Requires a real host with a live Docker daemon |
+| Integration / E2E | Pass | Full manual checklist run against Docker 29.6.1 / API 1.55 — see below |
 | Edge cases | Pass (unit level) | Nil-pointer, truncation, empty-list, traversal all covered |
 
 Per-package coverage: certs 79.1, config 90.9, dockerx 95.2, httpapi 84.8, logging 84.6,
@@ -174,8 +174,41 @@ appears in a `VolumeSummary`. A field-level assertion would miss a future embedd
 - [x] Lists capped at 500 with an honest `truncated` flag; empty list marshals as `[]`
 - [x] `gofmt`, `go vet`, `golangci-lint`, `gosec` all clean for this phase's code
 - [x] `./internal/...` coverage 85.4% ≥ 80%
-- [ ] **A paired client retrieves accurate data on a host with real workloads** — not verified;
-      requires a live daemon. This is the PRD's Phase 3 success signal and remains open.
+- [x] **A paired client retrieves accurate data on a host with real workloads** — verified against
+      Docker 29.6.1 / API 1.55. The PRD's Phase 3 success signal is met.
+
+## End-to-End Validation
+
+Environment: agent running in its own container against a real daemon, a genuinely paired device
+(EC keypair → CSR → `/v1/pair` → 201), and fixtures built to carry real secrets. The Engine was
+reached through a socat proxy so it could be made unreachable *while the agent stayed running* —
+stopping the host daemon would have killed the agent container too and proved nothing.
+
+| Check | Result |
+|---|---|
+| Container with `-e DB_PASSWORD=hunter2`, inspected | 698-byte body, no `hunter2`, no `DB_PASSWORD`, no `env` key |
+| Image with `ENV API_KEY=supersecretkey123`, inspected | no `supersecretkey123`, no `API_KEY`, no `env`, no `config` |
+| Volume with `type=tmpfs,o=size=1m,uid=1000` | no `options` key, none of the option values |
+| All eight routes, `default` mode | 200 |
+| All eight routes, `read-only` mode | 200 (confirms D10) |
+| Stopped container | absent from `/v1/containers`, present in `?all=true` as `exited` / `Exited (1)` |
+| Engine unreachable | four list routes 502 `docker engine unavailable`; `/v1/status` still 200; agent up, 0 restarts |
+| Engine restored | reads recover with no agent restart |
+| Unknown object | 404 |
+| `%2e%2e`, `%2e%2e%2finfo`, `a%2fb`, `foo$bar`, `-leading`, `sha256:ab` | 400 `invalid object reference`, none reached the Engine |
+| `POST /v1/containers` | 405 |
+| No client certificate | 401 `client certificate required` |
+| Device revoked | every read route 401 immediately, no agent restart |
+
+Two things worth recording:
+
+- **`curl` normalizes `%2e%2e` client-side**, which made the first traversal probe look like a
+  404 from the agent. With `--path-as-is` the request reaches the handler and returns the
+  documented 400. The contract holds; the initial reading was a client artifact.
+- **Confirmed review finding M4 with evidence.** The Debug request log does carry reference
+  values (`path=/v1/containers/cb6831df…`). It carries no secrets: zero hits for env values,
+  private key material, or pairing codes across the whole run. The "never log secrets" rule
+  holds; the plan checklist's "no reference values" claim does not.
 
 ## Next Steps
 

--- a/.claude/PRPs/reports/read-operations-report.md
+++ b/.claude/PRPs/reports/read-operations-report.md
@@ -1,0 +1,171 @@
+# Implementation Report: Read Operations (Phase 3)
+
+## Summary
+
+Eight mTLS-guarded `GET` routes give a paired device full read visibility into the host's
+containers, images, networks, and volumes. A new read-only surface on `internal/dockerx`
+projects Docker Engine responses through explicit allowlisted DTOs rather than forwarding
+raw Engine JSON, so no response can carry environment variables or volume driver options
+at any nesting depth.
+
+## Assessment vs Reality
+
+| Metric | Predicted (Plan) | Actual |
+|---|---|---|
+| Complexity | Medium–Large (18 files, 10 tasks, ~900 lines production Go) | Matched; 1,072 lines production Go across 9 new files |
+| Confidence | Plan carried verified SDK signatures | Two plan facts were wrong (see Deviations); both caught at compile time |
+| Files Changed | 18 (12 created, 6 updated) | 24 (17 created, 7 updated) |
+| Coverage | ≥ 80% on `./internal/...` | 85.4% (needed one unplanned test file to get there) |
+
+## Tasks Completed
+
+| # | Task | Status | Notes |
+|---|---|---|---|
+| 1 | DTO types and list envelope | Complete | All DTOs verbatim from the plan's allowlist |
+| 2 | Error classification | Complete | `errdefs` promoted from indirect to direct |
+| 3 | Object reference validation | Complete | Digest refs (`sha256:…`) rejected, asserted explicitly |
+| 4 | Container reads | Complete | Deviated — added `toPortsFromPortMap` |
+| 5 | Image, network, volume reads | Complete | Deviated — two plan facts corrected |
+| 6 | `requireOp` policy gate | Complete | No behavioural change today, by design (D10) |
+| 7 | `DockerReader` interfaces + 8 handlers | Complete | Deviated — `Server.dc` field added early to compile |
+| 8 | Wire routes and dependency | Complete | Deviated — `pair_test.go` also needed the new argument |
+| 9 | Handler and DTO tests | Complete | Split across two packages; two leak tests already existed |
+| 10 | Docs | Complete | README API table + "Why responses are projections" |
+| — | Coverage remediation | Complete | **Unplanned.** See Issues Encountered |
+
+## Validation Results
+
+| Level | Status | Notes |
+|---|---|---|
+| Static analysis (`gofmt`, `go vet`) | Pass | `go vet ./...` clean; new files gofmt-clean |
+| Lint (`golangci-lint`) | **Not run** | Not installed on this machine |
+| Security scan (`gosec`) | **Not run** | Not installed on this machine |
+| Unit tests | Pass | `go test ./internal/... -race` all green |
+| Coverage | Pass | 85.4% on `./internal/...`, floor is 80% |
+| Build | Pass | `CGO_ENABLED=0` static binary, 18.9 MB |
+| Integration / E2E | **Not run** | Requires a real host with a live Docker daemon |
+| Edge cases | Pass (unit level) | Nil-pointer, truncation, empty-list, traversal all covered |
+
+Per-package coverage: certs 79.1, config 90.9, dockerx 94.1, httpapi 84.8, logging 84.6,
+policy 100, state 80.2, tlsconf 100.
+
+## Files Changed
+
+| File | Action | Lines |
+|---|---|---|
+| `internal/dockerx/types.go` | CREATED | +164 |
+| `internal/dockerx/errors.go` | CREATED | +31 |
+| `internal/dockerx/ref.go` | CREATED | +29 |
+| `internal/dockerx/containers.go` | CREATED | +270 |
+| `internal/dockerx/images.go` | CREATED | +104 |
+| `internal/dockerx/networks.go` | CREATED | +113 |
+| `internal/dockerx/volumes.go` | CREATED | +84 |
+| `internal/httpapi/reads.go` | CREATED | +240 |
+| `internal/httpapi/policygate.go` | CREATED | +37 |
+| `internal/dockerx/types_test.go` | CREATED | +310 |
+| `internal/dockerx/errors_test.go` | CREATED | +83 |
+| `internal/dockerx/ref_test.go` | CREATED | +52 |
+| `internal/dockerx/containers_test.go` | CREATED | +346 |
+| `internal/dockerx/objects_test.go` | CREATED | +412 |
+| `internal/dockerx/engine_test.go` | CREATED | +656 |
+| `internal/httpapi/reads_test.go` | CREATED | +740 |
+| `internal/httpapi/policygate_test.go` | CREATED | +69 |
+| `internal/httpapi/server.go` | UPDATED | +30 / -1 |
+| `cmd/devmon-agent/main.go` | UPDATED | +1 / -1 |
+| `internal/httpapi/server_test.go` | UPDATED | +1 / -1 |
+| `internal/httpapi/status_test.go` | UPDATED | +7 / -1 |
+| `internal/httpapi/pair_test.go` | UPDATED | +1 / -1 |
+| `go.mod` | UPDATED | +2 / -2 |
+| `README.md` | UPDATED | +46 |
+
+## Deviations from Plan
+
+1. **`timeext.Time` conversion was a non-issue.** The plan warned that
+   `network.Network.Created` is `timeext.Time`, not `time.Time`, and prescribed a fallback.
+   In reality the upstream swagger-generated file imports the standard library as
+   `timeext "time"` — it is an import alias, not a distinct type. `Created` *is* a
+   `time.Time`. Used `n.Created.UTC().Format(time.RFC3339)` directly and documented the
+   finding in the mapper so nobody reintroduces a spurious conversion.
+
+2. **`image.InspectResponse.OS` is spelled `Os`.** Mapped `ImageDetail.OS = r.Os`.
+
+3. **Added `toPortsFromPortMap` (Task 4).** `ContainerDetail.Ports` is in the DTO allowlist
+   but the plan named no helper to populate it from `InspectResponse.NetworkSettings.Ports`
+   (`network.PortMap`, a different shape from `Summary.Ports`). Added with the same nil
+   guarding as the rest of the file.
+
+4. **`network.EndpointResource.IPv4Address/IPv6Address` are `netip.Prefix`, not `netip.Addr`.**
+   Same `.IsValid()` → `.String()` guard; values include the prefix length
+   (`"172.19.0.2/16"`), matching Docker's own documented example for that field.
+
+5. **`Server.dc` field landed in Task 7 rather than Task 8**, because `reads.go` does not
+   compile without it. Task 8 wired the constructor and routes as planned.
+
+6. **`internal/httpapi/pair_test.go` also needed the new `NewServer` argument.** The plan
+   enumerated four helpers; a fifth existed. One-line mechanical fix.
+
+7. **`TestImageDetailNeverCarriesEnv` and `TestVolumeSummaryNeverCarriesOptions` were
+   already written in Task 5's `objects_test.go`**, both already asserting on marshalled
+   JSON. Not duplicated in `types_test.go`; a comment there points at them.
+
+## Issues Encountered
+
+**Coverage came in below the floor at 78.0%.** After Task 9, `internal/dockerx` sat at
+58.6% because all eight Engine-calling wrappers were at 0% — every test covered only the
+pure mappers, so the truncation path, the `classify` error path, and the
+validate-ref-before-any-Engine-call ordering were never exercised through a real call.
+That is a genuine test gap, not just an unflattering number.
+
+Fixed by adding `internal/dockerx/engine_test.go`, which drives the wrappers against a
+fake Engine using an in-process `http.RoundTripper` injected via the SDK's exported
+`client.WithHTTPClient`. No live daemon and no listening socket. It proves, among other
+things, that an invalid reference produces `ErrInvalidRef` with **zero** requests reaching
+the Engine. `internal/dockerx` went 58.6% → 94.1%; the `./internal/...` total went
+78.0% → 85.4%.
+
+**`gofmt -l` flags the entire working tree.** The repo has `core.autocrlf=true`, so every
+checked-out file has CRLF and `gofmt` reports all of them. This is pre-existing and
+repo-wide, not introduced here; the committed blobs are LF and a Linux CI checkout is
+clean. Each new file was verified individually.
+
+**`golangci-lint` and `gosec` are not installed on this machine**, so two gates in the
+plan's validation section could not be run. `go vet ./...` is clean. These should run in
+CI or after installing the tools before merge.
+
+## Tests Written
+
+| Test File | Tests | Coverage |
+|---|---|---|
+| `internal/dockerx/types_test.go` | 8 field-count guards + 2 leak guards | DTO allowlist cannot widen silently |
+| `internal/dockerx/errors_test.go` | 1 table (3 cases) | `classify` not-found vs passthrough |
+| `internal/dockerx/ref_test.go` | 1 table (11 cases) | Traversal, digest, length boundaries |
+| `internal/dockerx/containers_test.go` | 9 | Container mappers, all nil-pointer branches |
+| `internal/dockerx/objects_test.go` | ~12 | Image/network/volume mappers, leak guards |
+| `internal/dockerx/engine_test.go` | 7 tables across all 8 methods | Wrappers, truncation, 404/500, ref-first |
+| `internal/httpapi/reads_test.go` | 11 tables across all 8 routes | 200/400/401/404/405/502, `?all=`, nil reader |
+| `internal/httpapi/policygate_test.go` | 1 table (6 cases) | 3 modes × 2 operations |
+
+The highest-value tests are the ones asserting on **marshalled JSON** that `hunter2` and
+`env` never appear in a `ContainerDetail` or `ImageDetail`, and that `options` never
+appears in a `VolumeSummary`. A field-level assertion would miss a future embedded struct.
+
+## Acceptance Criteria
+
+- [x] All 10 tasks complete
+- [x] Eight routes registered, each behind `requireDevice` **and** `requireOp(policy.OpRead)`, in that order
+- [x] No response DTO carries env vars or volume driver options, proven by marshalled-JSON tests
+- [x] `ErrNotFound` → 404, `ErrInvalidRef` → 400, all other Engine failures → 502; no 500 from a read route
+- [x] Lists capped at 500 with an honest `truncated` flag; empty list marshals as `[]`
+- [x] `gofmt`, `go vet` clean — **`golangci-lint` and `gosec` not run (not installed)**
+- [x] `./internal/...` coverage 85.4% ≥ 80%
+- [ ] **A paired client retrieves accurate data on a host with real workloads** — not verified;
+      requires a live daemon. This is the PRD's Phase 3 success signal and remains open.
+
+## Next Steps
+
+- [ ] Run `golangci-lint run ./...` and `gosec ./...` once installed, or rely on CI
+- [ ] Work the plan's Manual Validation checklist against a real host — in particular:
+      start a container with `-e DB_PASSWORD=hunter2` and confirm the string appears
+      nowhere in the API response; stop the daemon and confirm 502 with the agent still up
+- [ ] Code review via `/ecc:code-review` (`go-reviewer` + `security-reviewer`)
+- [ ] Create PR into `dev` via `/ecc:prp-pr`

--- a/.claude/PRPs/reports/read-operations-report.md
+++ b/.claude/PRPs/reports/read-operations-report.md
@@ -38,16 +38,32 @@ at any nesting depth.
 | Level | Status | Notes |
 |---|---|---|
 | Static analysis (`gofmt`, `go vet`) | Pass | `go vet ./...` clean; new files gofmt-clean |
-| Lint (`golangci-lint`) | **Not run** | Not installed on this machine |
-| Security scan (`gosec`) | **Not run** | Not installed on this machine |
+| Lint (`golangci-lint`) | Pass | v2.12.2, default linter set, `0 issues` repo-wide |
+| Security scan (`gosec`) | Pass | `gosec ./...` → **0 issues**, 34 files, 4,468 lines |
 | Unit tests | Pass | `go test ./internal/... -race` all green |
 | Coverage | Pass | 85.4% on `./internal/...`, floor is 80% |
 | Build | Pass | `CGO_ENABLED=0` static binary, 18.9 MB |
 | Integration / E2E | **Not run** | Requires a real host with a live Docker daemon |
 | Edge cases | Pass (unit level) | Nil-pointer, truncation, empty-list, traversal all covered |
 
-Per-package coverage: certs 79.1, config 90.9, dockerx 94.1, httpapi 84.8, logging 84.6,
+Per-package coverage: certs 79.1, config 90.9, dockerx 95.2, httpapi 84.8, logging 84.6,
 policy 100, state 80.2, tlsconf 100.
+
+**On the two security-scan numbers.** `gosec ./...` — the command in the Makefile and this plan —
+reports **0 issues**, because gosec skips `_test.go` files unless `-tests` is passed. Running
+`gosec -tests ./...` surfaces 5 findings, and `golangci-lint --enable gosec` surfaces 4 of the
+same set (it applies its own severity filtering). Every one of them is in a Phase 1–2 test file
+this phase never touched:
+
+| File | Rule | Note |
+|---|---|---|
+| `internal/certs/ca_test.go:346,367` | G306 | Fixture writes a stub file with `0o644` into a temp dir |
+| `internal/certs/store_test.go:141,163` | G306 | Same |
+| `internal/state/pairing_test.go:126` | G115 | `string(rune('a'+n))` int→rune conversion in a test loop |
+
+Production code is clean under both tools. The test-file findings are left alone deliberately —
+fixing them here would widen this PR beyond the eight read routes — but they are worth a small
+separate cleanup so that `gosec -tests` is also clean.
 
 ## Files Changed
 
@@ -156,14 +172,15 @@ appears in a `VolumeSummary`. A field-level assertion would miss a future embedd
 - [x] No response DTO carries env vars or volume driver options, proven by marshalled-JSON tests
 - [x] `ErrNotFound` → 404, `ErrInvalidRef` → 400, all other Engine failures → 502; no 500 from a read route
 - [x] Lists capped at 500 with an honest `truncated` flag; empty list marshals as `[]`
-- [x] `gofmt`, `go vet` clean — **`golangci-lint` and `gosec` not run (not installed)**
+- [x] `gofmt`, `go vet`, `golangci-lint`, `gosec` all clean for this phase's code
 - [x] `./internal/...` coverage 85.4% ≥ 80%
 - [ ] **A paired client retrieves accurate data on a host with real workloads** — not verified;
       requires a live daemon. This is the PRD's Phase 3 success signal and remains open.
 
 ## Next Steps
 
-- [ ] Run `golangci-lint run ./...` and `gosec ./...` once installed, or rely on CI
+- [x] ~~Run `golangci-lint` and `gosec`~~ — done, both clean
+- [ ] Separate cleanup commit for the five `gosec -tests` findings in Phase 1–2 test files
 - [ ] Work the plan's Manual Validation checklist against a real host — in particular:
       start a container with `-e DB_PASSWORD=hunter2` and confirm the string appears
       nowhere in the API response; stop the daemon and confirm 502 with the agent still up

--- a/.claude/PRPs/reviews/read-operations-review.md
+++ b/.claude/PRPs/reviews/read-operations-review.md
@@ -103,12 +103,18 @@ Each of these was checked against the source directly, not accepted on a reviewe
 | Tests (`go test ./... -race`) | Pass |
 | Coverage `./internal/...` | Pass — 85.5% (floor 80%) |
 | Build (`CGO_ENABLED=0`) | Pass |
-| `golangci-lint` | **Skipped — not installed** |
-| `gosec` | **Skipped — not installed** |
+| `golangci-lint` (v2.12.2) | Pass — `0 issues` repo-wide |
+| `gosec` | Pass — `gosec ./...` → `0 issues`, 34 files, 4,468 lines |
 
-`golangci-lint` and `gosec` are named in the plan's validation section and could not be run on
-this machine. They should run in CI or locally before merge; this review does not substitute
-for them.
+Both were run after the initial review, once the tools were installed.
+
+Worth stating precisely, because the two tools disagree at first glance: `gosec ./...` skips
+`_test.go` files by default. `gosec -tests ./...` reports 5 findings and
+`golangci-lint --enable gosec` reports 4 of the same set. All are in Phase 1–2 test files this
+phase never touched — `certs/ca_test.go:346,367` and `certs/store_test.go:141,163` (G306,
+fixtures writing `0o644` into a temp dir), `state/pairing_test.go:126` (G115,
+`string(rune('a'+n))`). Production code is clean under both tools. Left out of this PR to avoid
+widening the diff; worth a separate cleanup.
 
 ## Files Reviewed
 
@@ -120,7 +126,8 @@ Docs: `README.md`, `go.mod`
 
 ## Recommendation
 
-Approve for merge into `dev` once `golangci-lint` and `gosec` have run clean, and once the
-manual validation checklist has been worked against a host with a live Docker daemon — in
-particular the `-e DB_PASSWORD=hunter2` end-to-end secret check, which is the one assertion
-that closes the loop on this phase's central risk. M4 needs a decision but does not block.
+Approve for merge into `dev` once the manual validation checklist has been worked against a host
+with a live Docker daemon — in particular the `-e DB_PASSWORD=hunter2` end-to-end secret check,
+which is the one assertion that closes the loop on this phase's central risk. `golangci-lint`
+and `gosec` have since run clean against this phase's code. M4 needs a decision but does not
+block.

--- a/.claude/PRPs/reviews/read-operations-review.md
+++ b/.claude/PRPs/reviews/read-operations-review.md
@@ -64,6 +64,12 @@ plan's checklist line is now inaccurate and someone should decide deliberately: 
 it and correct the expectation, or template the path in the log. Flagged rather than silently
 resolved.
 
+**Confirmed empirically during E2E validation.** The agent's Debug log carries entries like
+`path=/v1/containers/cb6831df964c…` — the full reference. It carries no secrets: across the
+entire run there were zero hits for env values, private key material, or pairing codes. So the
+project's "never log key material" rule holds; only the checklist's stricter "no reference
+values" wording is contradicted. Still a decision, not a defect.
+
 ### LOW
 
 **L1** — `toContainerDetail` is 58 lines, over the project's 50-line guideline. Flat, not
@@ -126,8 +132,10 @@ Docs: `README.md`, `go.mod`
 
 ## Recommendation
 
-Approve for merge into `dev` once the manual validation checklist has been worked against a host
-with a live Docker daemon — in particular the `-e DB_PASSWORD=hunter2` end-to-end secret check,
-which is the one assertion that closes the loop on this phase's central risk. `golangci-lint`
-and `gosec` have since run clean against this phase's code. M4 needs a decision but does not
-block.
+**Approve for merge into `dev`.** Every precondition this review named has since been met:
+`golangci-lint` and `gosec` run clean, and the full manual checklist has been worked against
+Docker 29.6.1 / API 1.55 with a real paired device — including the `-e DB_PASSWORD=hunter2`
+check, which is the assertion that closes the loop on this phase's central risk. The response
+was 698 bytes and contained neither the secret nor an `env` key.
+
+M4 needs a decision but does not block; it is now backed by evidence rather than inference.

--- a/.claude/PRPs/reviews/read-operations-review.md
+++ b/.claude/PRPs/reviews/read-operations-review.md
@@ -1,0 +1,126 @@
+# Code Review: Read Operations (Phase 3)
+
+**Reviewed**: 2026-08-08
+**Branch**: `feat/read-operations` → `dev` (uncommitted working tree)
+**Reviewers**: `ecc:security-reviewer`, `ecc:go-reviewer`, plus main-session verification of every claim
+**Decision**: **APPROVE with comments** — no CRITICAL or HIGH findings
+
+## Summary
+
+The phase's stated security weight — D1/D2, that no secret ever leaves the agent — is enforced
+*structurally* rather than by convention: the DTOs have no field an env var or volume driver
+option could travel through, and that is proven by tests asserting on marshalled JSON rather
+than on struct fields. Reference validation runs before every SDK call. Middleware ordering is
+correct on all eight routes. Two MEDIUM findings were confirmed and fixed during review; the
+rest are notes.
+
+## Findings
+
+### CRITICAL
+None.
+
+### HIGH
+None.
+
+### MEDIUM
+
+**M1 — Unguarded zero timestamp produced a false date. FIXED.**
+`internal/dockerx/containers.go` (`toContainerSummary`) and `images.go` (`toImageSummary`)
+called `time.Unix(s.Created, 0).UTC().Format(time.RFC3339)` with no zero guard, so an Engine
+value of `0` emitted `"1970-01-01T00:00:00Z"` — a plausible-looking but false timestamp the
+Android client would render as a real date. The file already had the right pattern for this
+class of problem (`zeroTimeToEmpty`).
+*Fix*: added `unixToRFC3339(sec int64) string` returning `""` for `0`; used in both mappers.
+Tests added for the zero case in both.
+
+**M2 — Duplicated truncation and labels-default logic. FIXED.**
+The four-line truncation block was copy-pasted verbatim across all four list methods, and the
+`if labels == nil { labels = map[string]string{} }` pattern appeared five times. Confirmed by
+inspection, not assumed.
+*Fix*: extracted `truncate[T any](items []T) ([]T, bool)` and `defaultLabels(...)` into a new
+`internal/dockerx/list.go`, along with the `maxListItems` const. `callTimeout` deliberately
+stayed in `containers.go` — it governs inspect calls too, so filing it under listing helpers
+would have been misleading. Behaviour is identical; the boundary is still
+`len(items) > maxListItems`.
+
+**M3 — Truncation tests re-implement production logic. NOT FIXED (accepted).**
+Four tests assert truncation against a hand-copied `if len(items) > maxListItems` over a
+synthetic slice rather than calling the real method. If production truncation diverged, none
+would catch it. Left in place because `TestEngineListTruncation` covers the real call path
+through a fake Engine with 500/501 fixtures, so the property *is* genuinely tested; the
+synthetic tests are redundant rather than wrong. Worth deleting in a future cleanup.
+
+**M4 — Request log now records caller-supplied references. NOT FIXED (needs a decision).**
+`internal/httpapi/middleware.go` `withRequestLog` logs `r.URL.Path` at Debug. Its doc comment
+promises "method, path, status, and duration only", and the plan's own manual-validation
+checklist asserts `agent.log` carries "no container names, no reference values". Phase 3 adds
+routes with path parameters (`/v1/containers/{id}`, `/v1/volumes/{name}`), so the logged path
+now contains whatever reference the caller sent. The middleware is pre-existing Phase 2 code
+and was not modified here — this phase changed what it *means*.
+
+Not changed, because container IDs and volume names are not secrets, this is Debug-only, and
+redacting the path segment would meaningfully degrade the log's diagnostic value. But the
+plan's checklist line is now inaccurate and someone should decide deliberately: either accept
+it and correct the expectation, or template the path in the log. Flagged rather than silently
+resolved.
+
+### LOW
+
+**L1** — `toContainerDetail` is 58 lines, over the project's 50-line guideline. Flat, not
+nested; each guard block reads as part of one cohesive unit. Splitting it to hit the number
+would hurt readability. Left as-is.
+
+**L2 (INFO, no action)** — `ValidateRef` excludes `:`, so `GET /v1/images/{id}` cannot inspect
+an image by digest. The `go-reviewer` raised this as "confirm against the client contract".
+It is already settled: plan decision D6 and Task 3 both call for digest refs to fail, with a
+test asserting it specifically so nobody widens the pattern later. Not an open question.
+
+## Verified Properties
+
+Each of these was checked against the source directly, not accepted on a reviewer's word:
+
+- No `.Env` or `.Options` field access anywhere in production `dockerx` code — only doc comments.
+- `ValidateRef` is the first statement in all four inspect methods, before any Engine call;
+  `engine_test.go` proves an invalid ref reaches the Engine **zero** times.
+- The regexp is anchored; Go's RE2 binds `^`/`$` to string boundaries with no multiline flag,
+  so an embedded-newline bypass is not possible.
+- All eight routes register as `requireDevice(requireOp(policy.OpRead, h))` — auth outside,
+  policy inside, so an unauthenticated caller cannot probe the policy tier via 403-vs-401.
+- Error bodies are terse; `TestErrorBodiesLeakNothing` asserts the state dir, `docker.sock`,
+  and `devmon.db` appear in none of the 400/401/404/405/502 responses.
+- Every Engine call derives a 15s timeout with `defer cancel()`; no leaked context on the
+  validation-failure early-return path.
+- Nil guards on every optional pointer, with tests that exercise the nil path rather than
+  fully-populated fixtures.
+- 500-item cap is a package constant, not derived from any request input.
+
+## Validation Results
+
+| Check | Result |
+|---|---|
+| `go vet ./...` | Pass |
+| `gofmt` (changed files) | Pass |
+| Tests (`go test ./... -race`) | Pass |
+| Coverage `./internal/...` | Pass — 85.5% (floor 80%) |
+| Build (`CGO_ENABLED=0`) | Pass |
+| `golangci-lint` | **Skipped — not installed** |
+| `gosec` | **Skipped — not installed** |
+
+`golangci-lint` and `gosec` are named in the plan's validation section and could not be run on
+this machine. They should run in CI or locally before merge; this review does not substitute
+for them.
+
+## Files Reviewed
+
+Production: `internal/dockerx/{types,errors,ref,containers,images,networks,volumes,list}.go`,
+`internal/httpapi/{reads,policygate,server}.go`, `cmd/devmon-agent/main.go`
+Tests: `internal/dockerx/{types,errors,ref,containers,objects,engine}_test.go`,
+`internal/httpapi/{reads,policygate,server,status,pair}_test.go`
+Docs: `README.md`, `go.mod`
+
+## Recommendation
+
+Approve for merge into `dev` once `golangci-lint` and `gosec` have run clean, and once the
+manual validation checklist has been worked against a host with a live Docker daemon — in
+particular the `-e DB_PASSWORD=hunter2` end-to-end secret check, which is the one assertion
+that closes the loop on this phase's central risk. M4 needs a decision but does not block.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,52 @@ than failing obscurely at the first query.
 | `POST /v1/pair` | pairing code | Exchange a CSR for a client certificate |
 | `POST /v1/device/renew` | client cert | Exchange a CSR for a fresh certificate |
 | `DELETE /v1/device/self` | client cert | Unpair this device |
+| `GET /v1/containers?all=<bool>` | client cert | List containers; `all=true` includes stopped ones |
+| `GET /v1/containers/{id}` | client cert | Inspect one container |
+| `GET /v1/images` | client cert | List images |
+| `GET /v1/images/{id}` | client cert | Inspect one image |
+| `GET /v1/networks` | client cert | List networks |
+| `GET /v1/networks/{id}` | client cert | Inspect one network |
+| `GET /v1/volumes` | client cert | List volumes |
+| `GET /v1/volumes/{name}` | client cert | Inspect one volume |
+
+Failure modes shared by every read route:
+
+| Condition | Status | Body |
+|---|---|---|
+| No, unknown, or revoked client certificate | 401 | `{"error":"client certificate required"}` |
+| Host policy forbids the operation | 403 | `{"error":"operation not permitted by host policy"}` |
+| Malformed object reference | 400 | `{"error":"invalid object reference"}` |
+| No such object | 404 | `{"error":"not found"}` |
+| Engine unreachable, timed out, or otherwise failing | 502 | `{"error":"docker engine unavailable"}` |
+
+502 rather than 500 is deliberate: the Engine is an upstream dependency, so its
+failures are gateway failures. That keeps 500 meaning "the agent itself broke",
+which is a different page for whoever is on call.
+
+### Why responses are projections
+
+Read responses are not the Docker Engine's JSON. Every field is copied into an
+explicit allowlist type before it is serialised, so what the API returns is a
+decision rather than a consequence of whatever the Engine emits this release.
+
+**Environment variables are never returned, at any level.** A container's
+`Config.Env` and an image's baked-in env hold the database passwords and API
+keys the operator passed in, and this channel was never designed to carry them.
+Redacting values would still disclose which secrets exist and what they are
+called, so the fields simply do not exist in the response types. The same
+reasoning removes a volume's driver `Options`, which routinely carry NFS and
+CIFS credentials.
+
+**Command lines are returned.** Unlike env vars, the command, entrypoint, and
+args are what identify a misconfigured container, and they are already visible
+in the host's process table and in `docker ps`. This is a bounded, deliberate
+disclosure rather than an oversight.
+
+**Lists are capped at 500 items** and carry a `truncated` flag. A host with
+thousands of images would otherwise send a multi-megabyte body to a phone on a
+mobile connection. The cap is server-side and cannot be raised by a client,
+which is the same rule the rest of the agent's configuration follows.
 
 `/v1/status` is the only endpoint served without a client certificate. Its fields
 are a strict allowlist — it may inform, never issue — and it carries no host,

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -161,7 +161,7 @@ func serve(ctx context.Context, cfg config.Config, sink *logging.Sink, log *slog
 	// Client CAs come from the agent's own certificate authority: a device's
 	// client certificate is verified against ca.Pool() at the handshake.
 	tlsCfg := tlsconf.Build(cert, ca.Pool())
-	srv := httpapi.NewServer(cfg, st, ca, tlsCfg, log)
+	srv := httpapi.NewServer(cfg, st, ca, dc, tlsCfg, log)
 	pruner := state.NewPruner(st, cfg.AuditMaxAge, cfg.AuditMaxRows, log)
 
 	log.Info("agent listening",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/scnplt/devmon-agent
 go 1.26.4
 
 require (
+	github.com/containerd/errdefs v1.0.0
+	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.56.0
@@ -10,7 +12,6 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
@@ -22,7 +23,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/internal/dockerx/containers.go
+++ b/internal/dockerx/containers.go
@@ -1,0 +1,253 @@
+package dockerx
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+)
+
+// callTimeout bounds every Engine call. The HTTP server's WriteTimeout is 30s;
+// a wedged Engine must become a 502 the agent controls rather than a response
+// that dies mid-body on the client.
+const callTimeout = 15 * time.Second
+
+// ListContainers returns every container on the host, or only running ones
+// when all is false, capped at maxListItems.
+func (c *Client) ListContainers(ctx context.Context, all bool) (ListResult[ContainerSummary], error) {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	res, err := c.api.ContainerList(ctx, client.ContainerListOptions{All: all})
+	if err != nil {
+		return ListResult[ContainerSummary]{}, classify("list containers", err)
+	}
+
+	items := make([]ContainerSummary, 0, len(res.Items))
+	for _, s := range res.Items {
+		items = append(items, toContainerSummary(s))
+	}
+
+	items, truncated := truncate(items)
+
+	return ListResult[ContainerSummary]{Items: items, Truncated: truncated}, nil
+}
+
+// InspectContainer returns the full projection of a single container. ref is
+// validated before any Engine call reaches out over the network.
+func (c *Client) InspectContainer(ctx context.Context, ref string) (ContainerDetail, error) {
+	if err := ValidateRef(ref); err != nil {
+		return ContainerDetail{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	// Size: false — calculating the container's filesystem size walks the
+	// filesystem and is not needed for this projection.
+	res, err := c.api.ContainerInspect(ctx, ref, client.ContainerInspectOptions{})
+	if err != nil {
+		return ContainerDetail{}, classify("inspect container", err)
+	}
+
+	return toContainerDetail(res.Container), nil
+}
+
+// toContainerSummary projects a container.Summary onto the allowlisted DTO.
+// s.Health and s.NetworkSettings are nil for ordinary containers (no
+// healthcheck, no attached network) and must be guarded.
+func toContainerSummary(s container.Summary) ContainerSummary {
+	var health string
+	if s.Health != nil {
+		health = string(s.Health.Status)
+	}
+
+	ports := make([]Port, 0, len(s.Ports))
+	for _, p := range s.Ports {
+		ports = append(ports, toPort(p))
+	}
+
+	names := make([]string, 0, len(s.Names))
+	names = append(names, s.Names...)
+
+	return ContainerSummary{
+		ID:        s.ID,
+		Names:     names,
+		Image:     s.Image,
+		ImageID:   s.ImageID,
+		Command:   s.Command,
+		CreatedAt: unixToRFC3339(s.Created),
+		State:     string(s.State),
+		Status:    s.Status,
+		Health:    health,
+		Labels:    defaultLabels(s.Labels),
+		Ports:     ports,
+	}
+}
+
+// toContainerDetail projects a container.InspectResponse onto the allowlisted
+// DTO. State, Config, and HostConfig are all nil in ordinary real-world cases
+// (a container mid-creation, an image with no config, a restore of an old
+// record) and must be guarded individually.
+func toContainerDetail(r container.InspectResponse) ContainerDetail {
+	d := ContainerDetail{
+		ID:           r.ID,
+		Name:         r.Name,
+		Image:        r.Image,
+		CreatedAt:    r.Created,
+		Command:      r.Path,
+		Platform:     r.Platform,
+		RestartCount: r.RestartCount,
+		Mounts:       toMounts(r.Mounts),
+	}
+
+	args := make([]string, 0, len(r.Args))
+	args = append(args, r.Args...)
+	d.Args = args
+
+	if r.State != nil {
+		d.State = string(r.State.Status)
+		d.Running = r.State.Running
+		d.Paused = r.State.Paused
+		d.Restarting = r.State.Restarting
+		d.ExitCode = r.State.ExitCode
+		d.StartedAt = zeroTimeToEmpty(r.State.StartedAt)
+		d.FinishedAt = zeroTimeToEmpty(r.State.FinishedAt)
+		if r.State.Health != nil {
+			d.Health = string(r.State.Health.Status)
+		}
+	}
+
+	if r.Config != nil {
+		d.Labels = r.Config.Labels
+		d.WorkingDir = r.Config.WorkingDir
+		d.User = r.Config.User
+		entrypoint := make([]string, 0, len(r.Config.Entrypoint))
+		entrypoint = append(entrypoint, r.Config.Entrypoint...)
+		d.Entrypoint = entrypoint
+	}
+	d.Labels = defaultLabels(d.Labels)
+
+	if r.HostConfig != nil {
+		d.RestartPolicy = string(r.HostConfig.RestartPolicy.Name)
+	}
+
+	if r.NetworkSettings != nil {
+		d.Networks = toEndpointSummaries(r.NetworkSettings.Networks)
+		d.Ports = toPortsFromPortMap(r.NetworkSettings.Ports)
+	}
+	if d.Networks == nil {
+		d.Networks = make([]EndpointSummary, 0)
+	}
+	if d.Ports == nil {
+		d.Ports = make([]Port, 0)
+	}
+
+	return d
+}
+
+// zeroTimeToEmpty returns "" for a container timestamp that Docker reports as
+// the zero RFC3339Nano value ("0001-01-01T00:00:00Z"), which means "never
+// started" or "never finished" rather than an actual timestamp.
+func zeroTimeToEmpty(ts string) string {
+	if ts == "" || ts[:4] == "0001" {
+		return ""
+	}
+	return ts
+}
+
+// toPort projects a container.PortSummary onto the allowlisted DTO. IP is
+// netip.Addr, not a string, and is the zero value (invalid) for ports that
+// are exposed but not published to the host.
+func toPort(p container.PortSummary) Port {
+	var ip string
+	if p.IP.IsValid() {
+		ip = p.IP.String()
+	}
+	return Port{
+		IP:          ip,
+		PrivatePort: p.PrivatePort,
+		PublicPort:  p.PublicPort,
+		Protocol:    p.Type,
+	}
+}
+
+// toMounts projects a container's mount points onto the allowlisted DTO.
+func toMounts(mounts []container.MountPoint) []Mount {
+	out := make([]Mount, 0, len(mounts))
+	for _, m := range mounts {
+		out = append(out, Mount{
+			Type:        string(m.Type),
+			Name:        m.Name,
+			Source:      m.Source,
+			Destination: m.Destination,
+			ReadWrite:   m.RW,
+		})
+	}
+	return out
+}
+
+// toPortsFromPortMap projects an inspected container's port bindings onto the
+// allowlisted DTO. A container port with no host binding still has an entry
+// in the map, keyed by its exposed port, with a nil/empty binding slice.
+func toPortsFromPortMap(ports network.PortMap) []Port {
+	out := make([]Port, 0, len(ports))
+	for port, bindings := range ports {
+		if len(bindings) == 0 {
+			out = append(out, Port{
+				PrivatePort: port.Num(),
+				Protocol:    string(port.Proto()),
+			})
+			continue
+		}
+		for _, b := range bindings {
+			var ip string
+			if b.HostIP.IsValid() {
+				ip = b.HostIP.String()
+			}
+			var publicPort uint16
+			if n, err := strconv.ParseUint(b.HostPort, 10, 16); err == nil {
+				publicPort = uint16(n)
+			}
+			out = append(out, Port{
+				IP:          ip,
+				PrivatePort: port.Num(),
+				PublicPort:  publicPort,
+				Protocol:    string(port.Proto()),
+			})
+		}
+	}
+	return out
+}
+
+// toEndpointSummaries projects a container's per-network attachments onto the
+// allowlisted DTO. Map values can be nil even when the map itself is not.
+func toEndpointSummaries(networks map[string]*network.EndpointSettings) []EndpointSummary {
+	out := make([]EndpointSummary, 0, len(networks))
+	for name, ep := range networks {
+		if ep == nil {
+			continue
+		}
+		var ipAddress, gateway string
+		if ep.IPAddress.IsValid() {
+			ipAddress = ep.IPAddress.String()
+		}
+		if ep.Gateway.IsValid() {
+			gateway = ep.Gateway.String()
+		}
+		aliases := make([]string, 0, len(ep.Aliases))
+		aliases = append(aliases, ep.Aliases...)
+		out = append(out, EndpointSummary{
+			NetworkName: name,
+			NetworkID:   ep.NetworkID,
+			IPAddress:   ipAddress,
+			Gateway:     gateway,
+			MACAddress:  ep.MacAddress.String(),
+			Aliases:     aliases,
+		})
+	}
+	return out
+}

--- a/internal/dockerx/containers_test.go
+++ b/internal/dockerx/containers_test.go
@@ -1,0 +1,364 @@
+package dockerx
+
+import (
+	"encoding/json"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+)
+
+// TestToContainerSummaryZeroValue covers a container.Summary with every
+// pointer field nil, which is the ordinary shape the Engine returns for a
+// container with no healthcheck and no attached network. A fully-populated
+// fixture would never exercise the nil-guards that a real host triggers.
+func TestToContainerSummaryZeroValue(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := container.Summary{}
+
+	// Act
+	got := toContainerSummary(s)
+
+	// Assert
+	if got.Health != "" {
+		t.Errorf("got.Health = %q, want empty", got.Health)
+	}
+	if got.Ports == nil {
+		t.Error("got.Ports = nil, want empty non-nil slice")
+	}
+	if len(got.Ports) != 0 {
+		t.Errorf("len(got.Ports) = %d, want 0", len(got.Ports))
+	}
+	if got.Names == nil {
+		t.Error("got.Names = nil, want empty non-nil slice")
+	}
+	if got.Labels == nil {
+		t.Error("got.Labels = nil, want empty non-nil map")
+	}
+}
+
+// TestToContainerDetailNilState covers an InspectResponse whose State,
+// Config, and HostConfig are all nil. This is an ordinary shape (e.g. a
+// container mid-creation) and must not panic.
+func TestToContainerDetailNilState(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	r := container.InspectResponse{
+		ID:         "abc123",
+		State:      nil,
+		Config:     nil,
+		HostConfig: nil,
+	}
+
+	// Act
+	got := toContainerDetail(r)
+
+	// Assert
+	if got.State != "" {
+		t.Errorf("got.State = %q, want empty", got.State)
+	}
+	if got.Running {
+		t.Error("got.Running = true, want false")
+	}
+	if got.Health != "" {
+		t.Errorf("got.Health = %q, want empty", got.Health)
+	}
+	if got.RestartPolicy != "" {
+		t.Errorf("got.RestartPolicy = %q, want empty", got.RestartPolicy)
+	}
+	if got.Labels == nil {
+		t.Error("got.Labels = nil, want empty non-nil map")
+	}
+	if got.Networks == nil {
+		t.Error("got.Networks = nil, want empty non-nil slice")
+	}
+	if got.Ports == nil {
+		t.Error("got.Ports = nil, want empty non-nil slice")
+	}
+	if got.Args == nil {
+		t.Error("got.Args = nil, want empty non-nil slice")
+	}
+}
+
+// TestToContainerSummaryCreatedAt covers the int64 Unix-seconds to RFC3339
+// UTC conversion for container.Summary.Created.
+func TestToContainerSummaryCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := container.Summary{Created: 1700000000}
+
+	// Act
+	got := toContainerSummary(s)
+
+	// Assert
+	want := "2023-11-14T22:13:20Z"
+	if got.CreatedAt != want {
+		t.Errorf("got.CreatedAt = %q, want %q", got.CreatedAt, want)
+	}
+}
+
+// TestToContainerSummaryCreatedAtZero covers container.Summary.Created being
+// 0 (the Engine's "no creation time to report" value), which must not be
+// formatted as the Unix epoch.
+func TestToContainerSummaryCreatedAtZero(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := container.Summary{Created: 0}
+
+	// Act
+	got := toContainerSummary(s)
+
+	// Assert
+	if got.CreatedAt != "" {
+		t.Errorf("got.CreatedAt = %q, want empty", got.CreatedAt)
+	}
+}
+
+// TestToContainerDetailCreatedAtPassthrough covers InspectResponse.Created,
+// which is already an RFC3339Nano string and must not be reformatted.
+func TestToContainerDetailCreatedAtPassthrough(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	r := container.InspectResponse{Created: "2023-11-14T22:13:20.123456789Z"}
+
+	// Act
+	got := toContainerDetail(r)
+
+	// Assert
+	want := "2023-11-14T22:13:20.123456789Z"
+	if got.CreatedAt != want {
+		t.Errorf("got.CreatedAt = %q, want %q", got.CreatedAt, want)
+	}
+}
+
+// TestToPortInvalidIP covers a container.PortSummary whose IP is the zero
+// netip.Addr, which happens for a port that is exposed but not published to
+// the host.
+func TestToPortInvalidIP(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	p := container.PortSummary{
+		IP:          netip.Addr{},
+		PrivatePort: 8080,
+		Type:        "tcp",
+	}
+
+	// Act
+	got := toPort(p)
+
+	// Assert
+	if got.IP != "" {
+		t.Errorf("got.IP = %q, want empty for an invalid netip.Addr", got.IP)
+	}
+	if got.PrivatePort != 8080 {
+		t.Errorf("got.PrivatePort = %d, want 8080", got.PrivatePort)
+	}
+	if got.Protocol != "tcp" {
+		t.Errorf("got.Protocol = %q, want tcp", got.Protocol)
+	}
+}
+
+// TestToPortValidIP covers a container.PortSummary with a valid published
+// host IP, asserting the protocol comes from Type, not a nonexistent
+// Protocol field.
+func TestToPortValidIP(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	addr := netip.MustParseAddr("127.0.0.1")
+	p := container.PortSummary{
+		IP:          addr,
+		PrivatePort: 8080,
+		PublicPort:  8081,
+		Type:        "udp",
+	}
+
+	// Act
+	got := toPort(p)
+
+	// Assert
+	if got.IP != "127.0.0.1" {
+		t.Errorf("got.IP = %q, want 127.0.0.1", got.IP)
+	}
+	if got.PublicPort != 8081 {
+		t.Errorf("got.PublicPort = %d, want 8081", got.PublicPort)
+	}
+	if got.Protocol != "udp" {
+		t.Errorf("got.Protocol = %q, want udp", got.Protocol)
+	}
+}
+
+// TestToContainerSummaryHealthAndNetworkSettings covers the non-nil branches
+// of Health and NetworkSettings, which the zero-value test above deliberately
+// does not exercise.
+func TestToContainerSummaryHealthAndNetworkSettings(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := container.Summary{
+		Health: &container.HealthSummary{Status: container.Unhealthy},
+	}
+
+	// Act
+	got := toContainerSummary(s)
+
+	// Assert
+	if got.Health != string(container.Unhealthy) {
+		t.Errorf("got.Health = %q, want %q", got.Health, container.Unhealthy)
+	}
+}
+
+// TestToContainerDetailFullState covers a fully-populated State, Config, and
+// HostConfig, ensuring the non-nil branches project correctly and that no env
+// data leaks into any field.
+func TestToContainerDetailFullState(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	r := container.InspectResponse{
+		ID:      "abc123",
+		Name:    "/api",
+		Image:   "myapp:1.4",
+		Created: "2023-11-14T22:13:20Z",
+		Path:    "/app/server",
+		Args:    []string{"--port", "8080"},
+		State: &container.State{
+			Status:     "running",
+			Running:    true,
+			ExitCode:   0,
+			StartedAt:  "2023-11-14T22:13:21Z",
+			FinishedAt: "0001-01-01T00:00:00Z",
+			Health:     &container.Health{Status: container.Healthy},
+		},
+		Config: &container.Config{
+			Env:        []string{"DB_PASSWORD=hunter2"},
+			WorkingDir: "/app",
+			User:       "nobody",
+			Labels:     map[string]string{"app": "myapp"},
+			Entrypoint: []string{"/entrypoint.sh"},
+		},
+		HostConfig: &container.HostConfig{
+			RestartPolicy: container.RestartPolicy{Name: "always"},
+		},
+		NetworkSettings: &container.NetworkSettings{
+			Networks: map[string]*network.EndpointSettings{
+				"bridge": {
+					NetworkID: "net1",
+					IPAddress: netip.MustParseAddr("172.17.0.2"),
+				},
+				"nil-value": nil,
+			},
+			Ports: network.PortMap{
+				network.MustParsePort("8080/tcp"): {
+					{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "8081"},
+				},
+				network.MustParsePort("9090/udp"): {}, // exposed, not published
+			},
+		},
+	}
+
+	// Act
+	got := toContainerDetail(r)
+
+	// Assert
+	if got.FinishedAt != "" {
+		t.Errorf("got.FinishedAt = %q, want empty for the zero timestamp", got.FinishedAt)
+	}
+	if got.StartedAt != "2023-11-14T22:13:21Z" {
+		t.Errorf("got.StartedAt = %q, want 2023-11-14T22:13:21Z", got.StartedAt)
+	}
+	if got.Health != string(container.Healthy) {
+		t.Errorf("got.Health = %q, want %q", got.Health, container.Healthy)
+	}
+	if got.RestartPolicy != "always" {
+		t.Errorf("got.RestartPolicy = %q, want always", got.RestartPolicy)
+	}
+	if len(got.Networks) != 1 {
+		t.Fatalf("len(got.Networks) = %d, want 1 (the nil map value must be skipped)", len(got.Networks))
+	}
+	if got.Networks[0].IPAddress != "172.17.0.2" {
+		t.Errorf("got.Networks[0].IPAddress = %q, want 172.17.0.2", got.Networks[0].IPAddress)
+	}
+	if len(got.Ports) != 2 {
+		t.Fatalf("len(got.Ports) = %d, want 2", len(got.Ports))
+	}
+	var sawBound, sawUnbound bool
+	for _, p := range got.Ports {
+		switch {
+		case p.PrivatePort == 8080 && p.PublicPort == 8081 && p.IP == "0.0.0.0" && p.Protocol == "tcp":
+			sawBound = true
+		case p.PrivatePort == 9090 && p.PublicPort == 0 && p.IP == "" && p.Protocol == "udp":
+			sawUnbound = true
+		}
+	}
+	if !sawBound {
+		t.Errorf("got.Ports = %+v, want a bound 8080/tcp -> 0.0.0.0:8081 entry", got.Ports)
+	}
+	if !sawUnbound {
+		t.Errorf("got.Ports = %+v, want an unbound 9090/udp entry", got.Ports)
+	}
+
+	// The highest-value assertion in this test: no env var name or value
+	// anywhere in the marshalled JSON, at any nesting depth.
+	bodyBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(got) error = %v", err)
+	}
+	body := string(bodyBytes)
+	if strings.Contains(body, "hunter2") || strings.Contains(body, "DB_PASSWORD") || strings.Contains(body, `"env"`) {
+		t.Errorf("marshalled ContainerDetail leaks env data: %s", body)
+	}
+}
+
+// TestListContainersTruncation covers the boundary and over-the-boundary
+// truncation cases without a live daemon: the mapping and truncation logic is
+// exercised directly rather than through the SDK.
+func TestListContainersTruncation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		count         int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{name: "under the cap", count: 3, wantLen: 3, wantTruncated: false},
+		{name: "exactly at the cap", count: maxListItems, wantLen: maxListItems, wantTruncated: false},
+		{name: "over the cap", count: maxListItems + 1, wantLen: maxListItems, wantTruncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			items := make([]ContainerSummary, 0, tt.count)
+			for i := 0; i < tt.count; i++ {
+				items = append(items, ContainerSummary{})
+			}
+
+			// Act
+			truncated := false
+			if len(items) > maxListItems {
+				items, truncated = items[:maxListItems], true
+			}
+
+			// Assert
+			if len(items) != tt.wantLen {
+				t.Errorf("len(items) = %d, want %d", len(items), tt.wantLen)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+		})
+	}
+}

--- a/internal/dockerx/engine_test.go
+++ b/internal/dockerx/engine_test.go
@@ -1,0 +1,656 @@
+package dockerx
+
+// This file exercises the eight Engine-calling wrapper methods (List/Inspect
+// for containers, images, networks, and volumes) against a fake Docker
+// Engine, without a live daemon.
+//
+// Rather than an httptest.Server (a real listening socket), the fake Engine
+// is an in-process http.RoundTripper backed by an http.ServeMux: requests
+// never leave the process, there is no port to bind, and version-prefixed
+// paths ("/v1.55/containers/json") are normalized before routing so each
+// route table only needs to name the unprefixed Engine path. client.New is
+// still exercised exactly as production code calls it (client.New(opts...)),
+// only the transport is swapped via the SDK's own exported client.WithHTTPClient
+// option; dockerx.New's Ping/negotiation path is already covered by
+// client_test.go and is not re-tested here.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/client"
+)
+
+// versionPrefix matches the negotiated API version segment ("/v1.55/...")
+// the moby client prepends to every request path.
+var versionPrefix = regexp.MustCompile(`^/v[0-9]+\.[0-9]+`)
+
+func stripVersion(path string) string {
+	return versionPrefix.ReplaceAllString(path, "")
+}
+
+// callRecorder counts Engine requests so a test can prove the Engine was, or
+// was not, contacted.
+type callRecorder struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (r *callRecorder) record() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.count++
+}
+
+func (r *callRecorder) Count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.count
+}
+
+// roundTripFunc adapts a function to http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+// newFakeEngine builds a *Client whose Engine calls are served in-process by
+// routes, keyed by method-prefixed pattern ("GET /containers/json") exactly
+// like internal/httpapi's own route registration. It returns a recorder of
+// every request the Engine transport received.
+func newFakeEngine(t *testing.T, routes map[string]http.HandlerFunc) (*Client, *callRecorder) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	for pattern, h := range routes {
+		mux.HandleFunc(pattern, h)
+	}
+
+	rec := &callRecorder{}
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rec.record()
+
+		r2 := req.Clone(req.Context())
+		r2.URL.Path = stripVersion(req.URL.Path)
+		r2.URL.RawPath = ""
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r2)
+		res := w.Result()
+		res.Request = req
+		return res, nil
+	})
+
+	api, err := client.New(client.WithHTTPClient(&http.Client{Transport: rt}))
+	if err != nil {
+		t.Fatalf("client.New() error = %v, want nil", err)
+	}
+
+	return &Client{api: api, log: testLogger()}, rec
+}
+
+// jsonHandler answers every request with status and body JSON-encoded.
+func jsonHandler(status int, body any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+// errorHandler answers every request with a bare status code, the shape the
+// Engine uses for failures. errhttp.ToNative classifies the sentinel purely
+// from the status code, so no Engine-style JSON error body is required.
+func errorHandler(status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "simulated engine failure", status)
+	}
+}
+
+// opSpec names one of the eight Engine-calling wrapper methods so the
+// classification, generic-failure, and empty-list tests can iterate all
+// eight without duplicating the route wiring per method.
+type opSpec struct {
+	name   string
+	method string
+
+	// pathFor returns the version-stripped Engine path the method requests.
+	// List operations ignore ref.
+	pathFor func(ref string) string
+
+	// callList runs a list operation, reporting the item count, whether the
+	// Items slice is non-nil, and Truncated. nil for inspect operations.
+	callList func(ctx context.Context, c *Client) (itemsLen int, itemsNonNil, truncated bool, err error)
+
+	// callInspect runs an inspect operation against ref, discarding the
+	// mapped result. nil for list operations.
+	callInspect func(ctx context.Context, c *Client, ref string) error
+}
+
+// route returns the method-prefixed ServeMux pattern for ref, used to wire a
+// single-endpoint fake Engine for this spec.
+func (s opSpec) route(ref string) string {
+	return s.method + " " + s.pathFor(ref)
+}
+
+// run exercises the spec end-to-end (list or inspect, whichever this spec
+// is) against ref, and returns only the resulting error. Used by the tests
+// that don't care about the mapped payload, only the error path.
+func (s opSpec) run(ctx context.Context, c *Client, ref string) error {
+	if s.callList != nil {
+		_, _, _, err := s.callList(ctx, c)
+		return err
+	}
+	return s.callInspect(ctx, c, ref)
+}
+
+func opSpecs() []opSpec {
+	return []opSpec{
+		{
+			name:    "ListContainers",
+			method:  http.MethodGet,
+			pathFor: func(string) string { return "/containers/json" },
+			callList: func(ctx context.Context, c *Client) (int, bool, bool, error) {
+				res, err := c.ListContainers(ctx, true)
+				return len(res.Items), res.Items != nil, res.Truncated, err
+			},
+		},
+		{
+			name:    "InspectContainer",
+			method:  http.MethodGet,
+			pathFor: func(ref string) string { return "/containers/" + ref + "/json" },
+			callInspect: func(ctx context.Context, c *Client, ref string) error {
+				_, err := c.InspectContainer(ctx, ref)
+				return err
+			},
+		},
+		{
+			name:    "ListImages",
+			method:  http.MethodGet,
+			pathFor: func(string) string { return "/images/json" },
+			callList: func(ctx context.Context, c *Client) (int, bool, bool, error) {
+				res, err := c.ListImages(ctx)
+				return len(res.Items), res.Items != nil, res.Truncated, err
+			},
+		},
+		{
+			name:    "InspectImage",
+			method:  http.MethodGet,
+			pathFor: func(ref string) string { return "/images/" + ref + "/json" },
+			callInspect: func(ctx context.Context, c *Client, ref string) error {
+				_, err := c.InspectImage(ctx, ref)
+				return err
+			},
+		},
+		{
+			name:    "ListNetworks",
+			method:  http.MethodGet,
+			pathFor: func(string) string { return "/networks" },
+			callList: func(ctx context.Context, c *Client) (int, bool, bool, error) {
+				res, err := c.ListNetworks(ctx)
+				return len(res.Items), res.Items != nil, res.Truncated, err
+			},
+		},
+		{
+			name:    "InspectNetwork",
+			method:  http.MethodGet,
+			pathFor: func(ref string) string { return "/networks/" + ref },
+			callInspect: func(ctx context.Context, c *Client, ref string) error {
+				_, err := c.InspectNetwork(ctx, ref)
+				return err
+			},
+		},
+		{
+			name:    "ListVolumes",
+			method:  http.MethodGet,
+			pathFor: func(string) string { return "/volumes" },
+			callList: func(ctx context.Context, c *Client) (int, bool, bool, error) {
+				res, err := c.ListVolumes(ctx)
+				return len(res.Items), res.Items != nil, res.Truncated, err
+			},
+		},
+		{
+			name:    "InspectVolume",
+			method:  http.MethodGet,
+			pathFor: func(ref string) string { return "/volumes/" + ref },
+			callInspect: func(ctx context.Context, c *Client, ref string) error {
+				_, err := c.InspectVolume(ctx, ref)
+				return err
+			},
+		},
+	}
+}
+
+// TestEngineHappyPath drives each of the eight wrapper methods through a
+// fake Engine returning one populated object, asserting the wrapper maps the
+// Engine's response onto the expected DTO.
+func TestEngineHappyPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		routes map[string]http.HandlerFunc
+		call   func(t *testing.T, c *Client)
+	}{
+		{
+			name: "ListContainers",
+			routes: map[string]http.HandlerFunc{
+				"GET /containers/json": jsonHandler(http.StatusOK, []container.Summary{
+					{ID: "c1", Names: []string{"/api"}, Image: "myapp:1.4", State: "running", Created: 1700000000},
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.ListContainers(context.Background(), true)
+				// Assert
+				if err != nil {
+					t.Fatalf("ListContainers() error = %v, want nil", err)
+				}
+				if len(got.Items) != 1 {
+					t.Fatalf("len(Items) = %d, want 1", len(got.Items))
+				}
+				if got.Items[0].ID != "c1" {
+					t.Errorf("Items[0].ID = %q, want %q", got.Items[0].ID, "c1")
+				}
+				if got.Items[0].State != "running" {
+					t.Errorf("Items[0].State = %q, want %q", got.Items[0].State, "running")
+				}
+			},
+		},
+		{
+			name: "InspectContainer",
+			routes: map[string]http.HandlerFunc{
+				"GET /containers/ref1/json": jsonHandler(http.StatusOK, container.InspectResponse{
+					ID:    "ref1",
+					Name:  "/api",
+					Image: "myapp:1.4",
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.InspectContainer(context.Background(), "ref1")
+				// Assert
+				if err != nil {
+					t.Fatalf("InspectContainer() error = %v, want nil", err)
+				}
+				if got.ID != "ref1" {
+					t.Errorf("ID = %q, want %q", got.ID, "ref1")
+				}
+				if got.Name != "/api" {
+					t.Errorf("Name = %q, want %q", got.Name, "/api")
+				}
+			},
+		},
+		{
+			name: "ListImages",
+			routes: map[string]http.HandlerFunc{
+				"GET /images/json": jsonHandler(http.StatusOK, []image.Summary{
+					{ID: "img1", RepoTags: []string{"myapp:1.4"}, Created: 1700000000},
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.ListImages(context.Background())
+				// Assert
+				if err != nil {
+					t.Fatalf("ListImages() error = %v, want nil", err)
+				}
+				if len(got.Items) != 1 {
+					t.Fatalf("len(Items) = %d, want 1", len(got.Items))
+				}
+				if got.Items[0].ID != "img1" {
+					t.Errorf("Items[0].ID = %q, want %q", got.Items[0].ID, "img1")
+				}
+			},
+		},
+		{
+			name: "InspectImage",
+			routes: map[string]http.HandlerFunc{
+				"GET /images/ref1/json": jsonHandler(http.StatusOK, image.InspectResponse{
+					ID:           "ref1",
+					Architecture: "amd64",
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.InspectImage(context.Background(), "ref1")
+				// Assert
+				if err != nil {
+					t.Fatalf("InspectImage() error = %v, want nil", err)
+				}
+				if got.ID != "ref1" {
+					t.Errorf("ID = %q, want %q", got.ID, "ref1")
+				}
+				if got.Architecture != "amd64" {
+					t.Errorf("Architecture = %q, want %q", got.Architecture, "amd64")
+				}
+			},
+		},
+		{
+			name: "ListNetworks",
+			routes: map[string]http.HandlerFunc{
+				"GET /networks": jsonHandler(http.StatusOK, []network.Summary{
+					{Network: network.Network{ID: "net1", Name: "bridge", Driver: "bridge"}},
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.ListNetworks(context.Background())
+				// Assert
+				if err != nil {
+					t.Fatalf("ListNetworks() error = %v, want nil", err)
+				}
+				if len(got.Items) != 1 {
+					t.Fatalf("len(Items) = %d, want 1", len(got.Items))
+				}
+				if got.Items[0].Name != "bridge" {
+					t.Errorf("Items[0].Name = %q, want %q", got.Items[0].Name, "bridge")
+				}
+			},
+		},
+		{
+			name: "InspectNetwork",
+			routes: map[string]http.HandlerFunc{
+				"GET /networks/ref1": jsonHandler(http.StatusOK, network.Inspect{
+					Network: network.Network{ID: "ref1", Name: "bridge"},
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.InspectNetwork(context.Background(), "ref1")
+				// Assert
+				if err != nil {
+					t.Fatalf("InspectNetwork() error = %v, want nil", err)
+				}
+				if got.ID != "ref1" {
+					t.Errorf("ID = %q, want %q", got.ID, "ref1")
+				}
+				if got.Name != "bridge" {
+					t.Errorf("Name = %q, want %q", got.Name, "bridge")
+				}
+			},
+		},
+		{
+			name: "ListVolumes",
+			routes: map[string]http.HandlerFunc{
+				"GET /volumes": jsonHandler(http.StatusOK, volume.ListResponse{
+					Volumes: []volume.Volume{{Name: "vol1", Driver: "local"}},
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.ListVolumes(context.Background())
+				// Assert
+				if err != nil {
+					t.Fatalf("ListVolumes() error = %v, want nil", err)
+				}
+				if len(got.Items) != 1 {
+					t.Fatalf("len(Items) = %d, want 1", len(got.Items))
+				}
+				if got.Items[0].Name != "vol1" {
+					t.Errorf("Items[0].Name = %q, want %q", got.Items[0].Name, "vol1")
+				}
+			},
+		},
+		{
+			name: "InspectVolume",
+			routes: map[string]http.HandlerFunc{
+				"GET /volumes/ref1": jsonHandler(http.StatusOK, volume.Volume{
+					Name:   "ref1",
+					Driver: "local",
+				}),
+			},
+			call: func(t *testing.T, c *Client) {
+				// Act
+				got, err := c.InspectVolume(context.Background(), "ref1")
+				// Assert
+				if err != nil {
+					t.Fatalf("InspectVolume() error = %v, want nil", err)
+				}
+				if got.Name != "ref1" {
+					t.Errorf("Name = %q, want %q", got.Name, "ref1")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _ := newFakeEngine(t, tt.routes)
+			tt.call(t, c)
+		})
+	}
+}
+
+// TestEngineListTruncation drives ListContainers through the real call path
+// with 501 and 500 fixture summaries, proving the truncation boundary is
+// applied to what the Engine actually returned, not a synthetic slice.
+func TestEngineListTruncation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		fixtureCount  int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{name: "501 summaries truncates to 500", fixtureCount: 501, wantLen: 500, wantTruncated: true},
+		{name: "500 summaries is the untruncated boundary", fixtureCount: 500, wantLen: 500, wantTruncated: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			summaries := make([]container.Summary, tt.fixtureCount)
+			for i := range summaries {
+				summaries[i] = container.Summary{ID: "c" + string(rune('0'+i%10))}
+			}
+			c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+				"GET /containers/json": jsonHandler(http.StatusOK, summaries),
+			})
+
+			// Act
+			got, err := c.ListContainers(context.Background(), true)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("ListContainers() error = %v, want nil", err)
+			}
+			if len(got.Items) != tt.wantLen {
+				t.Errorf("len(Items) = %d, want %d", len(got.Items), tt.wantLen)
+			}
+			if got.Truncated != tt.wantTruncated {
+				t.Errorf("Truncated = %v, want %v", got.Truncated, tt.wantTruncated)
+			}
+		})
+	}
+}
+
+// TestEngineNotFoundClassification drives every wrapper method through a
+// fake Engine answering 404, proving classify's not-found mapping is
+// reached from the real call path, not just exercised as a pure function.
+func TestEngineNotFoundClassification(t *testing.T) {
+	t.Parallel()
+
+	for _, spec := range opSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			const ref = "ref1"
+			c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+				spec.route(ref): errorHandler(http.StatusNotFound),
+			})
+
+			// Act
+			err := spec.run(context.Background(), c, ref)
+
+			// Assert
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("err = %v, want errors.Is(err, ErrNotFound)", err)
+			}
+		})
+	}
+}
+
+// TestEngineGenericFailure drives every wrapper method through a fake Engine
+// answering 500, proving a non-not-found Engine failure surfaces as an
+// error that is NOT ErrNotFound.
+func TestEngineGenericFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, spec := range opSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			const ref = "ref1"
+			c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+				spec.route(ref): errorHandler(http.StatusInternalServerError),
+			})
+
+			// Act
+			err := spec.run(context.Background(), c, ref)
+
+			// Assert
+			if err == nil {
+				t.Fatal("err = nil, want a generic engine failure")
+			}
+			if errors.Is(err, ErrNotFound) {
+				t.Errorf("err = %v, want NOT errors.Is(err, ErrNotFound)", err)
+			}
+		})
+	}
+}
+
+// TestEngineValidateRefFirst drives every inspect method with an invalid
+// reference, proving ValidateRef rejects it before any Engine request is
+// made: the fake Engine records zero requests.
+func TestEngineValidateRefFirst(t *testing.T) {
+	t.Parallel()
+
+	const badRef = "../../info"
+
+	for _, spec := range opSpecs() {
+		if spec.callInspect == nil {
+			continue
+		}
+
+		t.Run(spec.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: no routes registered — any request the Engine
+			// receives is itself proof of failure via the recorder below.
+			c, rec := newFakeEngine(t, map[string]http.HandlerFunc{})
+
+			// Act
+			err := spec.callInspect(context.Background(), c, badRef)
+
+			// Assert
+			if !errors.Is(err, ErrInvalidRef) {
+				t.Fatalf("err = %v, want errors.Is(err, ErrInvalidRef)", err)
+			}
+			if got := rec.Count(); got != 0 {
+				t.Errorf("engine request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+// TestEngineEmptyList drives every list method through a fake Engine
+// returning zero objects, proving the response marshals as a non-nil, empty
+// Items slice with Truncated false, through the real call path.
+func TestEngineEmptyList(t *testing.T) {
+	t.Parallel()
+
+	for _, spec := range opSpecs() {
+		if spec.callList == nil {
+			continue
+		}
+
+		t.Run(spec.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			var body any
+			switch spec.name {
+			case "ListVolumes":
+				body = volume.ListResponse{Volumes: []volume.Volume{}}
+			case "ListContainers":
+				body = []container.Summary{}
+			case "ListImages":
+				body = []image.Summary{}
+			case "ListNetworks":
+				body = []network.Summary{}
+			}
+			c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+				spec.route(""): jsonHandler(http.StatusOK, body),
+			})
+
+			// Act
+			itemsLen, itemsNonNil, truncated, err := spec.callList(context.Background(), c)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("%s() error = %v, want nil", spec.name, err)
+			}
+			if itemsLen != 0 {
+				t.Errorf("len(Items) = %d, want 0", itemsLen)
+			}
+			if !itemsNonNil {
+				t.Error("Items is nil, want a non-nil empty slice")
+			}
+			if truncated {
+				t.Error("Truncated = true, want false")
+			}
+		})
+	}
+}
+
+// TestListVolumesWarningsNotInResponse proves VolumeListResult.Warnings —
+// which can name driver-internal host paths — never reaches the returned
+// DTOs, only the log.
+func TestListVolumesWarningsNotInResponse(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+		"GET /volumes": jsonHandler(http.StatusOK, volume.ListResponse{
+			Volumes:  []volume.Volume{{Name: "vol1", Driver: "local"}},
+			Warnings: []string{"/var/lib/docker/volumes/broken: unreadable"},
+		}),
+	})
+
+	// Act
+	got, err := c.ListVolumes(context.Background())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ListVolumes() error = %v, want nil", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(got.Items))
+	}
+	marshalled, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal ListVolumes result: %v", err)
+	}
+	if got, want := string(marshalled), "unreadable"; regexp.MustCompile(want).MatchString(got) {
+		t.Errorf("response body %q contains warning text %q", got, want)
+	}
+}

--- a/internal/dockerx/errors.go
+++ b/internal/dockerx/errors.go
@@ -1,0 +1,31 @@
+package dockerx
+
+import (
+	"errors"
+	"fmt"
+
+	cerrdefs "github.com/containerd/errdefs"
+)
+
+// ErrNotFound is returned when the Engine reports no such object. It is the
+// only Engine failure the API distinguishes: the caller is an authenticated
+// device, so telling it "that container is gone" is information it is
+// entitled to, while every other Engine fault is an upstream problem the
+// client can only retry.
+var ErrNotFound = errors.New("docker object not found")
+
+// ErrInvalidRef is returned by ValidateRef. It never reaches the Engine.
+var ErrInvalidRef = errors.New("invalid docker object reference")
+
+// classify maps a raw Engine error onto the package's sentinel errors,
+// wrapping the result with op so a caller can name the failing operation
+// without inspecting the underlying error type.
+func classify(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if cerrdefs.IsNotFound(err) {
+		return fmt.Errorf("%s: %w", op, ErrNotFound)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}

--- a/internal/dockerx/errors_test.go
+++ b/internal/dockerx/errors_test.go
@@ -1,0 +1,83 @@
+package dockerx
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+)
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	originalErr := errors.New("boom")
+
+	tests := []struct {
+		name          string
+		op            string
+		err           error
+		wantNil       bool
+		wantNotFound  bool
+		wantOriginal  error
+		wantOpInError string
+	}{
+		{
+			name:    "nil error passes through as nil",
+			op:      "inspect container",
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			name:          "not found error maps to ErrNotFound",
+			op:            "inspect container",
+			err:           cerrdefs.ErrNotFound,
+			wantNotFound:  true,
+			wantOpInError: "inspect container",
+		},
+		{
+			name:          "plain error is wrapped but not classified as not found",
+			op:            "list containers",
+			err:           originalErr,
+			wantOriginal:  originalErr,
+			wantOpInError: "list containers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := classify(tt.op, tt.err)
+
+			// Assert
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("classify(%q, nil) = %v, want nil", tt.op, got)
+				}
+				return
+			}
+
+			if tt.wantNotFound {
+				if !errors.Is(got, ErrNotFound) {
+					t.Errorf("errors.Is(got, ErrNotFound) = false, want true")
+				}
+				if !strings.HasPrefix(got.Error(), tt.wantOpInError) {
+					t.Errorf("got.Error() = %q, want prefix %q", got.Error(), tt.wantOpInError)
+				}
+				return
+			}
+
+			if errors.Is(got, ErrNotFound) {
+				t.Errorf("errors.Is(got, ErrNotFound) = true, want false")
+			}
+			if !errors.Is(got, tt.wantOriginal) {
+				t.Errorf("errors.Is(got, originalErr) = false, want true")
+			}
+			if !strings.HasPrefix(got.Error(), tt.wantOpInError) {
+				t.Errorf("got.Error() = %q, want prefix %q", got.Error(), tt.wantOpInError)
+			}
+		})
+	}
+}

--- a/internal/dockerx/images.go
+++ b/internal/dockerx/images.go
@@ -1,0 +1,95 @@
+package dockerx
+
+import (
+	"context"
+
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client"
+)
+
+// ListImages returns every image on the host, capped at maxListItems.
+func (c *Client) ListImages(ctx context.Context) (ListResult[ImageSummary], error) {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	// All stays false (the zero value): ImageListOptions.All returns
+	// intermediate layers, which is noise on a phone and not part of D12.
+	res, err := c.api.ImageList(ctx, client.ImageListOptions{})
+	if err != nil {
+		return ListResult[ImageSummary]{}, classify("list images", err)
+	}
+
+	items := make([]ImageSummary, 0, len(res.Items))
+	for _, s := range res.Items {
+		items = append(items, toImageSummary(s))
+	}
+
+	items, truncated := truncate(items)
+
+	return ListResult[ImageSummary]{Items: items, Truncated: truncated}, nil
+}
+
+// InspectImage returns the full projection of a single image. ref is
+// validated before any Engine call reaches out over the network.
+func (c *Client) InspectImage(ctx context.Context, ref string) (ImageDetail, error) {
+	if err := ValidateRef(ref); err != nil {
+		return ImageDetail{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	// ImageInspect is variadic in the v29 SDK, not an options struct.
+	res, err := c.api.ImageInspect(ctx, ref)
+	if err != nil {
+		return ImageDetail{}, classify("inspect image", err)
+	}
+
+	return toImageDetail(res.InspectResponse), nil
+}
+
+// toImageSummary projects an image.Summary onto the allowlisted DTO. Created
+// is Unix seconds and must be converted to RFC3339 UTC.
+func toImageSummary(s image.Summary) ImageSummary {
+	repoTags := make([]string, 0, len(s.RepoTags))
+	repoTags = append(repoTags, s.RepoTags...)
+
+	repoDigests := make([]string, 0, len(s.RepoDigests))
+	repoDigests = append(repoDigests, s.RepoDigests...)
+
+	return ImageSummary{
+		ID:          s.ID,
+		ParentID:    s.ParentID,
+		RepoTags:    repoTags,
+		RepoDigests: repoDigests,
+		CreatedAt:   unixToRFC3339(s.Created),
+		Size:        s.Size,
+		Containers:  s.Containers,
+		Labels:      defaultLabels(s.Labels),
+	}
+}
+
+// toImageDetail projects an image.InspectResponse onto the allowlisted DTO.
+// Created is already an RFC3339Nano string here, unlike Summary.Created's
+// int64, and is `json:",omitempty"` upstream so it can be empty — passed
+// through as-is, never reformatted. Config, which carries the image's baked-in
+// Env, is never mapped (D2).
+func toImageDetail(r image.InspectResponse) ImageDetail {
+	repoTags := make([]string, 0, len(r.RepoTags))
+	repoTags = append(repoTags, r.RepoTags...)
+
+	repoDigests := make([]string, 0, len(r.RepoDigests))
+	repoDigests = append(repoDigests, r.RepoDigests...)
+
+	return ImageDetail{
+		ID:           r.ID,
+		RepoTags:     repoTags,
+		RepoDigests:  repoDigests,
+		CreatedAt:    r.Created,
+		Size:         r.Size,
+		Architecture: r.Architecture,
+		OS:           r.Os,
+		Author:       r.Author,
+		Comment:      r.Comment,
+	}
+}

--- a/internal/dockerx/list.go
+++ b/internal/dockerx/list.go
@@ -1,0 +1,40 @@
+package dockerx
+
+import "time"
+
+// maxListItems caps every list response. A host with thousands of images would
+// otherwise produce a body no phone should receive. The cap is server-side and
+// not client-adjustable, consistent with the agent's configuration boundary.
+const maxListItems = 500
+
+// truncate caps items at maxListItems and reports whether truncation occurred.
+// Shared by every list method so the cap and its boundary behavior (exactly
+// maxListItems items is not truncated, one more is) live in a single place.
+func truncate[T any](items []T) ([]T, bool) {
+	if len(items) > maxListItems {
+		return items[:maxListItems], true
+	}
+	return items, false
+}
+
+// defaultLabels returns m unchanged, or a non-nil empty map when m is nil. A
+// nil map marshals to JSON null rather than {}, which would force the Android
+// client to handle both a map and a null for the same field.
+func defaultLabels(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+// unixToRFC3339 converts Unix seconds to an RFC3339 UTC string, treating 0 as
+// absent rather than the epoch: Docker reports Created as 0 when the engine
+// has no creation time to give, and formatting that as
+// "1970-01-01T00:00:00Z" would present a real-looking but false date to the
+// client.
+func unixToRFC3339(sec int64) string {
+	if sec == 0 {
+		return ""
+	}
+	return time.Unix(sec, 0).UTC().Format(time.RFC3339)
+}

--- a/internal/dockerx/networks.go
+++ b/internal/dockerx/networks.go
@@ -1,0 +1,105 @@
+package dockerx
+
+import (
+	"context"
+	"time"
+
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+)
+
+// ListNetworks returns every network on the host, capped at maxListItems.
+func (c *Client) ListNetworks(ctx context.Context) (ListResult[NetworkSummary], error) {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	res, err := c.api.NetworkList(ctx, client.NetworkListOptions{})
+	if err != nil {
+		return ListResult[NetworkSummary]{}, classify("list networks", err)
+	}
+
+	items := make([]NetworkSummary, 0, len(res.Items))
+	for _, s := range res.Items {
+		items = append(items, toNetworkSummary(s.Network))
+	}
+
+	items, truncated := truncate(items)
+
+	return ListResult[NetworkSummary]{Items: items, Truncated: truncated}, nil
+}
+
+// InspectNetwork returns the full projection of a single network, including
+// its attached containers. ref is validated before any Engine call reaches
+// out over the network.
+func (c *Client) InspectNetwork(ctx context.Context, ref string) (NetworkDetail, error) {
+	if err := ValidateRef(ref); err != nil {
+		return NetworkDetail{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	res, err := c.api.NetworkInspect(ctx, ref, client.NetworkInspectOptions{})
+	if err != nil {
+		return NetworkDetail{}, classify("inspect network", err)
+	}
+
+	return toNetworkDetail(res.Network), nil
+}
+
+// toNetworkSummary projects a network.Network onto the allowlisted DTO.
+// network.Summary and network.Inspect both embed network.Network, so this one
+// mapper serves list, and detail (via toNetworkDetail below).
+//
+// Created's declared type is network.Network.Created (documented as
+// timeext.Time in the upstream swagger-generated file). The import in that
+// file is `timeext "time"` — an alias for the standard library "time"
+// package, not a distinct named type — so Created is a plain time.Time and
+// needs no conversion.
+func toNetworkSummary(n network.Network) NetworkSummary {
+	return NetworkSummary{
+		ID:         n.ID,
+		Name:       n.Name,
+		Driver:     n.Driver,
+		Scope:      n.Scope,
+		CreatedAt:  n.Created.UTC().Format(time.RFC3339),
+		Internal:   n.Internal,
+		EnableIPv6: n.EnableIPv6,
+		Labels:     defaultLabels(n.Labels),
+	}
+}
+
+// toNetworkDetail projects a network.Inspect onto the allowlisted DTO,
+// including its attached containers.
+func toNetworkDetail(n network.Inspect) NetworkDetail {
+	containers := make([]NetworkEndpoint, 0, len(n.Containers))
+	for id, ep := range n.Containers {
+		containers = append(containers, toNetworkEndpoint(id, ep))
+	}
+
+	return NetworkDetail{
+		NetworkSummary: toNetworkSummary(n.Network),
+		Containers:     containers,
+	}
+}
+
+// toNetworkEndpoint projects a single container's attachment to an inspected
+// network onto the allowlisted DTO. IPv4Address and IPv6Address are
+// netip.Prefix, not netip.Addr, and must be guarded with IsValid() the same
+// way.
+func toNetworkEndpoint(containerID string, ep network.EndpointResource) NetworkEndpoint {
+	var ipv4, ipv6 string
+	if ep.IPv4Address.IsValid() {
+		ipv4 = ep.IPv4Address.String()
+	}
+	if ep.IPv6Address.IsValid() {
+		ipv6 = ep.IPv6Address.String()
+	}
+
+	return NetworkEndpoint{
+		ContainerID: containerID,
+		Name:        ep.Name,
+		IPv4Address: ipv4,
+		IPv6Address: ipv6,
+	}
+}

--- a/internal/dockerx/objects_test.go
+++ b/internal/dockerx/objects_test.go
@@ -1,0 +1,430 @@
+package dockerx
+
+import (
+	"encoding/json"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/volume"
+)
+
+// TestToImageSummaryZeroValue covers an image.Summary with every slice and
+// map field nil, the ordinary shape for an image with no tags.
+func TestToImageSummaryZeroValue(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := image.Summary{}
+
+	// Act
+	got := toImageSummary(s)
+
+	// Assert
+	if got.RepoTags == nil {
+		t.Error("got.RepoTags = nil, want empty non-nil slice")
+	}
+	if got.RepoDigests == nil {
+		t.Error("got.RepoDigests = nil, want empty non-nil slice")
+	}
+	if got.Labels == nil {
+		t.Error("got.Labels = nil, want empty non-nil map")
+	}
+}
+
+// TestToImageSummaryCreatedAt covers the int64 Unix-seconds to RFC3339 UTC
+// conversion for image.Summary.Created.
+func TestToImageSummaryCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := image.Summary{Created: 1700000000}
+
+	// Act
+	got := toImageSummary(s)
+
+	// Assert
+	want := "2023-11-14T22:13:20Z"
+	if got.CreatedAt != want {
+		t.Errorf("got.CreatedAt = %q, want %q", got.CreatedAt, want)
+	}
+}
+
+// TestToImageSummaryCreatedAtZero covers image.Summary.Created being 0 (the
+// Engine's "no creation time to report" value), which must not be formatted
+// as the Unix epoch.
+func TestToImageSummaryCreatedAtZero(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := image.Summary{Created: 0}
+
+	// Act
+	got := toImageSummary(s)
+
+	// Assert
+	if got.CreatedAt != "" {
+		t.Errorf("got.CreatedAt = %q, want empty", got.CreatedAt)
+	}
+}
+
+// TestToImageDetailEmptyCreated covers image.InspectResponse.Created being
+// empty (it is `json:",omitempty"` upstream) and must pass through as-is
+// rather than being reformatted or defaulted.
+func TestToImageDetailEmptyCreated(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	r := image.InspectResponse{ID: "sha256:abc"}
+
+	// Act
+	got := toImageDetail(r)
+
+	// Assert
+	if got.CreatedAt != "" {
+		t.Errorf("got.CreatedAt = %q, want empty", got.CreatedAt)
+	}
+	if got.RepoTags == nil {
+		t.Error("got.RepoTags = nil, want empty non-nil slice")
+	}
+	if got.RepoDigests == nil {
+		t.Error("got.RepoDigests = nil, want empty non-nil slice")
+	}
+}
+
+// TestImageDetailNeverCarriesEnv covers the highest-value assertion for this
+// DTO: marshalling never leaks the image config's baked-in Env, even though
+// image.InspectResponse.Config holds it.
+func TestImageDetailNeverCarriesEnv(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	r := image.InspectResponse{
+		ID:           "sha256:abc",
+		RepoTags:     []string{"myapp:1.4"},
+		Created:      "2023-11-14T22:13:20Z",
+		Architecture: "amd64",
+		Os:           "linux",
+	}
+
+	// Act
+	got := toImageDetail(r)
+	bodyBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(got) error = %v", err)
+	}
+
+	// Assert
+	body := string(bodyBytes)
+	if strings.Contains(body, `"env"`) || strings.Contains(body, "API_KEY") {
+		t.Errorf("marshalled ImageDetail leaks env data: %s", body)
+	}
+	if got.OS != "linux" {
+		t.Errorf("got.OS = %q, want linux", got.OS)
+	}
+}
+
+// TestListImagesTruncation covers the boundary and over-the-boundary
+// truncation cases without a live daemon.
+func TestListImagesTruncation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		count         int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{name: "under the cap", count: 3, wantLen: 3, wantTruncated: false},
+		{name: "exactly at the cap", count: maxListItems, wantLen: maxListItems, wantTruncated: false},
+		{name: "over the cap", count: maxListItems + 1, wantLen: maxListItems, wantTruncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			items := make([]ImageSummary, 0, tt.count)
+			for i := 0; i < tt.count; i++ {
+				items = append(items, ImageSummary{})
+			}
+
+			// Act
+			truncated := false
+			if len(items) > maxListItems {
+				items, truncated = items[:maxListItems], true
+			}
+
+			// Assert
+			if len(items) != tt.wantLen {
+				t.Errorf("len(items) = %d, want %d", len(items), tt.wantLen)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+		})
+	}
+}
+
+// TestToNetworkSummaryZeroValue covers a network.Network with every map
+// field nil, the ordinary shape for a network with no labels.
+func TestToNetworkSummaryZeroValue(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	n := network.Network{}
+
+	// Act
+	got := toNetworkSummary(n)
+
+	// Assert
+	if got.Labels == nil {
+		t.Error("got.Labels = nil, want empty non-nil map")
+	}
+}
+
+// TestToNetworkSummaryCreatedAt covers the network.Network.Created field,
+// which is declared as timeext.Time upstream but is actually the standard
+// library time.Time (the upstream import is `timeext "time"`, an alias, not
+// a distinct named type), so it needs a direct .Format call, no conversion.
+func TestToNetworkSummaryCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	created := time.Date(2023, 11, 14, 22, 13, 20, 0, time.UTC)
+	n := network.Network{Created: created}
+
+	// Act
+	got := toNetworkSummary(n)
+
+	// Assert
+	want := "2023-11-14T22:13:20Z"
+	if got.CreatedAt != want {
+		t.Errorf("got.CreatedAt = %q, want %q", got.CreatedAt, want)
+	}
+}
+
+// TestToNetworkDetailNoContainers covers an inspected network with nothing
+// attached, the ordinary shape for a freshly created network.
+func TestToNetworkDetailNoContainers(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	n := network.Inspect{
+		Network: network.Network{ID: "net1", Name: "bridge"},
+	}
+
+	// Act
+	got := toNetworkDetail(n)
+
+	// Assert
+	if got.Containers == nil {
+		t.Error("got.Containers = nil, want empty non-nil slice")
+	}
+	if len(got.Containers) != 0 {
+		t.Errorf("len(got.Containers) = %d, want 0", len(got.Containers))
+	}
+	if got.ID != "net1" {
+		t.Errorf("got.ID = %q, want net1", got.ID)
+	}
+}
+
+// TestToNetworkDetailWithContainers covers an inspected network with an
+// attached container, asserting the netip.Prefix IPv4Address/IPv6Address
+// fields (not netip.Addr) are guarded and rendered correctly.
+func TestToNetworkDetailWithContainers(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	n := network.Inspect{
+		Network: network.Network{ID: "net1", Name: "bridge"},
+		Containers: map[string]network.EndpointResource{
+			"c1": {
+				Name:        "api",
+				IPv4Address: netip.MustParsePrefix("172.19.0.2/16"),
+			},
+		},
+	}
+
+	// Act
+	got := toNetworkDetail(n)
+
+	// Assert
+	if len(got.Containers) != 1 {
+		t.Fatalf("len(got.Containers) = %d, want 1", len(got.Containers))
+	}
+	ep := got.Containers[0]
+	if ep.ContainerID != "c1" {
+		t.Errorf("ep.ContainerID = %q, want c1", ep.ContainerID)
+	}
+	if ep.Name != "api" {
+		t.Errorf("ep.Name = %q, want api", ep.Name)
+	}
+	if ep.IPv4Address != "172.19.0.2/16" {
+		t.Errorf("ep.IPv4Address = %q, want 172.19.0.2/16", ep.IPv4Address)
+	}
+	if ep.IPv6Address != "" {
+		t.Errorf("ep.IPv6Address = %q, want empty for an unset netip.Prefix", ep.IPv6Address)
+	}
+}
+
+// TestListNetworksTruncation covers the boundary and over-the-boundary
+// truncation cases without a live daemon.
+func TestListNetworksTruncation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		count         int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{name: "under the cap", count: 3, wantLen: 3, wantTruncated: false},
+		{name: "exactly at the cap", count: maxListItems, wantLen: maxListItems, wantTruncated: false},
+		{name: "over the cap", count: maxListItems + 1, wantLen: maxListItems, wantTruncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			items := make([]NetworkSummary, 0, tt.count)
+			for i := 0; i < tt.count; i++ {
+				items = append(items, NetworkSummary{})
+			}
+
+			// Act
+			truncated := false
+			if len(items) > maxListItems {
+				items, truncated = items[:maxListItems], true
+			}
+
+			// Assert
+			if len(items) != tt.wantLen {
+				t.Errorf("len(items) = %d, want %d", len(items), tt.wantLen)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+		})
+	}
+}
+
+// TestToVolumeSummaryNilUsageData covers a volume.Volume whose UsageData is
+// nil, the ordinary shape unless disk-usage information was explicitly
+// requested.
+func TestToVolumeSummaryNilUsageData(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	v := volume.Volume{Name: "tardis", UsageData: nil}
+
+	// Act
+	got := toVolumeSummary(v)
+
+	// Assert
+	if got.SizeBytes != nil {
+		t.Errorf("got.SizeBytes = %v, want nil", got.SizeBytes)
+	}
+	if got.Labels == nil {
+		t.Error("got.Labels = nil, want empty non-nil map")
+	}
+}
+
+// TestToVolumeSummaryWithUsageData covers a volume.Volume with a non-nil
+// UsageData, asserting the pointer is populated from UsageData.Size.
+func TestToVolumeSummaryWithUsageData(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	v := volume.Volume{
+		Name:      "tardis",
+		UsageData: &volume.UsageData{Size: 4096, RefCount: 1},
+	}
+
+	// Act
+	got := toVolumeSummary(v)
+
+	// Assert
+	if got.SizeBytes == nil {
+		t.Fatal("got.SizeBytes = nil, want a populated pointer")
+	}
+	if *got.SizeBytes != 4096 {
+		t.Errorf("*got.SizeBytes = %d, want 4096", *got.SizeBytes)
+	}
+}
+
+// TestVolumeSummaryNeverCarriesOptions covers the highest-value assertion for
+// this DTO: marshalling never leaks volume.Volume.Options, which routinely
+// carries tmpfs/CIFS/NFS credentials.
+func TestVolumeSummaryNeverCarriesOptions(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	v := volume.Volume{
+		Name:    "cifs-share",
+		Driver:  "local",
+		Options: map[string]string{"o": "username=admin,password=hunter2"},
+	}
+
+	// Act
+	got := toVolumeSummary(v)
+	bodyBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(got) error = %v", err)
+	}
+
+	// Assert
+	body := string(bodyBytes)
+	if strings.Contains(body, "hunter2") || strings.Contains(body, `"options"`) {
+		t.Errorf("marshalled VolumeSummary leaks driver options: %s", body)
+	}
+}
+
+// TestListVolumesTruncation covers the boundary and over-the-boundary
+// truncation cases without a live daemon.
+func TestListVolumesTruncation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		count         int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{name: "under the cap", count: 3, wantLen: 3, wantTruncated: false},
+		{name: "exactly at the cap", count: maxListItems, wantLen: maxListItems, wantTruncated: false},
+		{name: "over the cap", count: maxListItems + 1, wantLen: maxListItems, wantTruncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			items := make([]VolumeSummary, 0, tt.count)
+			for i := 0; i < tt.count; i++ {
+				items = append(items, VolumeSummary{})
+			}
+
+			// Act
+			truncated := false
+			if len(items) > maxListItems {
+				items, truncated = items[:maxListItems], true
+			}
+
+			// Assert
+			if len(items) != tt.wantLen {
+				t.Errorf("len(items) = %d, want %d", len(items), tt.wantLen)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+		})
+	}
+}

--- a/internal/dockerx/ref.go
+++ b/internal/dockerx/ref.go
@@ -1,0 +1,29 @@
+package dockerx
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// refPattern is the boundary check on every container, image, network, or
+// volume reference before it reaches the Docker Engine. The moby client
+// interpolates the reference directly into the Engine request URL path, so a
+// value like "../../info" is not a malformed ID, it is a path traversal
+// attempt against the Engine's HTTP API. net/http.ServeMux already refuses a
+// "/" inside a "{id}" wildcard and cleans ".." segments, but relying on two
+// layers of framework behaviour to keep an attacker-controlled segment out of
+// an upstream URL is exactly the kind of assumption that breaks silently on a
+// dependency bump. This pattern is validated at the boundary instead, and
+// deliberately excludes ":" so digest references (e.g. "sha256:abc...") are
+// rejected rather than accepted.
+var refPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$`)
+
+// ValidateRef reports whether ref is safe to interpolate into an Engine
+// request path. It returns ErrInvalidRef, wrapped with ref for context, when
+// ref does not match refPattern.
+func ValidateRef(ref string) error {
+	if !refPattern.MatchString(ref) {
+		return fmt.Errorf("validate ref %q: %w", ref, ErrInvalidRef)
+	}
+	return nil
+}

--- a/internal/dockerx/ref_test.go
+++ b/internal/dockerx/ref_test.go
@@ -1,0 +1,52 @@
+package dockerx
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr bool
+	}{
+		{name: "empty string", ref: "", wantErr: true},
+		{name: "bare traversal", ref: "..", wantErr: true},
+		{name: "nested traversal", ref: "../../info", wantErr: true},
+		{name: "slash separated segments", ref: "a/b", wantErr: true},
+		{name: "leading dash", ref: "-abc", wantErr: true},
+		{name: "leading dot", ref: ".hidden", wantErr: true},
+		{name: "129 character string", ref: strings.Repeat("a", 129), wantErr: true},
+		{name: "digest reference", ref: "sha256:ab", wantErr: true},
+		{name: "short hex id", ref: "a1b2c3d4e5f6", wantErr: false},
+		{name: "name with underscore, dash, dot", ref: "my_app-1.2", wantErr: false},
+		{name: "128 character string", ref: strings.Repeat("a", 128), wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			ref := tt.ref
+
+			// Act
+			err := ValidateRef(ref)
+
+			// Assert
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidRef) {
+					t.Fatalf("ValidateRef(%q) error = %v, want ErrInvalidRef", ref, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateRef(%q) error = %v, want nil", ref, err)
+			}
+		})
+	}
+}

--- a/internal/dockerx/types.go
+++ b/internal/dockerx/types.go
@@ -1,0 +1,164 @@
+package dockerx
+
+// Response DTOs for the read operations (Phase 3).
+//
+// D1: this file is the complete, explicit allowlist of what a paired device is
+// permitted to learn about a Docker object. Nothing in internal/dockerx forwards
+// an Engine struct verbatim — every field below was added on purpose, and adding
+// a new one is a deliberate act that must also update the corresponding
+// *FieldCount test.
+//
+// D2: environment variables are never returned, at any level. container.Config.Env,
+// the image config's baked-in Env, and volume.Volume.Options (which routinely
+// carries tmpfs/CIFS/NFS credentials) have no field here and must never gain one.
+// Redacting a value still discloses that a secret exists and its name; omission is
+// the only version of this that cannot leak.
+
+// ListResult is the envelope every list route returns. A bare top-level JSON
+// array cannot gain a field later without breaking every client, and Truncated
+// needs somewhere to live from day one (D9).
+type ListResult[T any] struct {
+	Items     []T  `json:"items"`
+	Truncated bool `json:"truncated"`
+}
+
+// Port is a single published or exposed container port.
+type Port struct {
+	IP          string `json:"ip,omitempty"` // from netip.Addr; "" when !IsValid()
+	PrivatePort uint16 `json:"private_port"`
+	PublicPort  uint16 `json:"public_port,omitempty"`
+	Protocol    string `json:"protocol"` // from PortSummary.Type
+}
+
+// Mount is a single filesystem mount attached to a container.
+type Mount struct {
+	Type        string `json:"type"`
+	Name        string `json:"name,omitempty"`
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	ReadWrite   bool   `json:"read_write"`
+}
+
+// EndpointSummary is a container's attachment to a single network.
+type EndpointSummary struct {
+	NetworkName string   `json:"network_name"`
+	NetworkID   string   `json:"network_id"`
+	IPAddress   string   `json:"ip_address,omitempty"`
+	Gateway     string   `json:"gateway,omitempty"`
+	MACAddress  string   `json:"mac_address,omitempty"`
+	Aliases     []string `json:"aliases,omitempty"`
+}
+
+// ContainerSummary is one entry of a container list. 11 fields.
+type ContainerSummary struct {
+	ID        string            `json:"id"`
+	Names     []string          `json:"names"`
+	Image     string            `json:"image"`
+	ImageID   string            `json:"image_id"`
+	Command   string            `json:"command"`
+	CreatedAt string            `json:"created_at"` // RFC3339 UTC
+	State     string            `json:"state"`
+	Status    string            `json:"status"`
+	Health    string            `json:"health,omitempty"` // "" when Health is nil
+	Labels    map[string]string `json:"labels"`
+	Ports     []Port            `json:"ports"`
+}
+
+// ContainerDetail is the full projection of a single container. 24 fields.
+// NO env. NO raw Engine payload.
+type ContainerDetail struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Image         string            `json:"image"`
+	CreatedAt     string            `json:"created_at"` // RFC3339 UTC
+	State         string            `json:"state"`
+	Running       bool              `json:"running"`
+	Paused        bool              `json:"paused"`
+	Restarting    bool              `json:"restarting"`
+	ExitCode      int               `json:"exit_code"`
+	StartedAt     string            `json:"started_at,omitempty"`
+	FinishedAt    string            `json:"finished_at,omitempty"`
+	Health        string            `json:"health,omitempty"`
+	RestartCount  int               `json:"restart_count"`
+	RestartPolicy string            `json:"restart_policy,omitempty"`
+	Platform      string            `json:"platform"`
+	Labels        map[string]string `json:"labels"`
+	Command       string            `json:"command"` // InspectResponse.Path
+	Args          []string          `json:"args"`
+	Entrypoint    []string          `json:"entrypoint,omitempty"`
+	WorkingDir    string            `json:"working_dir,omitempty"`
+	User          string            `json:"user,omitempty"`
+	Mounts        []Mount           `json:"mounts"`
+	Networks      []EndpointSummary `json:"networks"`
+	Ports         []Port            `json:"ports"`
+}
+
+// ImageSummary is one entry of an image list. 8 fields.
+type ImageSummary struct {
+	ID          string            `json:"id"`
+	ParentID    string            `json:"parent_id,omitempty"`
+	RepoTags    []string          `json:"repo_tags"`
+	RepoDigests []string          `json:"repo_digests"`
+	CreatedAt   string            `json:"created_at"` // RFC3339 UTC from int64
+	Size        int64             `json:"size"`
+	Containers  int64             `json:"containers"` // -1 means "not calculated"
+	Labels      map[string]string `json:"labels"`
+}
+
+// ImageDetail is the full projection of a single image. 9 fields.
+//
+// image.InspectResponse.Config carries the image's baked-in Env. It is NOT
+// mapped. D2 applies to images too.
+type ImageDetail struct {
+	ID           string   `json:"id"`
+	RepoTags     []string `json:"repo_tags"`
+	RepoDigests  []string `json:"repo_digests"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	Size         int64    `json:"size"`
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	Author       string   `json:"author,omitempty"`
+	Comment      string   `json:"comment,omitempty"`
+}
+
+// NetworkSummary is one entry of a network list. 8 fields.
+type NetworkSummary struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Scope      string            `json:"scope"`
+	CreatedAt  string            `json:"created_at"`
+	Internal   bool              `json:"internal"`
+	EnableIPv6 bool              `json:"enable_ipv6"`
+	Labels     map[string]string `json:"labels"`
+}
+
+// NetworkDetail is a NetworkSummary plus the containers attached to it.
+type NetworkDetail struct {
+	NetworkSummary
+	Containers []NetworkEndpoint `json:"containers"`
+}
+
+// NetworkEndpoint is a single container's attachment to an inspected network.
+type NetworkEndpoint struct {
+	ContainerID string `json:"container_id"`
+	Name        string `json:"name"`
+	IPv4Address string `json:"ipv4_address,omitempty"`
+	IPv6Address string `json:"ipv6_address,omitempty"`
+}
+
+// VolumeSummary is both a volume list entry and a volume inspect response
+// (VolumeDetail is VolumeSummary; there is no separate detail shape). 7 fields.
+//
+// volume.Volume.Options is NOT mapped: for tmpfs and CIFS/NFS volumes it
+// routinely contains credentials (o=username=...,password=...). D2's reasoning
+// applies verbatim.
+type VolumeSummary struct {
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Mountpoint string            `json:"mountpoint"`
+	CreatedAt  string            `json:"created_at,omitempty"`
+	Scope      string            `json:"scope"`
+	Labels     map[string]string `json:"labels"`
+	SizeBytes  *int64            `json:"size_bytes,omitempty"` // from UsageData.Size when non-nil
+}

--- a/internal/dockerx/types_test.go
+++ b/internal/dockerx/types_test.go
@@ -1,0 +1,310 @@
+package dockerx
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+)
+
+// keysOf returns the sorted-by-insertion (map order, unspecified) keys of a
+// decoded JSON object, for readable failure messages in the *FieldCount
+// tests below.
+func keysOf(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// marshalToMap marshals v and decodes the result into a map[string]any, so a
+// *FieldCount test can assert on the JSON shape rather than the Go struct.
+func marshalToMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal(%#v) error = %v", v, err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("json.Unmarshal(%s) error = %v", raw, err)
+	}
+	return body
+}
+
+// The *FieldCount tests below are the D1 allowlist guard: every DTO is
+// marshalled fully populated (so omitempty cannot hide a field from the
+// count) and the resulting key count is asserted exactly, not just the
+// presence of the expected keys. A later phase that widens a payload must
+// touch this test deliberately (FIELD_ALLOWLIST_GUARD, mirroring
+// TestStatusFieldCount in internal/httpapi/status_test.go).
+
+func TestContainerSummaryFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cs := ContainerSummary{
+		ID:        "abc123",
+		Names:     []string{"/api"},
+		Image:     "myapp:1.4",
+		ImageID:   "sha256:xyz",
+		Command:   "/app/server",
+		CreatedAt: "2023-11-14T22:13:20Z",
+		State:     "running",
+		Status:    "Up 3 minutes",
+		Health:    "healthy",
+		Labels:    map[string]string{"app": "myapp"},
+		Ports:     []Port{{PrivatePort: 8080, Protocol: "tcp"}},
+	}
+
+	// Act
+	body := marshalToMap(t, cs)
+
+	// Assert
+	if len(body) != 11 {
+		t.Fatalf("ContainerSummary payload has %d keys (%v), want exactly 11", len(body), keysOf(body))
+	}
+}
+
+func TestContainerDetailFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cd := ContainerDetail{
+		ID:            "abc123",
+		Name:          "/api",
+		Image:         "myapp:1.4",
+		CreatedAt:     "2023-11-14T22:13:20Z",
+		State:         "running",
+		Running:       true,
+		Paused:        false,
+		Restarting:    false,
+		ExitCode:      0,
+		StartedAt:     "2023-11-14T22:13:21Z",
+		FinishedAt:    "2023-11-14T22:14:21Z",
+		Health:        "healthy",
+		RestartCount:  1,
+		RestartPolicy: "always",
+		Platform:      "linux",
+		Labels:        map[string]string{"app": "myapp"},
+		Command:       "/app/server",
+		Args:          []string{"--port", "8080"},
+		Entrypoint:    []string{"/entrypoint.sh"},
+		WorkingDir:    "/app",
+		User:          "nobody",
+		Mounts:        []Mount{{Type: "volume", Source: "/data", Destination: "/data", ReadWrite: true}},
+		Networks:      []EndpointSummary{{NetworkName: "bridge", NetworkID: "net1"}},
+		Ports:         []Port{{PrivatePort: 8080, Protocol: "tcp"}},
+	}
+
+	// Act
+	body := marshalToMap(t, cd)
+
+	// Assert
+	if len(body) != 24 {
+		t.Fatalf("ContainerDetail payload has %d keys (%v), want exactly 24", len(body), keysOf(body))
+	}
+}
+
+func TestImageSummaryFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	is := ImageSummary{
+		ID:          "sha256:abc",
+		ParentID:    "sha256:parent",
+		RepoTags:    []string{"myapp:1.4"},
+		RepoDigests: []string{"myapp@sha256:def"},
+		CreatedAt:   "2023-11-14T22:13:20Z",
+		Size:        1024,
+		Containers:  2,
+		Labels:      map[string]string{"maintainer": "ops"},
+	}
+
+	// Act
+	body := marshalToMap(t, is)
+
+	// Assert
+	if len(body) != 8 {
+		t.Fatalf("ImageSummary payload has %d keys (%v), want exactly 8", len(body), keysOf(body))
+	}
+}
+
+func TestImageDetailFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	id := ImageDetail{
+		ID:           "sha256:abc",
+		RepoTags:     []string{"myapp:1.4"},
+		RepoDigests:  []string{"myapp@sha256:def"},
+		CreatedAt:    "2023-11-14T22:13:20Z",
+		Size:         1024,
+		Architecture: "amd64",
+		OS:           "linux",
+		Author:       "ops team",
+		Comment:      "release build",
+	}
+
+	// Act
+	body := marshalToMap(t, id)
+
+	// Assert
+	if len(body) != 9 {
+		t.Fatalf("ImageDetail payload has %d keys (%v), want exactly 9", len(body), keysOf(body))
+	}
+}
+
+func TestNetworkSummaryFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	ns := NetworkSummary{
+		ID:         "net1",
+		Name:       "bridge",
+		Driver:     "bridge",
+		Scope:      "local",
+		CreatedAt:  "2023-11-14T22:13:20Z",
+		Internal:   false,
+		EnableIPv6: true,
+		Labels:     map[string]string{"env": "prod"},
+	}
+
+	// Act
+	body := marshalToMap(t, ns)
+
+	// Assert
+	if len(body) != 8 {
+		t.Fatalf("NetworkSummary payload has %d keys (%v), want exactly 8", len(body), keysOf(body))
+	}
+}
+
+func TestNetworkDetailFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	nd := NetworkDetail{
+		NetworkSummary: NetworkSummary{
+			ID:         "net1",
+			Name:       "bridge",
+			Driver:     "bridge",
+			Scope:      "local",
+			CreatedAt:  "2023-11-14T22:13:20Z",
+			Internal:   false,
+			EnableIPv6: true,
+			Labels:     map[string]string{"env": "prod"},
+		},
+		Containers: []NetworkEndpoint{{ContainerID: "c1", Name: "api", IPv4Address: "172.19.0.2"}},
+	}
+
+	// Act
+	body := marshalToMap(t, nd)
+
+	// Assert
+	// NetworkSummary's 8 embedded fields, flattened, plus "containers".
+	if len(body) != 9 {
+		t.Fatalf("NetworkDetail payload has %d keys (%v), want exactly 9", len(body), keysOf(body))
+	}
+}
+
+func TestVolumeSummaryFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	size := int64(4096)
+	vs := VolumeSummary{
+		Name:       "tardis",
+		Driver:     "local",
+		Mountpoint: "/var/lib/docker/volumes/tardis/_data",
+		CreatedAt:  "2023-11-14T22:13:20Z",
+		Scope:      "local",
+		Labels:     map[string]string{"app": "myapp"},
+		SizeBytes:  &size,
+	}
+
+	// Act
+	body := marshalToMap(t, vs)
+
+	// Assert
+	if len(body) != 7 {
+		t.Fatalf("VolumeSummary payload has %d keys (%v), want exactly 7", len(body), keysOf(body))
+	}
+}
+
+func TestListResultFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	lr := ListResult[ContainerSummary]{
+		Items:     []ContainerSummary{{ID: "abc123"}},
+		Truncated: true,
+	}
+
+	// Act
+	body := marshalToMap(t, lr)
+
+	// Assert
+	if len(body) != 2 {
+		t.Fatalf("ListResult payload has %d keys (%v), want exactly 2", len(body), keysOf(body))
+	}
+}
+
+// TestContainerDetailNeverCarriesEnv is the D2 guard: it asserts on the
+// marshalled JSON string rather than on struct fields, so a future embedded
+// struct or a removed json:"-" cannot slip a leaked env var past this test.
+func TestContainerDetailNeverCarriesEnv(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	r := container.InspectResponse{
+		ID: "abc123",
+		Config: &container.Config{
+			Env: []string{"DB_PASSWORD=hunter2"},
+		},
+	}
+
+	// Act
+	got := toContainerDetail(r)
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(got) error = %v", err)
+	}
+
+	// Assert
+	body := string(raw)
+	if strings.Contains(body, `"env"`) || strings.Contains(body, "hunter2") {
+		t.Errorf("marshalled ContainerDetail leaks env data: %s", body)
+	}
+}
+
+// TestImageDetailNeverCarriesEnv and TestVolumeSummaryNeverCarriesOptions are
+// deliberately not duplicated here: internal/dockerx/objects_test.go already
+// asserts both on marshalled JSON (Task 5), and re-adding them under
+// different names would be redundant coverage of the same D2 guarantee
+// rather than a new guard.
+
+// TestEmptyListMarshalsAsArray asserts a zero-item ListResult marshals its
+// Items field as an empty array, never null, so a client never has to handle
+// both shapes.
+func TestEmptyListMarshalsAsArray(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	lr := ListResult[ContainerSummary]{Items: []ContainerSummary{}, Truncated: false}
+
+	// Act
+	raw, err := json.Marshal(lr)
+	if err != nil {
+		t.Fatalf("json.Marshal(lr) error = %v", err)
+	}
+
+	// Assert
+	if !strings.Contains(string(raw), `"items":[]`) {
+		t.Errorf("marshalled ListResult = %s, want it to contain \"items\":[]", raw)
+	}
+	if strings.Contains(string(raw), `"items":null`) {
+		t.Errorf("marshalled ListResult = %s, items must never be null", raw)
+	}
+}

--- a/internal/dockerx/volumes.go
+++ b/internal/dockerx/volumes.go
@@ -1,0 +1,76 @@
+package dockerx
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/client"
+)
+
+// ListVolumes returns every volume on the host, capped at maxListItems.
+func (c *Client) ListVolumes(ctx context.Context) (ListResult[VolumeSummary], error) {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	res, err := c.api.VolumeList(ctx, client.VolumeListOptions{})
+	if err != nil {
+		return ListResult[VolumeSummary]{}, classify("list volumes", err)
+	}
+
+	// Warnings can name driver-internal host paths and must never reach the
+	// response body; they are logged for the operator instead.
+	if len(res.Warnings) > 0 {
+		c.log.Warn("volume list warnings", slog.Any("warnings", res.Warnings))
+	}
+
+	items := make([]VolumeSummary, 0, len(res.Items))
+	for _, v := range res.Items {
+		items = append(items, toVolumeSummary(v))
+	}
+
+	items, truncated := truncate(items)
+
+	return ListResult[VolumeSummary]{Items: items, Truncated: truncated}, nil
+}
+
+// InspectVolume returns the full projection of a single volume. ref is
+// validated before any Engine call reaches out over the network.
+func (c *Client) InspectVolume(ctx context.Context, ref string) (VolumeSummary, error) {
+	if err := ValidateRef(ref); err != nil {
+		return VolumeSummary{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	res, err := c.api.VolumeInspect(ctx, ref, client.VolumeInspectOptions{})
+	if err != nil {
+		return VolumeSummary{}, classify("inspect volume", err)
+	}
+
+	return toVolumeSummary(res.Volume), nil
+}
+
+// toVolumeSummary projects a volume.Volume onto the allowlisted DTO. It is
+// used for both list entries and the inspect response (VolumeDetail is
+// VolumeSummary). CreatedAt is already an RFC3339 string. UsageData can be
+// nil, in which case SizeBytes stays nil. Options is never mapped: for tmpfs
+// and CIFS/NFS volumes it routinely carries credentials (D2).
+func toVolumeSummary(v volume.Volume) VolumeSummary {
+	var sizeBytes *int64
+	if v.UsageData != nil {
+		size := v.UsageData.Size
+		sizeBytes = &size
+	}
+
+	return VolumeSummary{
+		Name:       v.Name,
+		Driver:     v.Driver,
+		Mountpoint: v.Mountpoint,
+		CreatedAt:  v.CreatedAt,
+		Scope:      v.Scope,
+		Labels:     defaultLabels(v.Labels),
+		SizeBytes:  sizeBytes,
+	}
+}

--- a/internal/httpapi/pair_test.go
+++ b/internal/httpapi/pair_test.go
@@ -38,7 +38,7 @@ func testServerForPairing(t *testing.T) (*Server, *state.Store, *certs.CA) {
 	if err != nil {
 		t.Fatalf("LoadOrCreateCA: %v", err)
 	}
-	return NewServer(cfg, st, ca, nil, testLogger()), st, ca
+	return NewServer(cfg, st, ca, nil, nil, testLogger()), st, ca
 }
 
 // generateCSRPEM builds a PEM-encoded PKCS#10 CSR from a fresh EC P-256 key,

--- a/internal/httpapi/policygate.go
+++ b/internal/httpapi/policygate.go
@@ -1,0 +1,37 @@
+package httpapi
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/scnplt/devmon-agent/internal/policy"
+)
+
+// msgPolicyForbidden is served when the host's startup policy does not permit
+// the operation. Unlike the terse authentication rejections, this one is
+// deliberately specific: the caller is an authenticated device, and the whole
+// point of advertising the policy mode is that a client can tell "the host
+// forbids this" apart from "the agent is broken".
+const msgPolicyForbidden = "operation not permitted by host policy"
+
+// requireOp rejects a request when the host's policy mode does not permit op,
+// and otherwise runs next unchanged.
+//
+// Composition order matters: routes wrap this as requireDevice(requireOp(op,
+// handler)), so the policy check runs after authentication. Inverting that
+// order would let an unauthenticated scanner probe the host's policy tier by
+// observing 403 vs 401 on routes it has no certificate for.
+func (s *Server) requireOp(op policy.Operation, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.cfg.PolicyMode.Allows(op) {
+			attrs := []any{slog.String("operation", string(op))}
+			if device, ok := DeviceFrom(r.Context()); ok {
+				attrs = append(attrs, slog.String("device_id", device.ID))
+			}
+			s.log.Warn("rejected request forbidden by host policy", attrs...)
+			s.writeError(w, http.StatusForbidden, msgPolicyForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/httpapi/policygate_test.go
+++ b/internal/httpapi/policygate_test.go
@@ -1,0 +1,69 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/scnplt/devmon-agent/internal/policy"
+)
+
+// TestRequireOp exercises every policy mode against both an operation every
+// tier permits (OpRead) and one only the destructive tier permits (OpDelete),
+// asserting the exact status and, on rejection, the exact msgPolicyForbidden
+// body.
+func TestRequireOp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mode       policy.Mode
+		op         policy.Operation
+		wantStatus int
+	}{
+		{name: "read-only allows read", mode: policy.ModeReadOnly, op: policy.OpRead, wantStatus: http.StatusOK},
+		{name: "read-only denies delete", mode: policy.ModeReadOnly, op: policy.OpDelete, wantStatus: http.StatusForbidden},
+		{name: "default allows read", mode: policy.ModeDefault, op: policy.OpRead, wantStatus: http.StatusOK},
+		{name: "default denies delete", mode: policy.ModeDefault, op: policy.OpDelete, wantStatus: http.StatusForbidden},
+		{name: "full allows read", mode: policy.ModeFull, op: policy.OpRead, wantStatus: http.StatusOK},
+		{name: "full allows delete", mode: policy.ModeFull, op: policy.OpDelete, wantStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s := testServer(t, tt.mode)
+			var ran bool
+			guarded := s.requireOp(tt.op, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				ran = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v1/protected", nil)
+
+			// Act
+			guarded.ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			wantRan := tt.wantStatus == http.StatusOK
+			if ran != wantRan {
+				t.Errorf("handler ran = %v, want %v", ran, wantRan)
+			}
+			if tt.wantStatus == http.StatusForbidden {
+				var body errorBody
+				if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				if body.Error != msgPolicyForbidden {
+					t.Errorf("error = %q, want the exact %q", body.Error, msgPolicyForbidden)
+				}
+			}
+		})
+	}
+}

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -1,0 +1,240 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/scnplt/devmon-agent/internal/dockerx"
+)
+
+// Four small interfaces, declared here rather than in dockerx, because the
+// consumer owns the contract (repo rule: accept interfaces, return structs).
+// Splitting by object type keeps each within the 1-3 method guideline and
+// lets Phase 4 and Phase 5 add their own without widening this one.
+
+// ContainerReader lists and inspects containers.
+type ContainerReader interface {
+	ListContainers(ctx context.Context, all bool) (dockerx.ListResult[dockerx.ContainerSummary], error)
+	InspectContainer(ctx context.Context, ref string) (dockerx.ContainerDetail, error)
+}
+
+// ImageReader lists and inspects images.
+type ImageReader interface {
+	ListImages(ctx context.Context) (dockerx.ListResult[dockerx.ImageSummary], error)
+	InspectImage(ctx context.Context, ref string) (dockerx.ImageDetail, error)
+}
+
+// NetworkReader lists and inspects networks.
+type NetworkReader interface {
+	ListNetworks(ctx context.Context) (dockerx.ListResult[dockerx.NetworkSummary], error)
+	InspectNetwork(ctx context.Context, ref string) (dockerx.NetworkDetail, error)
+}
+
+// VolumeReader lists and inspects volumes.
+type VolumeReader interface {
+	ListVolumes(ctx context.Context) (dockerx.ListResult[dockerx.VolumeSummary], error)
+	InspectVolume(ctx context.Context, ref string) (dockerx.VolumeSummary, error)
+}
+
+// DockerReader is the full read-only surface the eight routes in this file
+// depend on. *dockerx.Client satisfies it; a test fake can satisfy it without
+// a live Engine.
+type DockerReader interface {
+	ContainerReader
+	ImageReader
+	NetworkReader
+	VolumeReader
+}
+
+// Compile-time proof the concrete client still satisfies the contract. A
+// signature mismatch fails here, in the package that owns the contract,
+// rather than as a confusing error at the cmd/devmon-agent call site.
+var _ DockerReader = (*dockerx.Client)(nil)
+
+// Messages for the three failure bodies a dockerx read can produce. Every
+// value here is a security decision: none of them names the underlying
+// Engine error, which may carry a socket path or other host detail.
+const (
+	// msgInvalidRef is served when a path-supplied object reference fails
+	// dockerx.ValidateRef. The request never reached the Engine.
+	msgInvalidRef = "invalid object reference"
+
+	// msgNotFound is served when the Engine confirms the object does not
+	// exist. Safe to state plainly here: the caller is already an
+	// authenticated device (requireDevice ran first), so the anti-enumeration
+	// reasoning behind /v1/pair's uniform rejection does not apply.
+	msgNotFound = "not found"
+
+	// msgEngineUnavailable is served for every Engine failure that is not a
+	// validation error or a confirmed absence: unreachable socket, timeout,
+	// or any other upstream fault. The Engine is a dependency of this agent,
+	// so its failures are gateway failures (502), not agent bugs (500) —
+	// 500 must keep meaning "the agent itself broke".
+	msgEngineUnavailable = "docker engine unavailable"
+)
+
+// writeDockerError maps a dockerx failure onto a status code. ErrInvalidRef
+// is a client mistake (400), ErrNotFound is an answer (404), and everything
+// else is the Engine failing upstream of us (502) — never 500, which must
+// keep meaning "the agent itself broke".
+func (s *Server) writeDockerError(w http.ResponseWriter, op string, err error) {
+	switch {
+	case errors.Is(err, dockerx.ErrInvalidRef):
+		s.writeError(w, http.StatusBadRequest, msgInvalidRef)
+	case errors.Is(err, dockerx.ErrNotFound):
+		s.writeError(w, http.StatusNotFound, msgNotFound)
+	default:
+		s.log.Error(op, slog.Any("err", err))
+		s.writeError(w, http.StatusBadGateway, msgEngineUnavailable)
+	}
+}
+
+// requireDocker reports whether the server has a Docker reader configured,
+// answering 502 without panicking otherwise. The existing test helpers
+// construct servers with nil dependencies deliberately, and the eight routes
+// below are registered unconditionally, so every handler must tolerate a nil
+// s.dc rather than assume routes() only wires them when dc is present.
+func (s *Server) requireDocker(w http.ResponseWriter) bool {
+	if s.dc == nil {
+		s.log.Error("docker reader not configured")
+		s.writeError(w, http.StatusBadGateway, msgEngineUnavailable)
+		return false
+	}
+	return true
+}
+
+// listAllParam parses the ?all= query parameter. A parse error is a client
+// typo, not an attack: it defaults to false rather than failing the request.
+func listAllParam(r *http.Request) bool {
+	all, err := strconv.ParseBool(r.URL.Query().Get("all"))
+	if err != nil {
+		return false
+	}
+	return all
+}
+
+// handleListContainers lists containers, optionally including stopped ones.
+func (s *Server) handleListContainers(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.ListContainers(r.Context(), listAllParam(r))
+	if err != nil {
+		s.writeDockerError(w, "list containers", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleInspectContainer returns the full projection of a single container.
+func (s *Server) handleInspectContainer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.InspectContainer(r.Context(), r.PathValue("id"))
+	if err != nil {
+		s.writeDockerError(w, "inspect container", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleListImages lists images on the host.
+func (s *Server) handleListImages(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.ListImages(r.Context())
+	if err != nil {
+		s.writeDockerError(w, "list images", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleInspectImage returns the full projection of a single image.
+func (s *Server) handleInspectImage(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.InspectImage(r.Context(), r.PathValue("id"))
+	if err != nil {
+		s.writeDockerError(w, "inspect image", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleListNetworks lists networks on the host.
+func (s *Server) handleListNetworks(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.ListNetworks(r.Context())
+	if err != nil {
+		s.writeDockerError(w, "list networks", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleInspectNetwork returns the full projection of a single network,
+// including its attached containers.
+func (s *Server) handleInspectNetwork(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.InspectNetwork(r.Context(), r.PathValue("id"))
+	if err != nil {
+		s.writeDockerError(w, "inspect network", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleListVolumes lists volumes on the host.
+func (s *Server) handleListVolumes(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.ListVolumes(r.Context())
+	if err != nil {
+		s.writeDockerError(w, "list volumes", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// handleInspectVolume returns the full projection of a single volume.
+// Volumes are named, not IDed, so the reference comes from the "name" path
+// value rather than "id".
+func (s *Server) handleInspectVolume(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	resp, err := s.dc.InspectVolume(r.Context(), r.PathValue("name"))
+	if err != nil {
+		s.writeDockerError(w, "inspect volume", err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -1,0 +1,740 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+	"github.com/scnplt/devmon-agent/internal/dockerx"
+	"github.com/scnplt/devmon-agent/internal/policy"
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// fakeDocker implements DockerReader with a per-method function field, so
+// each test injects only the behaviour it needs. A nil function field
+// answers with a zero value and no error rather than panicking, mirroring
+// what a handler sees from a Docker reader that has nothing to say yet.
+type fakeDocker struct {
+	listContainersFn   func(ctx context.Context, all bool) (dockerx.ListResult[dockerx.ContainerSummary], error)
+	inspectContainerFn func(ctx context.Context, ref string) (dockerx.ContainerDetail, error)
+	listImagesFn       func(ctx context.Context) (dockerx.ListResult[dockerx.ImageSummary], error)
+	inspectImageFn     func(ctx context.Context, ref string) (dockerx.ImageDetail, error)
+	listNetworksFn     func(ctx context.Context) (dockerx.ListResult[dockerx.NetworkSummary], error)
+	inspectNetworkFn   func(ctx context.Context, ref string) (dockerx.NetworkDetail, error)
+	listVolumesFn      func(ctx context.Context) (dockerx.ListResult[dockerx.VolumeSummary], error)
+	inspectVolumeFn    func(ctx context.Context, ref string) (dockerx.VolumeSummary, error)
+}
+
+var _ DockerReader = (*fakeDocker)(nil)
+
+func (fd *fakeDocker) ListContainers(ctx context.Context, all bool) (dockerx.ListResult[dockerx.ContainerSummary], error) {
+	if fd.listContainersFn == nil {
+		return dockerx.ListResult[dockerx.ContainerSummary]{}, nil
+	}
+	return fd.listContainersFn(ctx, all)
+}
+
+func (fd *fakeDocker) InspectContainer(ctx context.Context, ref string) (dockerx.ContainerDetail, error) {
+	if fd.inspectContainerFn == nil {
+		return dockerx.ContainerDetail{}, nil
+	}
+	return fd.inspectContainerFn(ctx, ref)
+}
+
+func (fd *fakeDocker) ListImages(ctx context.Context) (dockerx.ListResult[dockerx.ImageSummary], error) {
+	if fd.listImagesFn == nil {
+		return dockerx.ListResult[dockerx.ImageSummary]{}, nil
+	}
+	return fd.listImagesFn(ctx)
+}
+
+func (fd *fakeDocker) InspectImage(ctx context.Context, ref string) (dockerx.ImageDetail, error) {
+	if fd.inspectImageFn == nil {
+		return dockerx.ImageDetail{}, nil
+	}
+	return fd.inspectImageFn(ctx, ref)
+}
+
+func (fd *fakeDocker) ListNetworks(ctx context.Context) (dockerx.ListResult[dockerx.NetworkSummary], error) {
+	if fd.listNetworksFn == nil {
+		return dockerx.ListResult[dockerx.NetworkSummary]{}, nil
+	}
+	return fd.listNetworksFn(ctx)
+}
+
+func (fd *fakeDocker) InspectNetwork(ctx context.Context, ref string) (dockerx.NetworkDetail, error) {
+	if fd.inspectNetworkFn == nil {
+		return dockerx.NetworkDetail{}, nil
+	}
+	return fd.inspectNetworkFn(ctx, ref)
+}
+
+func (fd *fakeDocker) ListVolumes(ctx context.Context) (dockerx.ListResult[dockerx.VolumeSummary], error) {
+	if fd.listVolumesFn == nil {
+		return dockerx.ListResult[dockerx.VolumeSummary]{}, nil
+	}
+	return fd.listVolumesFn(ctx)
+}
+
+func (fd *fakeDocker) InspectVolume(ctx context.Context, ref string) (dockerx.VolumeSummary, error) {
+	if fd.inspectVolumeFn == nil {
+		return dockerx.VolumeSummary{}, nil
+	}
+	return fd.inspectVolumeFn(ctx, ref)
+}
+
+// testServerWithDocker is a fifth Server helper, additive to testServer,
+// testServerWithCA, testServerWithStore, and testServerForPairing: the read
+// routes need both a real *state.Store, to drive requireDevice, and an
+// injected DockerReader. testServer keeps constructing servers with a nil
+// dc, which several passing tests rely on, so this helper stays separate
+// rather than widening it.
+func testServerWithDocker(t *testing.T, mode policy.Mode, dc DockerReader) (*Server, *state.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Config{StateDir: dir, ListenAddr: ":8443", PolicyMode: mode}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), testLogger())
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return NewServer(cfg, st, nil, dc, nil, testLogger()), st
+}
+
+// testServerWithDockerAndLogger mirrors testServerWithDocker but takes an
+// explicit logger, for the one test that needs to inspect what was logged.
+func testServerWithDockerAndLogger(t *testing.T, mode policy.Mode, dc DockerReader, log *slog.Logger) (*Server, *state.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Config{StateDir: dir, ListenAddr: ":8443", PolicyMode: mode}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), log)
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return NewServer(cfg, st, nil, dc, nil, log), st
+}
+
+// pairDeviceForRead creates and records an active device in st, returning
+// the serial of the certificate that authenticates it, for driving
+// requireDevice without a real TLS handshake — the same technique
+// status_test.go's TestRequireDeviceResolvesRealDevice uses.
+func pairDeviceForRead(t *testing.T, st *state.Store) *big.Int {
+	t.Helper()
+	ctx := context.Background()
+	device, err := st.CreateDevice(ctx, "read test device")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	serial := big.NewInt(time.Now().UnixNano())
+	now := time.Now()
+	if err := st.RecordDeviceCert(ctx, device.ID, serial.Text(16), now, now.Add(90*24*time.Hour)); err != nil {
+		t.Fatalf("RecordDeviceCert: %v", err)
+	}
+	return serial
+}
+
+// newCapturingLogger returns a logger whose output lands in the returned
+// buffer, for the one test that must prove an Engine error's text reaches
+// the log but not the response body.
+func newCapturingLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, nil)), &buf
+}
+
+// dockerRouteCase describes one of the eight read routes: how to make its
+// backing fakeDocker method fail, how to make it succeed, and how to verify
+// a successful body.
+type dockerRouteCase struct {
+	name    string
+	path    string
+	setErr  func(fd *fakeDocker, err error)
+	setOK   func(fd *fakeDocker)
+	checkOK func(t *testing.T, body []byte)
+}
+
+func dockerRouteCases() []dockerRouteCase {
+	return []dockerRouteCase{
+		{
+			name: "list containers",
+			path: "/v1/containers",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.listContainersFn = func(context.Context, bool) (dockerx.ListResult[dockerx.ContainerSummary], error) {
+					return dockerx.ListResult[dockerx.ContainerSummary]{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.listContainersFn = func(context.Context, bool) (dockerx.ListResult[dockerx.ContainerSummary], error) {
+					return dockerx.ListResult[dockerx.ContainerSummary]{Items: []dockerx.ContainerSummary{{ID: "c1"}}}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.ListResult[dockerx.ContainerSummary]
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if len(got.Items) != 1 || got.Items[0].ID != "c1" {
+					t.Errorf("items = %+v, want one item with id c1", got.Items)
+				}
+			},
+		},
+		{
+			name: "inspect container",
+			path: "/v1/containers/abc123",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.inspectContainerFn = func(context.Context, string) (dockerx.ContainerDetail, error) {
+					return dockerx.ContainerDetail{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.inspectContainerFn = func(context.Context, string) (dockerx.ContainerDetail, error) {
+					return dockerx.ContainerDetail{ID: "c1", Name: "/c1"}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.ContainerDetail
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if got.ID != "c1" {
+					t.Errorf("id = %q, want c1", got.ID)
+				}
+			},
+		},
+		{
+			name: "list images",
+			path: "/v1/images",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.listImagesFn = func(context.Context) (dockerx.ListResult[dockerx.ImageSummary], error) {
+					return dockerx.ListResult[dockerx.ImageSummary]{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.listImagesFn = func(context.Context) (dockerx.ListResult[dockerx.ImageSummary], error) {
+					return dockerx.ListResult[dockerx.ImageSummary]{Items: []dockerx.ImageSummary{{ID: "i1"}}}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.ListResult[dockerx.ImageSummary]
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if len(got.Items) != 1 || got.Items[0].ID != "i1" {
+					t.Errorf("items = %+v, want one item with id i1", got.Items)
+				}
+			},
+		},
+		{
+			name: "inspect image",
+			path: "/v1/images/abc123",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.inspectImageFn = func(context.Context, string) (dockerx.ImageDetail, error) {
+					return dockerx.ImageDetail{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.inspectImageFn = func(context.Context, string) (dockerx.ImageDetail, error) {
+					return dockerx.ImageDetail{ID: "i1"}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.ImageDetail
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if got.ID != "i1" {
+					t.Errorf("id = %q, want i1", got.ID)
+				}
+			},
+		},
+		{
+			name: "list networks",
+			path: "/v1/networks",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.listNetworksFn = func(context.Context) (dockerx.ListResult[dockerx.NetworkSummary], error) {
+					return dockerx.ListResult[dockerx.NetworkSummary]{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.listNetworksFn = func(context.Context) (dockerx.ListResult[dockerx.NetworkSummary], error) {
+					return dockerx.ListResult[dockerx.NetworkSummary]{Items: []dockerx.NetworkSummary{{ID: "n1"}}}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.ListResult[dockerx.NetworkSummary]
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if len(got.Items) != 1 || got.Items[0].ID != "n1" {
+					t.Errorf("items = %+v, want one item with id n1", got.Items)
+				}
+			},
+		},
+		{
+			name: "inspect network",
+			path: "/v1/networks/abc123",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.inspectNetworkFn = func(context.Context, string) (dockerx.NetworkDetail, error) {
+					return dockerx.NetworkDetail{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.inspectNetworkFn = func(context.Context, string) (dockerx.NetworkDetail, error) {
+					return dockerx.NetworkDetail{NetworkSummary: dockerx.NetworkSummary{ID: "n1"}}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.NetworkDetail
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if got.ID != "n1" {
+					t.Errorf("id = %q, want n1", got.ID)
+				}
+			},
+		},
+		{
+			name: "list volumes",
+			path: "/v1/volumes",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.listVolumesFn = func(context.Context) (dockerx.ListResult[dockerx.VolumeSummary], error) {
+					return dockerx.ListResult[dockerx.VolumeSummary]{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.listVolumesFn = func(context.Context) (dockerx.ListResult[dockerx.VolumeSummary], error) {
+					return dockerx.ListResult[dockerx.VolumeSummary]{Items: []dockerx.VolumeSummary{{Name: "v1"}}}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.ListResult[dockerx.VolumeSummary]
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if len(got.Items) != 1 || got.Items[0].Name != "v1" {
+					t.Errorf("items = %+v, want one item named v1", got.Items)
+				}
+			},
+		},
+		{
+			name: "inspect volume",
+			path: "/v1/volumes/myvol",
+			setErr: func(fd *fakeDocker, err error) {
+				fd.inspectVolumeFn = func(context.Context, string) (dockerx.VolumeSummary, error) {
+					return dockerx.VolumeSummary{}, err
+				}
+			},
+			setOK: func(fd *fakeDocker) {
+				fd.inspectVolumeFn = func(context.Context, string) (dockerx.VolumeSummary, error) {
+					return dockerx.VolumeSummary{Name: "v1"}, nil
+				}
+			},
+			checkOK: func(t *testing.T, body []byte) {
+				var got dockerx.VolumeSummary
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if got.Name != "v1" {
+					t.Errorf("name = %q, want v1", got.Name)
+				}
+			},
+		},
+	}
+}
+
+// TestReadRoutesSucceed asserts each of the eight routes answers 200 with
+// the fake's data when a valid device drives the request.
+func TestReadRoutesSucceed(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			tc.setOK(fd)
+			s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+			serial := pairDeviceForRead(t, st)
+			req := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+			}
+			tc.checkOK(t, rec.Body.Bytes())
+		})
+	}
+}
+
+// TestReadRoutesNotFound asserts each route maps dockerx.ErrNotFound to a
+// 404 with the exact fixed body.
+func TestReadRoutesNotFound(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			tc.setErr(fd, dockerx.ErrNotFound)
+			s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+			serial := pairDeviceForRead(t, st)
+			req := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404; body: %s", rec.Code, rec.Body.String())
+			}
+			want := `{"error":"not found"}` + "\n"
+			if rec.Body.String() != want {
+				t.Errorf("body = %q, want %q", rec.Body.String(), want)
+			}
+		})
+	}
+}
+
+// TestReadRoutesInvalidRef asserts each route maps dockerx.ErrInvalidRef to
+// a 400.
+func TestReadRoutesInvalidRef(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			tc.setErr(fd, dockerx.ErrInvalidRef)
+			s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+			serial := pairDeviceForRead(t, st)
+			req := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+			}
+			var body errorBody
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Error != msgInvalidRef {
+				t.Errorf("error = %q, want %q", body.Error, msgInvalidRef)
+			}
+		})
+	}
+}
+
+// TestReadRoutesEngineFailure asserts a generic Engine error becomes a 502
+// with the fixed msgEngineUnavailable body, and that the underlying error
+// text is logged but never returned to the client.
+func TestReadRoutesEngineFailure(t *testing.T) {
+	t.Parallel()
+
+	const wantLogged = "engine handle closed unexpectedly on host-internal-path"
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			tc.setErr(fd, errors.New(wantLogged))
+			log, buf := newCapturingLogger()
+			s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+			serial := pairDeviceForRead(t, st)
+			req := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502; body: %s", rec.Code, rec.Body.String())
+			}
+			var body errorBody
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Error != msgEngineUnavailable {
+				t.Errorf("error = %q, want %q", body.Error, msgEngineUnavailable)
+			}
+			if bodyContains(rec.Body.String(), wantLogged) {
+				t.Errorf("response body leaks the underlying error text: %s", rec.Body.String())
+			}
+			if !bodyContains(buf.String(), wantLogged) {
+				t.Errorf("log does not contain the underlying error text; log: %s", buf.String())
+			}
+		})
+	}
+}
+
+// TestReadRoutesRequireDevice asserts each route answers 401 with the
+// standard terse body when no client certificate is presented.
+func TestReadRoutesRequireDevice(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s, _ := testServerWithDocker(t, policy.ModeDefault, &fakeDocker{})
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+			}
+			var body errorBody
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Error != msgClientCertRequired {
+				t.Errorf("error = %q, want %q", body.Error, msgClientCertRequired)
+			}
+		})
+	}
+}
+
+// TestReadRoutesRejectOtherMethods asserts POST to each known read path
+// answers 405, mirroring TestStatusRejectsOtherMethods.
+func TestReadRoutesRejectOtherMethods(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s, _ := testServerWithDocker(t, policy.ModeDefault, &fakeDocker{})
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("POST %s = %d, want 405", tc.path, rec.Code)
+			}
+		})
+	}
+}
+
+// TestReadRoutesAllowedUnderReadOnlyPolicy proves D10: OpRead is permitted
+// by every policy mode, so ModeReadOnly must not change the observable
+// behaviour of any of the eight routes.
+func TestReadRoutesAllowedUnderReadOnlyPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			tc.setOK(fd)
+			s, st := testServerWithDocker(t, policy.ModeReadOnly, fd)
+			serial := pairDeviceForRead(t, st)
+			req := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusOK {
+				t.Errorf("status under read-only policy = %d, want 200; body: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestListAllParameter confirms the ParseBool-defaults-to-false rule: a
+// malformed or absent ?all= value is treated as false rather than 400.
+func TestListAllParameter(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	var gotAll []bool
+	fd := &fakeDocker{
+		listContainersFn: func(_ context.Context, all bool) (dockerx.ListResult[dockerx.ContainerSummary], error) {
+			gotAll = append(gotAll, all)
+			return dockerx.ListResult[dockerx.ContainerSummary]{}, nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+
+	queries := []string{"?all=true", "?all=false", "?all=", "?all=yes", ""}
+
+	// Act
+	for _, q := range queries {
+		req := requestWithPeerSerial(http.MethodGet, "/v1/containers"+q, nil, serial)
+		rec := httptest.NewRecorder()
+		s.routes().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("query %q: status = %d, want 200; body: %s", q, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Assert
+	want := []bool{true, false, false, false, false}
+	if len(gotAll) != len(want) {
+		t.Fatalf("fake observed %d calls (%v), want %d", len(gotAll), gotAll, len(want))
+	}
+	for i := range want {
+		if gotAll[i] != want[i] {
+			t.Errorf("call %d (%q): all = %v, want %v", i, queries[i], gotAll[i], want[i])
+		}
+	}
+}
+
+// TestNilDockerReader asserts every read route answers 502 without panicking
+// when the server has no Docker reader configured.
+func TestNilDockerReader(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dockerRouteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s, st := testServerWithDocker(t, policy.ModeDefault, nil)
+			serial := pairDeviceForRead(t, st)
+			req := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+			rec := httptest.NewRecorder()
+
+			// Act
+			s.routes().ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502; body: %s", rec.Code, rec.Body.String())
+			}
+			var body errorBody
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Error != msgEngineUnavailable {
+				t.Errorf("error = %q, want %q", body.Error, msgEngineUnavailable)
+			}
+		})
+	}
+}
+
+// TestEmptyListMarshalsAsArray asserts that an empty list from the fake
+// serialises as "items":[], never "items":null.
+func TestEmptyListMarshalsAsArray(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		listContainersFn: func(context.Context, bool) (dockerx.ListResult[dockerx.ContainerSummary], error) {
+			return dockerx.ListResult[dockerx.ContainerSummary]{Items: []dockerx.ContainerSummary{}}, nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers", nil, serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if !bodyContains(rec.Body.String(), `"items":[]`) {
+		t.Errorf("body = %q, want it to contain %q", rec.Body.String(), `"items":[]`)
+	}
+	if bodyContains(rec.Body.String(), `"items":null`) {
+		t.Errorf("body = %q, an empty list must never marshal as null", rec.Body.String())
+	}
+}
+
+// TestErrorBodiesLeakNothing asserts that across every failure path, the
+// response body contains none of the host's state directory path, the
+// Docker socket, or the state database filename.
+func TestErrorBodiesLeakNothing(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{}
+	for _, tc := range dockerRouteCases() {
+		tc.setErr(fd, errors.New("dial unix "+`/var/run/docker.sock`+": connect: no such file or directory"))
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+
+	var bodies []string
+
+	// Act — collect every failure body: 401 (no cert), 400/404/502 (fake
+	// errors), and 405 (wrong method).
+	for _, tc := range dockerRouteCases() {
+		unauth := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		unauthRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(unauthRec, unauth)
+		bodies = append(bodies, unauthRec.Body.String())
+
+		wrongMethod := httptest.NewRequest(http.MethodPost, tc.path, nil)
+		wrongMethodRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(wrongMethodRec, wrongMethod)
+		bodies = append(bodies, wrongMethodRec.Body.String())
+
+		engineFail := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+		engineFailRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(engineFailRec, engineFail)
+		bodies = append(bodies, engineFailRec.Body.String())
+
+		tc.setErr(fd, dockerx.ErrNotFound)
+		notFound := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+		notFoundRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(notFoundRec, notFound)
+		bodies = append(bodies, notFoundRec.Body.String())
+
+		tc.setErr(fd, dockerx.ErrInvalidRef)
+		invalidRef := requestWithPeerSerial(http.MethodGet, tc.path, nil, serial)
+		invalidRefRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(invalidRefRec, invalidRef)
+		bodies = append(bodies, invalidRefRec.Body.String())
+	}
+
+	// Assert
+	for _, leak := range []string{s.cfg.StateDir, "docker.sock", "devmon.db"} {
+		for _, body := range bodies {
+			if leak != "" && bodyContains(body, leak) {
+				t.Errorf("a failure body leaks %q: %s", leak, body)
+			}
+		}
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/scnplt/devmon-agent/internal/certs"
 	"github.com/scnplt/devmon-agent/internal/config"
+	"github.com/scnplt/devmon-agent/internal/policy"
 	"github.com/scnplt/devmon-agent/internal/state"
 )
 
@@ -36,9 +37,11 @@ const (
 
 // Server owns the HTTPS listener and its routes.
 type Server struct {
-	cfg  config.Config
-	st   *state.Store
-	ca   *certs.CA
+	cfg config.Config
+	st  *state.Store
+	ca  *certs.CA
+	// dc is the Docker read surface the eight read routes depend on.
+	dc   DockerReader
 	log  *slog.Logger
 	http *http.Server
 }
@@ -49,9 +52,11 @@ type Server struct {
 // renew device certificates from it; the status handler derives the public
 // fingerprint from it on each call. ca may be nil in tests that do not
 // exercise certificate issuance; handleStatus tolerates that by serving an
-// empty fingerprint.
-func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, tlsCfg *tls.Config, log *slog.Logger) *Server {
-	s := &Server{cfg: cfg, st: st, ca: ca, log: log}
+// empty fingerprint. dc may likewise be nil in tests that do not exercise the
+// Docker read routes; every read handler tolerates that by serving 502
+// instead of panicking.
+func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger) *Server {
+	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log}
 
 	s.http = &http.Server{
 		Addr:              cfg.ListenAddr,
@@ -86,6 +91,20 @@ func (s *Server) routes() http.Handler {
 	// requireDevice from its client certificate — never from the request.
 	mux.Handle("POST /v1/device/renew", s.requireDevice(http.HandlerFunc(s.handleRenew)))
 	mux.Handle("DELETE /v1/device/self", s.requireDevice(http.HandlerFunc(s.handleUnpairSelf)))
+
+	// Read operations. Every one is guarded twice: requireDevice proves who is
+	// calling, requireOp proves the host's startup policy permits it.
+	read := func(pattern string, h http.HandlerFunc) {
+		mux.Handle(pattern, s.requireDevice(s.requireOp(policy.OpRead, h)))
+	}
+	read("GET /v1/containers", s.handleListContainers)
+	read("GET /v1/containers/{id}", s.handleInspectContainer)
+	read("GET /v1/images", s.handleListImages)
+	read("GET /v1/images/{id}", s.handleInspectImage)
+	read("GET /v1/networks", s.handleListNetworks)
+	read("GET /v1/networks/{id}", s.handleInspectNetwork)
+	read("GET /v1/volumes", s.handleListVolumes)
+	read("GET /v1/volumes/{name}", s.handleInspectVolume)
 
 	return s.withRecovery(s.withRequestLog(mux))
 }

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -28,7 +28,7 @@ func testTLSConfig(t *testing.T) *tls.Config {
 func runnableServer(t *testing.T, addr string) *Server {
 	t.Helper()
 	cfg := config.Config{StateDir: t.TempDir(), ListenAddr: addr, PolicyMode: policy.ModeDefault}
-	return NewServer(cfg, nil, nil, testTLSConfig(t), testLogger())
+	return NewServer(cfg, nil, nil, nil, testTLSConfig(t), testLogger())
 }
 
 // TestRunShutsDownCleanly is the graceful-shutdown contract: SIGTERM cancels the

--- a/internal/httpapi/status_test.go
+++ b/internal/httpapi/status_test.go
@@ -29,7 +29,7 @@ func testLogger() *slog.Logger {
 func testServer(t *testing.T, mode policy.Mode) *Server {
 	t.Helper()
 	cfg := config.Config{StateDir: t.TempDir(), ListenAddr: ":8443", PolicyMode: mode}
-	return NewServer(cfg, nil, nil, nil, testLogger())
+	return NewServer(cfg, nil, nil, nil, nil, testLogger())
 }
 
 // testServerWithCA is a second helper, additive to testServer, for tests that
@@ -43,7 +43,7 @@ func testServerWithCA(t *testing.T, mode policy.Mode) (*Server, *certs.CA) {
 	if err != nil {
 		t.Fatalf("LoadOrCreateCA: %v", err)
 	}
-	return NewServer(cfg, nil, ca, nil, testLogger()), ca
+	return NewServer(cfg, nil, ca, nil, nil, testLogger()), ca
 }
 
 // testServerWithStore is a third helper, additive to testServer and
@@ -59,7 +59,7 @@ func testServerWithStore(t *testing.T) (*Server, *state.Store) {
 		t.Fatalf("state.Open: %v", err)
 	}
 	t.Cleanup(func() { _ = st.Close() })
-	return NewServer(cfg, st, nil, nil, testLogger()), st
+	return NewServer(cfg, st, nil, nil, nil, testLogger()), st
 }
 
 // peerCertWithSerial builds a *tls.ConnectionState carrying a single peer
@@ -247,7 +247,7 @@ func TestUnknownPathLeaksNothing(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	// Act
-	s.routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/containers", nil))
+	s.routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/system/info", nil))
 
 	// Assert
 	if rec.Code != http.StatusNotFound {


### PR DESCRIPTION
Implements PRD **Phase 3 — Read operations**. Eight mTLS-guarded `GET` routes give a paired
device full read visibility into the host's Docker objects, backed by a new read-only surface
on `internal/dockerx`.

Plan: `.claude/PRPs/plans/completed/read-operations.plan.md`
Report: `.claude/PRPs/reports/read-operations-report.md`
Review: `.claude/PRPs/reviews/read-operations-review.md`

## Why this shape

This is the first phase where host data leaves the agent, so the entire security weight sits in
one decision: what a response is *allowed* to contain. Responses are **explicit allowlisted
DTOs**, never raw Engine JSON. Forwarding `container.InspectResponse` verbatim would put
`Config.Env` — every database password and API key the operator baked into a container — onto a
phone over a channel the PRD never budgeted for carrying secrets.

- **Environment variables are never returned, at any depth.** `container.Config.Env` and an
  image's baked-in env have no DTO field. Redacting values would still disclose which secrets
  exist and what they are named; omission is the only version that cannot leak. The same
  reasoning removes `volume.Volume.Options`, which routinely carries NFS/CIFS credentials.
- **Command lines *are* returned** — they identify a misconfigured container and are already
  visible in the host's process table. A deliberate, bounded disclosure.
- **References are validated before reaching the Engine.** The moby client interpolates the ID
  straight into the request URL path, so `^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$` is enforced at the
  boundary rather than relying on `ServeMux` behaviour.
- **502, not 500, for Engine failures.** The Engine is upstream of us; 500 must keep meaning
  "the agent itself broke".
- **Lists hard-capped at 500** with a `truncated` flag, server-side and not client-adjustable.

## API

| Route | Auth | Policy op |
|---|---|---|
| `GET /v1/containers?all=<bool>` | client cert | `read` |
| `GET /v1/containers/{id}` | client cert | `read` |
| `GET /v1/images` · `GET /v1/images/{id}` | client cert | `read` |
| `GET /v1/networks` · `GET /v1/networks/{id}` | client cert | `read` |
| `GET /v1/volumes` · `GET /v1/volumes/{name}` | client cert | `read` |

Every route is guarded twice — `requireDevice(requireOp(policy.OpRead, h))`, authentication
outside and policy inside, so an unauthenticated scanner cannot probe the host's policy tier by
observing 403 vs 401. `OpRead` is permitted by all three modes today, so `requireOp` is a no-op
behaviourally; it exists now so Phase 5 adds tiers to existing plumbing.

## Verification

| Check | Result |
|---|---|
| `go test ./... -race` | Pass |
| Coverage `./internal/...` | **85.5%** (floor 80%) |
| `go vet ./...` | Pass |
| `gofmt` | Pass |
| Build `CGO_ENABLED=0` | Pass — static binary |
| `golangci-lint` v2.12.2 | Pass — 0 issues repo-wide |
| `gosec ./...` | Pass — 0 issues, 34 files, 4,468 lines |

The highest-value tests assert on **marshalled JSON**, not struct fields: a `ContainerDetail`
built from `Config.Env: ["DB_PASSWORD=hunter2"]` is serialised and checked to contain neither
`env` nor `hunter2`. Same for `ImageDetail` and for volume `Options`. A field-level assertion
would miss a future embedded struct. `*FieldCount` tests pin the exact key count of all eight
DTOs so a later phase cannot widen a payload silently.

`engine_test.go` drives all eight wrappers against a fake Engine via an in-process
`http.RoundTripper` — no daemon, no socket — covering truncation boundaries (500 → false,
501 → true), 404-vs-500 classification, and proving an invalid reference reaches the Engine
**zero** times.

## Test plan before merge

- [x] ~~Run `golangci-lint run ./...` and `gosec ./...`~~ — both clean (see note below)
- [x] Start a container with `-e DB_PASSWORD=hunter2`, inspect it through the API — response is
      698 bytes and contains no `hunter2`, no `DB_PASSWORD`, no `env` key
- [x] Inspect an image built with `ENV API_KEY=supersecretkey123` — no `supersecretkey123`,
      no `API_KEY`, no `env`, no `config`
- [x] Volume created with driver options (`type=tmpfs,o=size=1m,uid=1000`) — response carries no
      `options` key and none of the option values
- [x] Stop a container → absent from `/v1/containers`, present in `?all=true` as
      `exited` / `Exited (1)`
- [x] Stop the Engine → all four list routes 502 `docker engine unavailable`, `/v1/status` still
      200, agent stayed up (0 restarts); Engine back → reads recover, still 0 restarts
- [x] `DEVMON_POLICY_MODE=read-only` → all eight routes still 200
- [x] Revoke a device → all read routes 401 `client certificate required` immediately, no agent
      restart; `/v1/status` still 200

## End-to-end validation (completed)

Run against **Docker 29.6.1 / API 1.55** with the agent in its own container, a real paired
device (mTLS, cert issued through `/v1/pair`), and purpose-built fixtures carrying real secrets.
All eight routes returned 200; error paths returned 404 / 400 / 405 / 401 as specified.

The Engine-failure case was exercised by running the agent through a socat proxy and stopping
the proxy, so the Engine became unreachable *while the agent kept running* — the property the
plan actually cares about. Stopping the host daemon outright would have killed the agent
container with it and proved nothing.

One clarification for anyone re-running this: `curl` normalizes `%2e%2e` client-side and the
agent answers 404. With `--path-as-is` the request reaches the handler and returns the
documented **400 `invalid object reference`**, as do `%2e%2e%2finfo`, `a%2fb`, `foo$bar`,
`-leading` and `sha256:ab`. A literal unencoded `..` is redirected (307) by stdlib ServeMux
path-cleaning before the handler runs. Every form is rejected before any Engine call.

## Gate note

`golangci-lint` and `gosec` were installed after this PR was opened and have both been run.
`gosec ./...` reports 0 issues.

The two tools appear to disagree, so to be precise: `gosec ./...` skips `_test.go` files by
default. `gosec -tests ./...` reports 5 findings and `golangci-lint --enable gosec` reports 4 of
the same set. All are in Phase 1-2 test files this PR never touches — `certs/ca_test.go:346,367`
and `certs/store_test.go:141,163` (G306, fixtures writing `0o644` into a temp dir) and
`state/pairing_test.go:126` (G115, `string(rune(...))`). Production code is clean under both.
Left out of this branch to keep the diff to the eight read routes; worth a separate cleanup.

## Reviewer notes

Two MEDIUM findings from `/ecc:code-review` were fixed in this branch: an unguarded
`time.Unix(0,0)` that emitted a false `1970-01-01` timestamp, and truncation/labels logic
duplicated across the four mapper files (extracted into `internal/dockerx/list.go`).

**One open decision, not blocking:** `withRequestLog` logs `r.URL.Path` at Debug. Its doc comment
promises "method, path, status, and duration only", and the plan's manual checklist asserts
`agent.log` carries no reference values. The `{id}`/`{name}` routes added here mean the logged
path now contains caller-supplied references. Container IDs and volume names are not secrets and
this is Debug-only, so nothing was changed — but the checklist wording is now inaccurate and the
call is worth making deliberately.

Deferred by design: container stats, logs (Phase 4), lifecycle operations (Phase 5), the agent's
own `protected: true` self-marking (Phase 5), server-side filtering, and pagination cursors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


