### PR TITLE
test: run the e2e targets with -v so skips are visible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,22 @@ COVER_PKGS := ./internal/...
 
 # The end-to-end suite needs a real Docker Engine and is excluded from every
 # default target by the `e2e` build tag, so `go build ./...`, `go vet ./...` and
-# `go test ./internal/...` never compile or run a line of it. -count=1 defeats
-# the test cache: e2e results depend entirely on state outside the module, so a
-# cached PASS from before a change is a false green.
+# `go test ./internal/...` never compile or run a line of it.
 E2E_PKGS := ./internal/e2e/...
+
+# -count=1 defeats the test cache: e2e results depend entirely on state outside
+# the module, so a cached PASS from before a change is a false green.
+#
+# -v is here for one reason: `go test` prints a test's SKIP and its reason only
+# under -v. Without it, a package whose tests all skipped reports a bare `ok`,
+# indistinguishable in the log from one that ran and passed them — so a green
+# run silently implies coverage it may not have. This suite skips for real and
+# specific reasons (no Engine reachable, a group that needs a Linux Engine, an
+# Engine too old for the field under test), and each has to be readable rather
+# than inferred. It is the argument DEVMON_E2E_REQUIRE=1 already makes one
+# level up, applied to the skips that flag deliberately does not convert into
+# failures.
+E2E_TESTFLAGS := -race -count=1 -v
 
 .PHONY: all build test test-race cover lint sec shellcheck image fmt clean e2e e2e-container e2e-endurance e2e-lint e2e-clean
 
@@ -72,16 +84,16 @@ shellcheck:
 # artifact. Requires a Linux Engine over unix:// or tcp:// — on Windows, run
 # these from a WSL2 shell.
 e2e:
-	CGO_ENABLED=1 go test -tags e2e $(E2E_PKGS) -race -count=1 -timeout 15m
+	CGO_ENABLED=1 go test -tags e2e $(E2E_PKGS) $(E2E_TESTFLAGS) -timeout 15m
 
 e2e-container:
-	CGO_ENABLED=1 go test -tags e2e ./internal/e2e/incontainer/... -race -count=1 -timeout 15m
+	CGO_ENABLED=1 go test -tags e2e ./internal/e2e/incontainer/... $(E2E_TESTFLAGS) -timeout 15m
 
 # The 30-minute stream and the retention budget. Both are compiled by every e2e
 # run and skip unless DEVMON_E2E_ENDURANCE=1, which this target sets along with
 # the longer timeout they need room inside.
 e2e-endurance:
-	DEVMON_E2E_ENDURANCE=1 CGO_ENABLED=1 go test -tags e2e ./internal/e2e/api/... -race -count=1 -timeout 45m
+	DEVMON_E2E_ENDURANCE=1 CGO_ENABLED=1 go test -tags e2e ./internal/e2e/api/... $(E2E_TESTFLAGS) -timeout 45m
 
 # `make lint` already covers the e2e files with gofmt, which ignores build tags.
 # go vet and golangci-lint do not, which is the only reason this target exists.

--- a/README.md
+++ b/README.md
@@ -727,6 +727,13 @@ whose own environment is built explicitly from each test case.
 Without an Engine, every test **skips** with a reason naming the endpoint —
 visibly, in `go test` output — rather than passing quietly.
 
+Every `make e2e*` target runs with `-v`, and that is load-bearing rather than
+cosmetic: `go test` prints a skip and its reason **only** under `-v`. Without
+it, a package whose tests all skipped reports a bare `ok`, indistinguishable
+from one that ran and passed them — a green run would silently imply coverage
+it does not have. The output is long; the alternative is a log that cannot tell
+you which of the reasons below fired.
+
 `TestContainerListReportsHealth` additionally needs Engine 29+ / API v1.52: the
 `ContainerSummary.Health` field the list projection reads was only added at
 that version, so on an older Engine (even a reachable, healthy one) the test


### PR DESCRIPTION
Part of #15 — the cheap floor named in that issue, not the whole fix.

## Why

`go test` prints a test's SKIP and its reason **only** under `-v`. Without it, a package whose tests all skipped reports a bare `ok`, indistinguishable in the log from one that ran and passed them. A green run silently implies coverage it may not have.

That is not hypothetical here. PR #13 was the first time the `e2e` job ever ran, and it now skips `TestContainerListReportsHealth` on every CI run — GitHub's runners speak Docker API 1.48 and the field under test arrived in 1.52. Nothing in the log says so; the package line just reads `ok`.

This is the argument `DEVMON_E2E_REQUIRE=1` already makes one level up, applied to the skips that flag deliberately does *not* convert into failures. An unreachable Engine is a hard failure in CI. A Linux-only group on a non-Linux Engine, an endurance test behind an opt-in, and an Engine too old for a field are all legitimate skips — and each has to be readable rather than inferred.

## What changed

`-race -count=1 -v` moves into a shared `E2E_TESTFLAGS`, used by `e2e`, `e2e-container` and `e2e-endurance`. That matches how the Makefile already treats `MODULE`, `COVER_PKGS` and `E2E_PKGS` — its header says these are "defined once here so it is never retyped". Timeouts stay per-target, since they differ by design (15m vs 45m).

README gains a paragraph explaining that the `-v` is load-bearing rather than cosmetic. It also corrects a claim that was subtly untrue before this change: the existing text said skips appear "visibly, in `go test` output", which was only true under `-v`.

## Verified

`make` is not available on this Windows host, so the expanded command was run directly. Without an Engine, all 76 tests skip — and every one now names its reason:

```
--- SKIP: TestStreamEnduranceThirtyMinutes (0.00s)
    contract_endurance_test.go:195: skipping long-running test: set DEVMON_E2E_ENDURANCE=1 to run it
--- SKIP: TestContainerListAllParameter (0.00s)
...
76 skips
```

Before this change that same run printed one `ok` per package and nothing else.

## What this PR does not prove

`e2e` only runs on PRs into `main`, so **this PR cannot exercise the target it edits** — it runs `test` alone. The Makefile change is plain variable substitution and was verified by expanding it by hand, but the first real execution of `make e2e` with these flags will be the next `dev` -> `main` PR. Same caveat as #14.

No Go code changed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>