### PR TITLE
fix: stop logging client disconnects from a log stream at ERROR

### DIFF
--- a/internal/httpapi/clientgone.go
+++ b/internal/httpapi/clientgone.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+)
+
+// isClientGone reports whether err — observed while ctx is the request's own
+// (possibly derived) context — indicates the peer disconnected rather than a
+// genuine service fault. handleStreamContainerLogs uses it for two decisions:
+// whether a terminal event: error frame is worth attempting at all once
+// StreamContainerLogs has already failed, and, if the frame is attempted,
+// what level a failed send should log at. A client that is no longer there
+// cannot receive anything the agent tries to tell it, so neither case is an
+// agent error.
+//
+// The checks are ordered from most to least structural, and only the last
+// one is a string match:
+//
+//  1. ctx.Err() != nil, or errors.Is(err, context.Canceled). This is the
+//     robust, portable signal: net/http's Request.Context doc comment states
+//     the context of an incoming server request "is canceled when the
+//     client's connection closes, the request is canceled (with HTTP/2), or
+//     when the ServeHTTP method returns" — so this one check already covers
+//     both the HTTP/1.1 and HTTP/2 disconnect paths with no string matching
+//     at all. handleStreamContainerLogs derives ctx via
+//     context.WithCancel(r.Context()) and defers cancel() before this
+//     predicate can ever run, so by Go's LIFO defer order that cancel() has
+//     not fired yet at either call site (the streamErr check or the terminal
+//     frame write): a non-nil ctx.Err() here can only come from the PARENT
+//     (r.Context()) having been canceled, i.e. the client actually going
+//     away, never from the handler's own unwind.
+//
+//  2. errors.Is(err, net.ErrClosed). Covers a closed-connection error
+//     surfacing through a net.Conn / net.OpError wrapper independently of
+//     whether the context has observed the cancellation yet.
+//
+//  3. A string match on the two disconnect errors actually measured on this
+//     route: "client disconnected" and "http2: stream closed". Both come
+//     from unexported package-level sentinels inside net/http's bundled
+//     HTTP/2 implementation (http2errClientDisconnected and
+//     http2errStreamClosed in h2_bundle.go) with no exported equivalent to
+//     compare against using errors.Is, so a substring check is genuinely the
+//     only option left once arms 1 and 2 do not match — this is a documented
+//     fallback, not the primary detector. In practice arm 1 already catches
+//     both measured cases (see TestIsClientGone), so this arm exists as a
+//     forward-compatible backstop rather than because it is load-bearing
+//     today.
+//
+// syscall.EPIPE and syscall.ECONNRESET were considered and deliberately left
+// out: syscall's error constants are not uniform across every platform this
+// package must build for (CGO_ENABLED=0, cross-compiled), so checking them
+// here would force a build-tag split for a case arm 1 already covers.
+func isClientGone(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "client disconnected") || strings.Contains(msg, "http2: stream closed")
+}

--- a/internal/httpapi/clientgone_test.go
+++ b/internal/httpapi/clientgone_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+// TestIsClientGone drives isClientGone over each of its arms directly,
+// independent of the HTTP stack, so the predicate's own logic is pinned
+// without needing a real disconnected connection.
+func TestIsClientGone(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{name: "nil error is never client-gone", ctx: context.Background(), err: nil, want: false},
+		{
+			name: "canceled context with an unrelated error is client-gone",
+			ctx:  canceledCtx,
+			err:  errors.New("write: broken pipe"),
+			want: true,
+		},
+		{
+			name: "live context but err wraps context.Canceled is client-gone",
+			ctx:  context.Background(),
+			err:  errors.Join(errors.New("flush sse frame"), context.Canceled),
+			want: true,
+		},
+		{
+			name: "err wraps net.ErrClosed is client-gone",
+			ctx:  context.Background(),
+			err:  errors.Join(errors.New("flush sse frame"), net.ErrClosed),
+			want: true,
+		},
+		{
+			name: "err text matches the observed HTTP/2 client-disconnected string",
+			ctx:  context.Background(),
+			err:  errors.New("flush sse frame: client disconnected"),
+			want: true,
+		},
+		{
+			name: "err text matches the observed HTTP/2 stream-closed string",
+			ctx:  context.Background(),
+			err:  errors.New("flush sse frame: http2: stream closed"),
+			want: true,
+		},
+		{
+			name: "a genuine, unrelated failure with a live context is not client-gone",
+			ctx:  context.Background(),
+			err:  errors.New("engine connection dropped"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := isClientGone(tt.ctx, tt.err)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("isClientGone(%v, %v) = %v, want %v", tt.ctx.Err(), tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/httpapi/logs.go
+++ b/internal/httpapi/logs.go
@@ -189,11 +189,33 @@ func (s *Server) handleStreamContainerLogs(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// A stream that failed because the client went away has nothing left to
+	// deliver and no one left to deliver it to: attempting the terminal
+	// frame below would just be a second write failing for the same reason
+	// the first one did, and logging that at ERROR would report, at the
+	// agent's highest severity, that it could not tell a client something
+	// the client is no longer there to hear (issue #9). See isClientGone's
+	// doc comment for exactly what "gone" is checked against — a genuine
+	// Engine fault with the client still connected falls through unchanged.
+	if isClientGone(ctx, streamErr) {
+		return
+	}
+
 	// Headers are already committed: the only way left to signal failure is
 	// a terminal event frame. D16 forbids logging the ref alongside the
 	// container's own output — this path never touches LogLine.Line, only
 	// the error.
 	if err := sse.event("", sseEventError, errorBody{Error: msgEngineUnavailable}); err != nil {
-		s.log.Error("stream container logs: write terminal error frame", slog.Any("err", err))
+		// streamErr above was a genuine Engine fault, not a disconnect — so
+		// this write was worth attempting. But the client can still have
+		// vanished in the gap between the Engine dying and this frame going
+		// out, and a failure for THAT reason is the same "no one to hear
+		// this" case one step later: DEBUG, not ERROR. Any other failure to
+		// send the frame is a distinct fault of its own and stays at ERROR.
+		if isClientGone(ctx, err) {
+			s.log.Debug("stream container logs: write terminal error frame", slog.Any("err", err))
+		} else {
+			s.log.Error("stream container logs: write terminal error frame", slog.Any("err", err))
+		}
 	}
 }

--- a/internal/httpapi/logs_test.go
+++ b/internal/httpapi/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -17,6 +18,30 @@ import (
 	"github.com/scnplt/devmon-agent/internal/dockerx"
 	"github.com/scnplt/devmon-agent/internal/policy"
 )
+
+// flushFailingRecorder wraps httptest.ResponseRecorder to make one specific
+// Flush call fail, so a test can force sse.event's "flush sse frame: %w" or
+// "flush sse headers: %w" path without a real disconnected socket.
+// FlushError, not Flush, is the method http.ResponseController looks for
+// first (see net/http's ResponseController.Flush), so implementing that one
+// method is enough to make the whole flush chain return failErr on the
+// failOn'th call and nil on every other call.
+type flushFailingRecorder struct {
+	*httptest.ResponseRecorder
+	failOn     int
+	failErr    error
+	flushCount int
+}
+
+func (f *flushFailingRecorder) SetWriteDeadline(time.Time) error { return nil }
+
+func (f *flushFailingRecorder) FlushError() error {
+	f.flushCount++
+	if f.flushCount == f.failOn {
+		return f.failErr
+	}
+	return nil
+}
 
 // logRoutePaths lists the two log routes, for the tests that assert identical
 // behaviour across both (401, 405, nil-reader, leak checks).
@@ -315,6 +340,136 @@ func TestStreamErrorAfterFirstLine(t *testing.T) {
 	wantSuffix := fmt.Sprintf("event: error\ndata: {\"error\":%q}\n\n", msgEngineUnavailable)
 	if !strings.HasSuffix(body, wantSuffix) {
 		t.Errorf("body = %q, want it to end with %q", body, wantSuffix)
+	}
+}
+
+// TestStreamClientDisconnectLogsNothingAtError is issue #9's regression: a
+// client that disconnects mid-stream must not produce an ERROR line. The
+// agent failing to tell a departed client that it is gone is not an agent
+// fault, so no terminal frame should even be attempted. This asserts on the
+// captured log content, not merely "no panic" — the old behaviour never
+// panicked, it just logged ERROR on every ordinary disconnect.
+func TestStreamClientDisconnectLogsNothingAtError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — the fake cancels the request's own context before returning
+	// its error, exactly as net/http cancels it when the underlying
+	// connection closes (see isClientGone's doc comment), and the recorder's
+	// first Flush call fails with the disconnect text actually observed on
+	// this route, so the error path is exercised the way it happens for
+	// real rather than via a synthetic error value.
+	rec := &flushFailingRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		failOn:           1,
+		failErr:          errors.New("client disconnected"),
+	}
+	var cancelReq context.CancelFunc
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(_ context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			cancelReq()
+			return emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "line before disconnect"})
+		},
+	}
+	log, buf := newCapturingLoggerAtLevel(slog.LevelDebug)
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+	cancelableCtx, cancel := context.WithCancel(req.Context())
+	cancelReq = cancel
+	req = req.WithContext(cancelableCtx)
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("agent log contains an ERROR line for an ordinary client disconnect: %s", buf.String())
+	}
+	if got := strings.Count(rec.Body.String(), "event: error"); got != 0 {
+		t.Errorf("body has %d terminal error frames, want 0: a disconnected client cannot receive one", got)
+	}
+}
+
+// TestStreamGenuineFailureStillSendsTerminalFrameWhenConnected pins the
+// unchanged half of issue #9's fix: a real Engine fault, with the client
+// still connected, must still produce the terminal event: error frame and
+// must not be swallowed as a false-positive "client gone".
+func TestStreamGenuineFailureStillSendsTerminalFrameWhenConnected(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(_ context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			if err := emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "one line before the fault"}); err != nil {
+				return err
+			}
+			return errors.New("engine connection dropped")
+		},
+	}
+	log, buf := newCapturingLoggerAtLevel(slog.LevelDebug)
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	body := rec.Body.String()
+	if got := strings.Count(body, "event: error\n"); got != 1 {
+		t.Errorf("body has %d event: error frames, want 1 for a genuine Engine fault; body: %q", got, body)
+	}
+	// The frame write itself succeeded (deadlineAwareRecorder never fails a
+	// flush), so nothing about the terminal frame should have been logged
+	// at any level.
+	if strings.Contains(buf.String(), "write terminal error frame") {
+		t.Errorf("agent log unexpectedly mentions the terminal frame for a successful send: %s", buf.String())
+	}
+}
+
+// TestStreamTerminalFrameClientGoneFailureLogsDebug is issue #9's second
+// arm: when the terminal frame IS attempted, because streamErr was a genuine
+// Engine fault, but the frame write itself then fails for a client-gone
+// reason, that failure logs at DEBUG rather than ERROR — the client vanished
+// one step later than in the first-arm case, but the argument is identical.
+func TestStreamTerminalFrameClientGoneFailureLogsDebug(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — flush #1 (SSE headers) and #2 (the "log" frame) succeed;
+	// flush #3, the terminal "error" frame, fails with the other disconnect
+	// string actually observed on this route. The request context is never
+	// canceled here, so this exercises isClientGone's string-match fallback
+	// arm specifically, independent of the context-cancellation arm covered
+	// by TestStreamClientDisconnectLogsNothingAtError.
+	rec := &flushFailingRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		failOn:           3,
+		failErr:          errors.New("http2: stream closed"),
+	}
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(_ context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			if err := emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "one line before the fault"}); err != nil {
+				return err
+			}
+			return errors.New("engine connection dropped")
+		},
+	}
+	log, buf := newCapturingLoggerAtLevel(slog.LevelDebug)
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	logged := buf.String()
+	if !strings.Contains(logged, "level=DEBUG") || !strings.Contains(logged, "write terminal error frame") {
+		t.Errorf("log = %q, want a DEBUG line mentioning the terminal frame write", logged)
+	}
+	if strings.Contains(logged, "level=ERROR") {
+		t.Errorf("log = %q, want no ERROR line: the terminal frame failed because the client was gone", logged)
 	}
 }
 

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -217,6 +217,15 @@ func newCapturingLogger() (*slog.Logger, *bytes.Buffer) {
 	return slog.New(slog.NewTextHandler(&buf, nil)), &buf
 }
 
+// newCapturingLoggerAtLevel mirrors newCapturingLogger but with an explicit
+// minimum level, for the tests in logs_test.go that must observe a DEBUG
+// line — slog.NewTextHandler's default level is INFO, so the default helper
+// above would silently drop it and the test would prove nothing.
+func newCapturingLoggerAtLevel(level slog.Level) (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})), &buf
+}
+
 // dockerRouteCase describes one of the eight read routes: how to make its
 // backing fakeDocker method fail, how to make it succeed, and how to verify
 // a successful body.


### PR DESCRIPTION
Closes #9.

## The defect

Every client disconnect from `GET /v1/containers/{id}/logs/stream` wrote an `ERROR` line to `agent.log`. Closing a log view is the most ordinary thing a user does, so on a phone this became the dominant line in a size-capped, rotated log — it burned the operator's log budget and buried the failures they would actually want to find. Phase 4 validation measured 21 abandoned streams producing 21 lines:

```
level=ERROR msg="stream container logs: write terminal error frame" err="flush sse frame: client disconnected"
level=ERROR msg="stream container logs: write terminal error frame" err="flush sse frame: http2: stream closed"
```

The sequence was correct up to its last step. The client goes away, `emit` fails, `StreamContainerLogs` returns that error, and the stream unwinds with its slot released — all deliberate. Then, because the response was already committed, the handler tried to send a terminal `event: error` frame; that write failed for the same reason the first one did, and the failure was logged at ERROR.

## The fix

The terminal frame is **skipped entirely** when the stream error is already a client-gone error.

Where the frame is still worth attempting — a genuine Engine fault with the client connected — **nothing changes**: the frame goes out, and a failure to send it stays at ERROR. That was the constraint this change had to respect, since trading log noise for blindness to real faults would be the worse bug.

One narrower case moved: a client vanishing in the gap between the Engine dying and the frame going out now logs at DEBUG, because it is the same "no one to hear this" case one step later.

## Why the predicate is not a string match

`isClientGone` (new, `internal/httpapi/clientgone.go`) is ordered most-to-least structural:

1. **`ctx.Err() != nil` / `errors.Is(err, context.Canceled)`** — `net/http` cancels a server request's context when the client's connection closes, on both HTTP/1.1 and HTTP/2. This alone covers both measured cases. The handler derives its context with `context.WithCancel(r.Context())` and defers `cancel()`, so by LIFO order that cancel has not fired at either call site — a non-nil `ctx.Err()` can only come from the client actually going away.
2. **`errors.Is(err, net.ErrClosed)`**.
3. A documented string-match **fallback** for the two observed messages, because both come from unexported sentinels in `net/http`'s bundled HTTP/2 code with no exported equivalent for `errors.Is`. It is a forward-compatible backstop, not the detector.

`syscall.EPIPE` / `ECONNRESET` were considered and left out: they would force a build-tag split for a case arm 1 already covers.

## Test plan

- [x] `TestStreamClientDisconnectLogsNothingAtError` — asserts on captured log output at ERROR level, which is the actual regression being prevented
- [x] `TestStreamGenuineFailureStillSendsTerminalFrameWhenConnected` — unchanged-behaviour regression guard
- [x] `TestStreamTerminalFrameClientGoneFailureLogsDebug`
- [x] `TestIsClientGone` — table-driven over each arm
- [x] All pre-existing stream tests still pass, including `TestStreamErrorAfterFirstLine`
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/... -race` — all green; `internal/httpapi` 89.7%, total **84.9%** (floor 80%)
- [x] `golangci-lint run ./...` — 0 issues; `gosec ./...` — 0 issues
- [x] `gofmt -l` clean on touched files

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>