### PR TITLE
fix: make the e2e suite pass on a native Linux Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,13 @@ whose own environment is built explicitly from each test case.
 Without an Engine, every test **skips** with a reason naming the endpoint —
 visibly, in `go test` output — rather than passing quietly.
 
+`TestContainerListReportsHealth` additionally needs Engine 29+ / API v1.52: the
+`ContainerSummary.Health` field the list projection reads was only added at
+that version, so on an older Engine (even a reachable, healthy one) the test
+skips with that reason instead of failing, and `DEVMON_E2E_REQUIRE=1` does not
+override that skip — it is a genuine Engine capability floor, not a missing
+Engine.
+
 **On Windows, run these from a WSL2 shell.** The agent accepts only `unix://`
 and `tcp://` Docker endpoints, so Docker Desktop's default
 `npipe:////./pipe/docker_engine` cannot be given to it at all, and the

--- a/internal/e2e/api/contract_reads_test.go
+++ b/internal/e2e/api/contract_reads_test.go
@@ -370,9 +370,18 @@ func TestContainerListAllParameter(t *testing.T) {
 // healthcheck eventually surfaces health: "unhealthy" in the list projection.
 // Docker needs a few checks before it reports the container unhealthy, so
 // this polls with a deadline rather than sleeping a fixed duration.
+//
+// Requires Engine 29+ / API v1.52: per the vendored swagger spec,
+// ContainerSummary.Health was added in API v1.52 — before that version the
+// list projection (/containers/json) never sends the field at all, so an
+// older Engine would leave "health" perpetually absent no matter how the
+// fixture container behaves. That is a genuine Engine capability floor, not
+// a bug in the projection, so the test skips below that version rather than
+// failing.
 func TestContainerListReportsHealth(t *testing.T) {
 	t.Parallel()
 	engine := harness.RequireEngine(t)
+	harness.RequireEngineAPIAtLeast(t, engine, "1.52")
 	_, d := readReadyAgent(t, "reads-health")
 
 	id := harness.StartFixture(t, engine, harness.FixtureOptions{

--- a/internal/e2e/harness/cli.go
+++ b/internal/e2e/harness/cli.go
@@ -66,13 +66,39 @@ func MintPairingCode(t *testing.T, a *Agent, name string) string {
 	return ""
 }
 
-// ListDevices runs `device list` and parses its tabwriter table.
+// ListDevices runs `device list` on the host against a and parses its
+// tabwriter table. a's state directory must be readable by the host test
+// user — a state directory written by a containerised agent (UID 65532,
+// files at 0600) is not; use ListDevicesInContainer for that case.
 func ListDevices(t *testing.T, a *Agent) []DeviceRow {
 	t.Helper()
+	return parseDeviceRows(t, runCLI(t, a, "device", "list"))
+}
 
-	out := runCLI(t, a, "device", "list")
+// RevokeDevice runs `device revoke <id>` against a.
+func RevokeDevice(t *testing.T, a *Agent, id string) {
+	t.Helper()
+	runCLI(t, a, "device", "revoke", id)
+}
+
+// ListAudit runs `audit list --limit <limit>` on the host against a and
+// parses its tabwriter table. Same host-readability caveat as ListDevices;
+// use ListAuditInContainer for a containerised agent's state directory.
+// Columns are split on runs of two-or-more spaces, not single spaces:
+// DETAIL can be empty, and DEVICE contains "id (name)" with a single space
+// inside it.
+func ListAudit(t *testing.T, a *Agent, limit int) []AuditRow {
+	t.Helper()
+	return parseAuditRows(t, runCLI(t, a, "audit", "list", "--limit", strconv.Itoa(limit)))
+}
+
+// parseDeviceRows parses `device list`'s tabwriter table into DeviceRow
+// values. Shared by the host-side (ListDevices) and in-container
+// (ListDevicesInContainer) call sites so their assertions never drift apart.
+func parseDeviceRows(t *testing.T, out string) []DeviceRow {
+	t.Helper()
+
 	rows := parseTable(t, out, 5)
-
 	result := make([]DeviceRow, 0, len(rows))
 	for _, f := range rows {
 		result = append(result, DeviceRow{
@@ -86,22 +112,13 @@ func ListDevices(t *testing.T, a *Agent) []DeviceRow {
 	return result
 }
 
-// RevokeDevice runs `device revoke <id>` against a.
-func RevokeDevice(t *testing.T, a *Agent, id string) {
-	t.Helper()
-	runCLI(t, a, "device", "revoke", id)
-}
-
-// ListAudit runs `audit list --limit <limit>` and parses its tabwriter table.
-// Columns are split on runs of two-or-more spaces, not single spaces:
-// DETAIL can be empty, and DEVICE contains "id (name)" with a single space
-// inside it.
-func ListAudit(t *testing.T, a *Agent, limit int) []AuditRow {
+// parseAuditRows parses `audit list`'s tabwriter table into AuditRow values.
+// Shared by the host-side (ListAudit) and in-container (ListAuditInContainer)
+// call sites so their assertions never drift apart.
+func parseAuditRows(t *testing.T, out string) []AuditRow {
 	t.Helper()
 
-	out := runCLI(t, a, "audit", "list", "--limit", strconv.Itoa(limit))
 	rows := parseTable(t, out, 6)
-
 	result := make([]AuditRow, 0, len(rows))
 	for _, f := range rows {
 		result = append(result, AuditRow{

--- a/internal/e2e/harness/engine.go
+++ b/internal/e2e/harness/engine.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -111,6 +112,83 @@ func skipOrFail(t *testing.T, reason string) {
 		t.Fatalf("%s (required by %s=1)", reason, envRequire)
 	}
 	t.Skip(reason)
+}
+
+// RequireEngineAPIAtLeast skips the calling test when cli's negotiated
+// Docker Engine API version is older than minVersion (a "major.minor"
+// string, e.g. "1.52"). Comparison is numeric on the major and minor
+// components, never a string comparison — "1.5" would otherwise sort after
+// "1.48".
+//
+// cli must come from RequireEngine, called first by the caller (see
+// RequireLinuxContainerEngine for the same composition pattern). This
+// function never dials its own connection and never decides "no Engine
+// answered" — that decision, and its DEVMON_E2E_REQUIRE=1 hard-failure path,
+// belongs entirely to RequireEngine/skipOrFail. If cli is nil, the caller has
+// already been skipped or failed by RequireEngine and this is a no-op.
+//
+// A Ping error here — on an Engine that already answered RequireEngine's own
+// ping moments earlier — is not a capability gap, so it is routed through
+// skipOrFail, not t.Skipf: DEVMON_E2E_REQUIRE=1 should still turn "Engine
+// stopped answering" into a hard failure.
+//
+// Only the actual version comparison — and an unparseable version string —
+// calls t.Skipf DIRECTLY, never skipOrFail: DEVMON_E2E_REQUIRE=1 exists to
+// turn "no Engine answered" into a hard failure so a silently-passing suite
+// cannot flip a PRD row (D5). An Engine that DID answer but predates the API
+// version carrying the field under test is not a missing Engine — it is a
+// genuine capability gap in the Engine itself, and no amount of
+// DEVMON_E2E_REQUIRE=1 can make an old Engine speak a field it never sends.
+// Forcing that case to a hard failure would make CI red on Engine versions
+// the project never claimed to support, for a reason unrelated to the code
+// under test.
+func RequireEngineAPIAtLeast(t *testing.T, cli *client.Client, minVersion string) {
+	t.Helper()
+
+	if cli == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
+	result, err := cli.Ping(ctx, client.PingOptions{NegotiateAPIVersion: true})
+	if err != nil {
+		skipOrFail(t, fmt.Sprintf("Docker Engine did not answer a ping: %v", err))
+		return
+	}
+
+	gotMajor, gotMinor, err := parseAPIVersion(result.APIVersion)
+	if err != nil {
+		t.Skipf("Docker Engine reported an unparseable API version %q: %v", result.APIVersion, err)
+		return
+	}
+	wantMajor, wantMinor, err := parseAPIVersion(minVersion)
+	if err != nil {
+		t.Fatalf("RequireEngineAPIAtLeast: minVersion %q: %v", minVersion, err)
+	}
+
+	if gotMajor < wantMajor || (gotMajor == wantMajor && gotMinor < wantMinor) {
+		t.Skipf("Docker Engine API version %s is older than the %s this test needs", result.APIVersion, minVersion)
+	}
+}
+
+// parseAPIVersion splits a "major.minor" Docker API version string into its
+// numeric components, so callers compare versions numerically rather than
+// lexicographically ("1.5" < "1.48" as strings, but not as versions).
+func parseAPIVersion(version string) (major, minor int, err error) {
+	parts := strings.SplitN(version, ".", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected a \"major.minor\" version, got %q", version)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse major version from %q: %w", version, err)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse minor version from %q: %w", version, err)
+	}
+	return major, minor, nil
 }
 
 // FixtureOptions describes one throwaway container the suite creates against

--- a/internal/e2e/harness/image.go
+++ b/internal/e2e/harness/image.go
@@ -165,6 +165,16 @@ type ContainerAgent struct {
 // TEST-ONLY widening of a directory StartAgent (well, here, RunAgentContainer)
 // deletes at cleanup; it is exactly the mistake the README warns real
 // operators against, done here on purpose and only here.
+//
+// GOTCHA (native Linux Engine only): the pre-start 0o777 above only covers
+// the directory itself. Everything the agent creates UNDERNEATH it while
+// running — logs/ (0700) and its log files (0600), both owned by UID 65532 —
+// is still narrow, and on a native Linux Engine those ownerships are real on
+// the host filesystem. When opts.StateDir == "" this function's stateDir is
+// a t.TempDir(), and Go's own t.TempDir() cleanup then fails to RemoveAll a
+// tree the host test user cannot traverse or delete. See
+// widenStateDirForCleanup for how the fix works and why it is a container,
+// not a host-side chmod.
 func RunAgentContainer(t *testing.T, e *client.Client, opts ContainerAgentOptions) *ContainerAgent {
 	t.Helper()
 	ctx := context.Background()
@@ -182,6 +192,11 @@ func RunAgentContainer(t *testing.T, e *client.Client, opts ContainerAgentOption
 	if err := os.Chmod(stateDir, 0o777); err != nil {
 		t.Fatalf("chmod state dir %s: %v", stateDir, err)
 	}
+	// Registered AFTER t.TempDir()'s own cleanup (above, when opts.StateDir ==
+	// ""): t.Cleanup funcs run LIFO, so this one runs BEFORE t.TempDir()'s
+	// RemoveAll gets a chance to trip over files it cannot delete. See the
+	// GOTCHA above and widenStateDirForCleanup's doc comment.
+	t.Cleanup(func() { widenStateDirForCleanup(t, e, stateDir) })
 
 	socketPath := dockerSocketPathOrFail(t)
 	binds := []string{
@@ -236,6 +251,79 @@ func RunAgentContainer(t *testing.T, e *client.Client, opts ContainerAgentOption
 	}
 	waitContainerReady(t, c)
 	return c
+}
+
+// widenStateDirForCleanup makes everything the agent created under stateDir
+// host-removable, by running a throwaway root container that chmods the
+// whole bind-mounted tree from the inside.
+//
+// The host test user cannot do this itself: the agent runs as UID 65532 and
+// creates logs/ (0700) and its log files (0600) under stateDir
+// (internal/logging/logging.go); on a native Linux Engine those ownerships
+// are real on the host filesystem, and a user can never chmod or remove
+// files it does not own, no matter what mode the PARENT directory carries.
+// Docker Desktop hides this entirely — it presents the bind mount through
+// its own VM, where the host user appears to own everything the container
+// wrote regardless of the in-container UID — which is why this asymmetry
+// only surfaces on a native Linux Engine such as the CI runner's.
+//
+// This is a cleanup helper, called from a t.Cleanup: failure is reported
+// with t.Logf, never t.Fatalf, so a permission problem here can never fail
+// the test it is cleaning up after.
+func widenStateDirForCleanup(t *testing.T, e *client.Client, stateDir string) {
+	t.Helper()
+
+	if os.Getenv(envKeep) == "1" {
+		t.Logf("%s=1: leaving %s ownership as-is for inspection", envKeep, stateDir)
+		return
+	}
+
+	ctx := context.Background()
+	if _, err := e.ImageInspect(ctx, defaultFixtureImage); err != nil {
+		rc, pullErr := e.ImagePull(ctx, defaultFixtureImage, client.ImagePullOptions{})
+		if pullErr != nil {
+			t.Logf("widen state dir %s: pull %s: %v", stateDir, defaultFixtureImage, pullErr)
+			return
+		}
+		waitErr := rc.Wait(ctx)
+		_ = rc.Close()
+		if waitErr != nil {
+			t.Logf("widen state dir %s: pull %s: %v", stateDir, defaultFixtureImage, waitErr)
+			return
+		}
+	}
+
+	name := fmt.Sprintf("devmon-e2e-widen-%s-%d", runID, time.Now().UnixNano())
+	created, err := e.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Name: name,
+		Config: &container.Config{
+			Image:  defaultFixtureImage,
+			Cmd:    []string{"chmod", "-R", "a+rwX", "/s"},
+			Labels: map[string]string{LabelSuite: "1", LabelRun: runID},
+		},
+		HostConfig: &container.HostConfig{
+			Binds: []string{stateDir + ":/s"},
+		},
+	})
+	if err != nil {
+		t.Logf("widen state dir %s: create widening container: %v", stateDir, err)
+		return
+	}
+	defer removeFixture(t, e, created.ID)
+
+	if _, err := e.ContainerStart(ctx, created.ID, client.ContainerStartOptions{}); err != nil {
+		t.Logf("widen state dir %s: start widening container: %v", stateDir, err)
+		return
+	}
+
+	wait := e.ContainerWait(ctx, created.ID, client.ContainerWaitOptions{Condition: container.WaitConditionNotRunning})
+	select {
+	case <-wait.Result:
+	case err := <-wait.Error:
+		t.Logf("widen state dir %s: wait for widening container: %v", stateDir, err)
+	case <-time.After(10 * time.Second):
+		t.Logf("widen state dir %s: widening container did not finish within 10s", stateDir)
+	}
 }
 
 // containerAgentEnv builds the DEVMON_* set for one containerised agent,
@@ -501,6 +589,45 @@ func MintPairingCodeInContainer(t *testing.T, c *ContainerAgent, name string) st
 	}
 	t.Fatalf("device pair-code (in container): did not find a %q line in %d lines of output", pairingCodePrefix, len(lines))
 	return ""
+}
+
+// devmonAgentBinPath is the path the shipped image installs the devmon-agent
+// binary at (Dockerfile); every in-container Exec of a `device`/`audit`
+// subcommand runs it from here.
+const devmonAgentBinPath = "/usr/local/bin/devmon-agent"
+
+// ListDevicesInContainer runs `device list` INSIDE the agent container via
+// Exec and parses it with the same parseDeviceRows helper ListDevices uses
+// on the host, so the two paths' assertions cannot drift apart.
+//
+// This exists because devmon.db is 0600, owned by UID 65532
+// (internal/state/store.go) — on a native Linux Engine the host test process
+// cannot open it directly, unlike Docker Desktop, which presents the bind
+// mount through its own VM where the host user appears to own everything.
+// Running the CLI where the file was written, inside the container, is the
+// same fix MintPairingCodeInContainer already applies to pairing.
+func ListDevicesInContainer(t *testing.T, c *ContainerAgent) []DeviceRow {
+	t.Helper()
+
+	out, exitCode := c.Exec(t, devmonAgentBinPath, "device", "list")
+	if exitCode != 0 {
+		t.Fatalf("device list (in container): exit code %d", exitCode)
+	}
+	return parseDeviceRows(t, out)
+}
+
+// ListAuditInContainer runs `audit list --limit <limit>` INSIDE the agent
+// container via Exec and parses it with the same parseAuditRows helper
+// ListAudit uses on the host. Same rationale as ListDevicesInContainer:
+// devmon.db is unreadable by the host test process on a native Linux Engine.
+func ListAuditInContainer(t *testing.T, c *ContainerAgent, limit int) []AuditRow {
+	t.Helper()
+
+	out, exitCode := c.Exec(t, devmonAgentBinPath, "audit", "list", "--limit", strconv.Itoa(limit))
+	if exitCode != 0 {
+		t.Fatalf("audit list (in container): exit code %d", exitCode)
+	}
+	return parseAuditRows(t, out)
 }
 
 // PairDeviceInContainer performs the same documented pairing sequence

--- a/internal/e2e/incontainer/contract_selfexclusion_test.go
+++ b/internal/e2e/incontainer/contract_selfexclusion_test.go
@@ -378,14 +378,13 @@ func TestAuditRecordsSelfRefusals(t *testing.T) {
 		}
 	}
 
-	// The CLI's DEVMON_STATE_DIR requirement is all runCLI reads off the
-	// *harness.Agent it is given (internal/e2e/harness/cli.go); the agent
-	// container's state directory is the same host path RunAgentContainer
-	// bind-mounted in, so a minimal Agent value carrying just that field lets
-	// this test reuse harness.ListAudit verbatim instead of duplicating the
-	// CLI subprocess and tabwriter-parsing logic here.
-	target := &harness.Agent{StateDir: c.StateDir}
-	rows := harness.ListAudit(t, target, len(refFormOrder)+5)
+	// audit list runs INSIDE the container: devmon.db is 0600, owned by
+	// UID 65532 (internal/state/store.go), and the host test user cannot
+	// open it directly on a native Linux Engine (image.go's
+	// ListAuditInContainer doc comment). It shares the same table-parsing
+	// helper the host-side harness.ListAudit uses, so the assertions below
+	// cannot drift from the host-side path.
+	rows := harness.ListAuditInContainer(t, c, len(refFormOrder)+5)
 
 	found := 0
 	for _, form := range refFormOrder {

--- a/internal/e2e/incontainer/contract_state_test.go
+++ b/internal/e2e/incontainer/contract_state_test.go
@@ -78,7 +78,11 @@ func TestStateSurvivesCrashRestart(t *testing.T) {
 		t.Errorf("post-restart GET /v1/containers with the pre-kill device certificate: status = %d, want %d; body = %v", status, http.StatusOK, obj)
 	}
 
-	rows := harness.ListDevices(t, &harness.Agent{StateDir: c.StateDir})
+	// device list runs INSIDE the container: devmon.db is 0600, owned by
+	// UID 65532 (internal/state/store.go), and the host test user cannot
+	// open it directly on a native Linux Engine (image.go's
+	// ListDevicesInContainer doc comment).
+	rows := harness.ListDevicesInContainer(t, c)
 	found := false
 	for _, row := range rows {
 		if row.ID == device.ID {


### PR DESCRIPTION
## Why

The `e2e` job is gated on `github.base_ref == 'main'`, so PR #13 (`dev` -> `main`) is the first time it has ever run in CI. It failed nine tests. None of them is a regression from the release commits — all three defects are assumptions the suite makes that hold on the WSL2 Engine the Phase 7 manual checklist used, and not on the runner's native Linux one.

## The three defects

**1. `TestContainerListReportsHealth` — Engine too old for the field under test**

`ContainerSummary.Health` was added in Docker API **v1.52** (`moby/moby/api@v1.55.0/swagger.yaml:5850-5855`). The runner speaks **1.48**, so `/containers/json` never sends the field, `toContainerSummary` leaves `health` empty, `omitempty` drops the key, and the test polled `<nil>` for the full 20s window.

That is an Engine capability floor, not a bug in the projection. The test now calls `RequireEngineAPIAtLeast(t, engine, "1.52")`. The version comparison skips **even under `DEVMON_E2E_REQUIRE=1`** — no flag can make an old Engine speak a field it never sends — but the helper takes the client `RequireEngine` already returned, so it can never swallow the "no Engine answered" case that flag exists to catch.

**2. `t.TempDir` cleanup failed on `logs/` — 7 tests**

```
TempDir RemoveAll cleanup: openfdat /tmp/TestX.../001/logs: permission denied
```

The image runs as UID 65532 and creates `logs/` at 0700 (`internal/logging/logging.go`). `RunAgentContainer` widened the state directory itself to 0777 before start, but nothing created underneath it. Seven tests failed at cleanup with every assertion already passing.

`widenStateDirForCleanup` runs a throwaway root container to `chmod -R a+rwX` the mount from the inside — the only way that works, since a host user cannot chmod files it does not own whatever mode the parent carries. Registered after `t.TempDir`'s own cleanup and so, LIFO, runs before it. Honours `DEVMON_E2E_KEEP=1`; failures are `t.Logf`, never fatal.

**3. Host CLI could not open the bind-mounted `devmon.db` — 2 tests**

```
state store is unreadable or corrupt: .../devmon.db: unable to open database file (14)
```

`devmon.db` is 0600 owned by 65532 (`internal/state/store.go`). Two tests ran the host binary against it directly. They now run `device list` and `audit list` inside the container via `Exec` — the fix `MintPairingCodeInContainer` already applied to pairing — sharing the host path's table parsers so the assertions cannot drift.

The `remove fixture container ... No such container` lines in the CI log are not causes: those tests deliberately remove the container, and cleanup's `t.Logf` only surfaces because defect 2 had already failed the test.

## Scope

No production code changed. Only `internal/e2e/**` and one README paragraph recording the Engine 29+ / API v1.52 floor for the health assertion.

## Test plan

- [x] `go build ./...`
- [x] `go vet -tags e2e ./internal/e2e/...`
- [x] `go test ./internal/... -race`
- [x] `go test -tags e2e ./internal/e2e/harness/ -race`
- [x] `go test -tags e2e -run XXX_NONE ./internal/e2e/...` (e2e binaries compile)
- [x] `golangci-lint run ./...` and `--build-tags e2e` — 0 issues
- [x] `gosec ./...` — 0 issues
- [x] `gofmt -l` clean on touched files
- [ ] **The e2e suite itself is not verified by this PR.** `e2e` only runs on PRs into `main`, so this PR runs `test` alone. The real proof is PR #13 re-running after this lands on `dev`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>