### PR TITLE
chore: add a changelog and prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to this project are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Versions here are the **image tags** — `ghcr.io/scnplt/devmon-agent:X.Y.Z`. The
+git tag carries a `v` prefix (`vX.Y.Z`); the image tag does not.
+
+An `Internal` section appears where there is one. It is not user-facing and
+changes nothing about the agent's behaviour, but this is an open repository and
+a contributor reading the history should not have to reconstruct why the build
+moved.
+
+## [0.1.1] - 2026-08-11
+
+### Fixed
+
+- Abandoning a log stream no longer writes an `ERROR` line. Closing a log view
+  is the most ordinary thing a client does, and every disconnect was logging, at
+  the agent's highest severity, that it could not deliver a terminal error frame
+  to a client that was no longer there. On a phone this became the dominant line
+  in a size-capped, rotated log — burning the operator's log budget and burying
+  the failures they would actually want to find. A genuine Engine fault with the
+  client still connected is unchanged: the frame is still sent, and a failure to
+  send it is still `ERROR`.
+  ([#9](https://github.com/scnplt/devmon-agent/issues/9))
+
+### Changed
+
+- The `make e2e`, `make e2e-container` and `make e2e-endurance` targets now run
+  with `-v`. `go test` prints a skip and its reason only under `-v`, so a
+  package whose tests all skipped previously reported a bare `ok` —
+  indistinguishable from one that ran and passed them. This suite skips for real
+  reasons, and each has to be readable rather than inferred.
+  (part of [#15](https://github.com/scnplt/devmon-agent/issues/15))
+
+### Internal
+
+- Every GitHub Actions action moved to a major that declares the Node 24
+  runtime, ahead of GitHub's removal of Node 20. All seven were affected:
+  `checkout` v4→v7, `setup-go` v5→v7, `golangci-lint-action` v8→v9,
+  `login-action` v3→v4, `setup-qemu-action` v3→v4, `setup-buildx-action` v3→v4,
+  `build-push-action` v6→v7.
+  ([#16](https://github.com/scnplt/devmon-agent/issues/16))
+- The end-to-end suite now passes on a native Linux Docker Engine, not only on
+  the WSL2 Engine the phase checklists used. Its first CI run exposed three
+  assumptions: files created inside the container under the bind mount are owned
+  by UID 65532 and unreachable from the host test user, and the `health` field
+  of the container list needs Engine 29+ / API v1.52, which GitHub's runners do
+  not yet speak.
+
+## [0.1.0] - 2026-08-11
+
+First public release — the full surface.
+
+### Added
+
+- **Identity.** The agent is its own certificate authority. An operator mints a
+  short-lived, single-use pairing code on the host; the device generates a
+  keypair and exchanges a CSR for a client certificate. Certificates renew
+  silently over the authenticated channel. Revocation takes effect on the next
+  request, with no restart.
+- **Reads.** List and inspect containers, images, networks and volumes, as
+  allowlisted projections rather than passthroughs of the Engine's payload — a
+  volume's driver options and a container's environment never leave the host.
+- **Logs.** Bounded historical retrieval plus a live SSE stream that survives an
+  abrupt connection loss and resumes without duplicating lines.
+- **Lifecycle.** `start`, `restart`, `stop`, `kill`, `delete`, bounded by a
+  policy mode fixed at startup (`read-only`, `default`, `full`) that a client can
+  never widen. The agent permanently excludes its own container from every
+  mutating route, in every mode.
+- **Audit.** Every mutating attempt recorded and attributed to the calling
+  device, including the ones policy refused. The audit table outlives the
+  operational log.
+- **Rate limiting.** Two tiers on the listening port.
+- **Installer.** `install.sh` takes a clean host to a printed pairing code:
+  resolving the docker socket GID, creating and chowning the state directory,
+  writing a `compose.yaml`, and waiting for the agent to answer.
+- **Multi-arch image.** `linux/amd64` and `linux/arm64`.
+
+[0.1.1]: https://github.com/scnplt/devmon-agent/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/scnplt/devmon-agent/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so an
 Android client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.1.0 — the full surface.** The agent is its own certificate
+**Status: 0.1.1 — the full surface.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -18,7 +18,7 @@ an audit table that outlives the operational log. The listening port is rate
 limited in two tiers, and an executable contract suite runs the real binary
 against a real Docker Engine.
 
-License: [AGPL-3.0-only](LICENSE).
+License: [AGPL-3.0-only](LICENSE). Changes by version: [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
@@ -68,7 +68,7 @@ docker run -d --name devmon-agent \
   --group-add "$(stat -c '%g' /var/run/docker.sock)" \
   -p 8443:8443 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.1.0
+  ghcr.io/scnplt/devmon-agent:0.1.1
 ```
 
 See `compose.example.yaml` for the equivalent Compose file and a reference for
@@ -78,7 +78,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.1.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.1.1","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -23,7 +23,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.1.0
+    image: ghcr.io/scnplt/devmon-agent:0.1.1
     restart: unless-stopped
 
     ports:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.1.0'
+IMAGE_TAG='0.1.1'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
Six commits have landed on `dev` since v0.1.0 and there is nowhere to read what they change. Release notes live only on the GitHub Release page — fine for one version, not fine at the second.

## CHANGELOG.md

[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, with **0.1.0 recorded retroactively** from its release notes so the file is complete rather than starting mid-history.

Two deliberate deviations:

- The header states that versions in this file are **image** tags. The git tag carries a `v` prefix and the image tag does not; confusing the two breaks a compose file.
- An **`Internal`** section carries changes that alter nothing about the agent's behaviour — the Node 24 action bump, and the e2e suite learning to run on a native Linux Engine. A user can skip it, but this is an open repository and a contributor should not have to reconstruct why the build moved.

What 0.1.1 contains: the log-stream `ERROR` fix (#9), the e2e `-v` change (part of #15), and the two internal items above (#16).

## Version pins moved to 0.1.1

| File | What |
|---|---|
| `install.sh` | `IMAGE_TAG='0.1.1'` |
| `compose.example.yaml` | `image: ghcr.io/scnplt/devmon-agent:0.1.1` |
| `README.md` | status line, pull example, sample `/v1/status` output, plus a link to the changelog |

`SECURITY.md` needs no edit — its table already reads `0.1.x` rather than an exact version, which is why it was written that way.

## Two things to know before merging

**Ordering.** These pins now name an image that **does not exist yet**. The tag has to be pushed immediately after the `dev` -> `main` release merge, or a clone of `main` installs against a missing tag. The window is minutes; the alternative — bumping after tagging — leaves `main` permanently one version behind itself.

**The date.** Both entries are dated `2026-08-11`. If the tag slips to another day, 0.1.1's date needs a touch-up before the release PR merges.

## Test plan

- [x] No stale `0.1.0` references remain outside `SECURITY.md`'s `< 0.1.0` row, which is correct
- [ ] `shellcheck -s sh install.sh` — not installed on this host; the `main`-only `shellcheck` job covers it on the release PR
- [x] No Go code, no Makefile, no workflow changes — `test` is the only relevant gate and it is unaffected

Not included: `.github/ISSUE_TEMPLATE/bug_report.yml` still shows `0.1.0` as the *placeholder* for the version field. It illustrates the format rather than pinning anything, and bumping it every release is churn for no gain.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>