### PR TITLE
ci: move every action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           # go.mod is the single source of truth for the toolchain version.
           go-version-file: go.mod
@@ -73,9 +73,9 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -94,7 +94,7 @@ jobs:
         run: go vet ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: ./...
@@ -104,7 +104,7 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Proves the CGO_ENABLED=0 / distroless-static path still links and runs.
       - name: docker build
@@ -125,7 +125,7 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: shellcheck
         run: shellcheck -s sh install.sh
@@ -135,9 +135,9 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -158,9 +158,9 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     name: publish image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # The git tag is vX.Y.Z; the image tag is X.Y.Z. README.md, the compose
       # example, and install.sh all name the unprefixed form, so stripping the
@@ -41,7 +41,7 @@ jobs:
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -51,13 +51,13 @@ jobs:
       # share of self-hosted VPS and home-lab targets are ARM, and the build is
       # CGO_ENABLED=0 pure Go onto distroless/static, so cross-compiling costs
       # nothing beyond this setup step.
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       # The same three build args the `image` job in ci.yml passes, so a
       # published binary reports its version the way a CI-built one does.
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Closes #16.

## Why now

GitHub deprecated the Node 20 action runtime and is already forcing the affected actions onto Node 24. The risk here is the inverse of the usual one: the forced upgrade was silently exercising each action on a runtime it does not declare, so a failure would land when GitHub flips the switch rather than when we choose to move.

## It was seven actions, not six

The issue originally recorded six. `golangci/golangci-lint-action@v8` also declares `node20` — it was missed because each **job** emits its own annotation listing only its own actions, and the issue was written from the `e2e` and `release` annotations. The `lint` job's annotation names it. Corrected in a comment on #16.

| Action | Was | Now | Exercised by this PR? |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | yes |
| `actions/setup-go` | v5 | **v7** | yes |
| `golangci/golangci-lint-action` | v8 | **v9** | no — `lint` is a `main`-only job |
| `docker/login-action` | v3 | **v4** | no |
| `docker/setup-qemu-action` | v3 | **v4** | no |
| `docker/setup-buildx-action` | v3 | **v4** | no |
| `docker/build-push-action` | v6 | **v7** | no |

## Breaking changes were checked, not assumed

Every major in between was read. What these majors remove, this repository does not use:

- **`setup-buildx-action` v4** removes deprecated inputs and outputs — it is invoked here with none at all.
- **`build-push-action` v7** removes the `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — neither is set. The inputs used here (`context`, `platforms`, `push`, `build-args`, `tags`) are unchanged.
- **`golangci-lint-action` v9** keeps both inputs used here, `version` and `args`; it adds `install-only` and module plugin support.
- **`setup-go` v6** changed toolchain selection. That one is genuinely behavioural for us, since the `test` job resolves the toolchain from `go-version-file: go.mod` (`go 1.26.5`) — and it is exercised on every PR, including this one.
- **`checkout` v5-v7**: node24, credentials persisted to a separate file, and v7 blocks checking out fork PRs under `pull_request_target` / `workflow_run` — triggers this repository does not use.

All seven declare `node24` and require Actions Runner **v2.327.1** or later; GitHub-hosted runners are well past that.

## Test plan

- [x] No old pins remain: `grep` for every prior major across `.github/` returns nothing
- [x] `test` job green on this PR — proves `checkout@v7` and `setup-go@v7`, including the v6 toolchain change against `go-version-file`
- [ ] `lint` (hence `golangci-lint-action@v9`) is a `main`-only job — first exercised on the next `dev` -> `main` PR
- [ ] **The four `docker/*` actions are not exercised by any PR.** `release.yml` triggers only on a `v*` tag, so the publish path is first proven by the next release. This is the verification caveat #16 itself called out.

No Go code, no Makefile, no docs changed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>