### PR TITLE
release: v0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           # go.mod is the single source of truth for the toolchain version.
           go-version-file: go.mod
@@ -73,9 +73,9 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -94,7 +94,7 @@ jobs:
         run: go vet ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: ./...
@@ -104,7 +104,7 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Proves the CGO_ENABLED=0 / distroless-static path still links and runs.
       - name: docker build
@@ -125,7 +125,7 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: shellcheck
         run: shellcheck -s sh install.sh
@@ -135,9 +135,9 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -158,9 +158,9 @@ jobs:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     name: publish image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # The git tag is vX.Y.Z; the image tag is X.Y.Z. README.md, the compose
       # example, and install.sh all name the unprefixed form, so stripping the
@@ -41,7 +41,7 @@ jobs:
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -51,13 +51,13 @@ jobs:
       # share of self-hosted VPS and home-lab targets are ARM, and the build is
       # CGO_ENABLED=0 pure Go onto distroless/static, so cross-compiling costs
       # nothing beyond this setup step.
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       # The same three build args the `image` job in ci.yml passes, so a
       # published binary reports its version the way a CI-built one does.
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to this project are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Versions here are the **image tags** — `ghcr.io/scnplt/devmon-agent:X.Y.Z`. The
+git tag carries a `v` prefix (`vX.Y.Z`); the image tag does not.
+
+An `Internal` section appears where there is one. It is not user-facing and
+changes nothing about the agent's behaviour, but this is an open repository and
+a contributor reading the history should not have to reconstruct why the build
+moved.
+
+## [0.1.1] - 2026-08-11
+
+### Fixed
+
+- Abandoning a log stream no longer writes an `ERROR` line. Closing a log view
+  is the most ordinary thing a client does, and every disconnect was logging, at
+  the agent's highest severity, that it could not deliver a terminal error frame
+  to a client that was no longer there. On a phone this became the dominant line
+  in a size-capped, rotated log — burning the operator's log budget and burying
+  the failures they would actually want to find. A genuine Engine fault with the
+  client still connected is unchanged: the frame is still sent, and a failure to
+  send it is still `ERROR`.
+  ([#9](https://github.com/scnplt/devmon-agent/issues/9))
+
+### Changed
+
+- The `make e2e`, `make e2e-container` and `make e2e-endurance` targets now run
+  with `-v`. `go test` prints a skip and its reason only under `-v`, so a
+  package whose tests all skipped previously reported a bare `ok` —
+  indistinguishable from one that ran and passed them. This suite skips for real
+  reasons, and each has to be readable rather than inferred.
+  (part of [#15](https://github.com/scnplt/devmon-agent/issues/15))
+
+### Internal
+
+- Every GitHub Actions action moved to a major that declares the Node 24
+  runtime, ahead of GitHub's removal of Node 20. All seven were affected:
+  `checkout` v4→v7, `setup-go` v5→v7, `golangci-lint-action` v8→v9,
+  `login-action` v3→v4, `setup-qemu-action` v3→v4, `setup-buildx-action` v3→v4,
+  `build-push-action` v6→v7.
+  ([#16](https://github.com/scnplt/devmon-agent/issues/16))
+- The end-to-end suite now passes on a native Linux Docker Engine, not only on
+  the WSL2 Engine the phase checklists used. Its first CI run exposed three
+  assumptions: files created inside the container under the bind mount are owned
+  by UID 65532 and unreachable from the host test user, and the `health` field
+  of the container list needs Engine 29+ / API v1.52, which GitHub's runners do
+  not yet speak.
+
+## [0.1.0] - 2026-08-11
+
+First public release — the full surface.
+
+### Added
+
+- **Identity.** The agent is its own certificate authority. An operator mints a
+  short-lived, single-use pairing code on the host; the device generates a
+  keypair and exchanges a CSR for a client certificate. Certificates renew
+  silently over the authenticated channel. Revocation takes effect on the next
+  request, with no restart.
+- **Reads.** List and inspect containers, images, networks and volumes, as
+  allowlisted projections rather than passthroughs of the Engine's payload — a
+  volume's driver options and a container's environment never leave the host.
+- **Logs.** Bounded historical retrieval plus a live SSE stream that survives an
+  abrupt connection loss and resumes without duplicating lines.
+- **Lifecycle.** `start`, `restart`, `stop`, `kill`, `delete`, bounded by a
+  policy mode fixed at startup (`read-only`, `default`, `full`) that a client can
+  never widen. The agent permanently excludes its own container from every
+  mutating route, in every mode.
+- **Audit.** Every mutating attempt recorded and attributed to the calling
+  device, including the ones policy refused. The audit table outlives the
+  operational log.
+- **Rate limiting.** Two tiers on the listening port.
+- **Installer.** `install.sh` takes a clean host to a printed pairing code:
+  resolving the docker socket GID, creating and chowning the state directory,
+  writing a `compose.yaml`, and waiting for the agent to answer.
+- **Multi-arch image.** `linux/amd64` and `linux/arm64`.
+
+[0.1.1]: https://github.com/scnplt/devmon-agent/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/scnplt/devmon-agent/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,22 @@ COVER_PKGS := ./internal/...
 
 # The end-to-end suite needs a real Docker Engine and is excluded from every
 # default target by the `e2e` build tag, so `go build ./...`, `go vet ./...` and
-# `go test ./internal/...` never compile or run a line of it. -count=1 defeats
-# the test cache: e2e results depend entirely on state outside the module, so a
-# cached PASS from before a change is a false green.
+# `go test ./internal/...` never compile or run a line of it.
 E2E_PKGS := ./internal/e2e/...
+
+# -count=1 defeats the test cache: e2e results depend entirely on state outside
+# the module, so a cached PASS from before a change is a false green.
+#
+# -v is here for one reason: `go test` prints a test's SKIP and its reason only
+# under -v. Without it, a package whose tests all skipped reports a bare `ok`,
+# indistinguishable in the log from one that ran and passed them — so a green
+# run silently implies coverage it may not have. This suite skips for real and
+# specific reasons (no Engine reachable, a group that needs a Linux Engine, an
+# Engine too old for the field under test), and each has to be readable rather
+# than inferred. It is the argument DEVMON_E2E_REQUIRE=1 already makes one
+# level up, applied to the skips that flag deliberately does not convert into
+# failures.
+E2E_TESTFLAGS := -race -count=1 -v
 
 .PHONY: all build test test-race cover lint sec shellcheck image fmt clean e2e e2e-container e2e-endurance e2e-lint e2e-clean
 
@@ -72,16 +84,16 @@ shellcheck:
 # artifact. Requires a Linux Engine over unix:// or tcp:// — on Windows, run
 # these from a WSL2 shell.
 e2e:
-	CGO_ENABLED=1 go test -tags e2e $(E2E_PKGS) -race -count=1 -timeout 15m
+	CGO_ENABLED=1 go test -tags e2e $(E2E_PKGS) $(E2E_TESTFLAGS) -timeout 15m
 
 e2e-container:
-	CGO_ENABLED=1 go test -tags e2e ./internal/e2e/incontainer/... -race -count=1 -timeout 15m
+	CGO_ENABLED=1 go test -tags e2e ./internal/e2e/incontainer/... $(E2E_TESTFLAGS) -timeout 15m
 
 # The 30-minute stream and the retention budget. Both are compiled by every e2e
 # run and skip unless DEVMON_E2E_ENDURANCE=1, which this target sets along with
 # the longer timeout they need room inside.
 e2e-endurance:
-	DEVMON_E2E_ENDURANCE=1 CGO_ENABLED=1 go test -tags e2e ./internal/e2e/api/... -race -count=1 -timeout 45m
+	DEVMON_E2E_ENDURANCE=1 CGO_ENABLED=1 go test -tags e2e ./internal/e2e/api/... $(E2E_TESTFLAGS) -timeout 45m
 
 # `make lint` already covers the e2e files with gofmt, which ignores build tags.
 # go vet and golangci-lint do not, which is the only reason this target exists.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so an
 Android client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.1.0 — the full surface.** The agent is its own certificate
+**Status: 0.1.1 — the full surface.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -18,7 +18,7 @@ an audit table that outlives the operational log. The listening port is rate
 limited in two tiers, and an executable contract suite runs the real binary
 against a real Docker Engine.
 
-License: [AGPL-3.0-only](LICENSE).
+License: [AGPL-3.0-only](LICENSE). Changes by version: [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
@@ -68,7 +68,7 @@ docker run -d --name devmon-agent \
   --group-add "$(stat -c '%g' /var/run/docker.sock)" \
   -p 8443:8443 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.1.0
+  ghcr.io/scnplt/devmon-agent:0.1.1
 ```
 
 See `compose.example.yaml` for the equivalent Compose file and a reference for
@@ -78,7 +78,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.1.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.1.1","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -727,6 +727,13 @@ whose own environment is built explicitly from each test case.
 Without an Engine, every test **skips** with a reason naming the endpoint —
 visibly, in `go test` output — rather than passing quietly.
 
+Every `make e2e*` target runs with `-v`, and that is load-bearing rather than
+cosmetic: `go test` prints a skip and its reason **only** under `-v`. Without
+it, a package whose tests all skipped reports a bare `ok`, indistinguishable
+from one that ran and passed them — a green run would silently imply coverage
+it does not have. The output is long; the alternative is a log that cannot tell
+you which of the reasons below fired.
+
 `TestContainerListReportsHealth` additionally needs Engine 29+ / API v1.52: the
 `ContainerSummary.Health` field the list projection reads was only added at
 that version, so on an older Engine (even a reachable, healthy one) the test

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -23,7 +23,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.1.0
+    image: ghcr.io/scnplt/devmon-agent:0.1.1
     restart: unless-stopped
 
     ports:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.1.0'
+IMAGE_TAG='0.1.1'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission

--- a/internal/httpapi/clientgone.go
+++ b/internal/httpapi/clientgone.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+)
+
+// isClientGone reports whether err — observed while ctx is the request's own
+// (possibly derived) context — indicates the peer disconnected rather than a
+// genuine service fault. handleStreamContainerLogs uses it for two decisions:
+// whether a terminal event: error frame is worth attempting at all once
+// StreamContainerLogs has already failed, and, if the frame is attempted,
+// what level a failed send should log at. A client that is no longer there
+// cannot receive anything the agent tries to tell it, so neither case is an
+// agent error.
+//
+// The checks are ordered from most to least structural, and only the last
+// one is a string match:
+//
+//  1. ctx.Err() != nil, or errors.Is(err, context.Canceled). This is the
+//     robust, portable signal: net/http's Request.Context doc comment states
+//     the context of an incoming server request "is canceled when the
+//     client's connection closes, the request is canceled (with HTTP/2), or
+//     when the ServeHTTP method returns" — so this one check already covers
+//     both the HTTP/1.1 and HTTP/2 disconnect paths with no string matching
+//     at all. handleStreamContainerLogs derives ctx via
+//     context.WithCancel(r.Context()) and defers cancel() before this
+//     predicate can ever run, so by Go's LIFO defer order that cancel() has
+//     not fired yet at either call site (the streamErr check or the terminal
+//     frame write): a non-nil ctx.Err() here can only come from the PARENT
+//     (r.Context()) having been canceled, i.e. the client actually going
+//     away, never from the handler's own unwind.
+//
+//  2. errors.Is(err, net.ErrClosed). Covers a closed-connection error
+//     surfacing through a net.Conn / net.OpError wrapper independently of
+//     whether the context has observed the cancellation yet.
+//
+//  3. A string match on the two disconnect errors actually measured on this
+//     route: "client disconnected" and "http2: stream closed". Both come
+//     from unexported package-level sentinels inside net/http's bundled
+//     HTTP/2 implementation (http2errClientDisconnected and
+//     http2errStreamClosed in h2_bundle.go) with no exported equivalent to
+//     compare against using errors.Is, so a substring check is genuinely the
+//     only option left once arms 1 and 2 do not match — this is a documented
+//     fallback, not the primary detector. In practice arm 1 already catches
+//     both measured cases (see TestIsClientGone), so this arm exists as a
+//     forward-compatible backstop rather than because it is load-bearing
+//     today.
+//
+// syscall.EPIPE and syscall.ECONNRESET were considered and deliberately left
+// out: syscall's error constants are not uniform across every platform this
+// package must build for (CGO_ENABLED=0, cross-compiled), so checking them
+// here would force a build-tag split for a case arm 1 already covers.
+func isClientGone(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "client disconnected") || strings.Contains(msg, "http2: stream closed")
+}

--- a/internal/httpapi/clientgone_test.go
+++ b/internal/httpapi/clientgone_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+// TestIsClientGone drives isClientGone over each of its arms directly,
+// independent of the HTTP stack, so the predicate's own logic is pinned
+// without needing a real disconnected connection.
+func TestIsClientGone(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{name: "nil error is never client-gone", ctx: context.Background(), err: nil, want: false},
+		{
+			name: "canceled context with an unrelated error is client-gone",
+			ctx:  canceledCtx,
+			err:  errors.New("write: broken pipe"),
+			want: true,
+		},
+		{
+			name: "live context but err wraps context.Canceled is client-gone",
+			ctx:  context.Background(),
+			err:  errors.Join(errors.New("flush sse frame"), context.Canceled),
+			want: true,
+		},
+		{
+			name: "err wraps net.ErrClosed is client-gone",
+			ctx:  context.Background(),
+			err:  errors.Join(errors.New("flush sse frame"), net.ErrClosed),
+			want: true,
+		},
+		{
+			name: "err text matches the observed HTTP/2 client-disconnected string",
+			ctx:  context.Background(),
+			err:  errors.New("flush sse frame: client disconnected"),
+			want: true,
+		},
+		{
+			name: "err text matches the observed HTTP/2 stream-closed string",
+			ctx:  context.Background(),
+			err:  errors.New("flush sse frame: http2: stream closed"),
+			want: true,
+		},
+		{
+			name: "a genuine, unrelated failure with a live context is not client-gone",
+			ctx:  context.Background(),
+			err:  errors.New("engine connection dropped"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := isClientGone(tt.ctx, tt.err)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("isClientGone(%v, %v) = %v, want %v", tt.ctx.Err(), tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/httpapi/logs.go
+++ b/internal/httpapi/logs.go
@@ -189,11 +189,33 @@ func (s *Server) handleStreamContainerLogs(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// A stream that failed because the client went away has nothing left to
+	// deliver and no one left to deliver it to: attempting the terminal
+	// frame below would just be a second write failing for the same reason
+	// the first one did, and logging that at ERROR would report, at the
+	// agent's highest severity, that it could not tell a client something
+	// the client is no longer there to hear (issue #9). See isClientGone's
+	// doc comment for exactly what "gone" is checked against — a genuine
+	// Engine fault with the client still connected falls through unchanged.
+	if isClientGone(ctx, streamErr) {
+		return
+	}
+
 	// Headers are already committed: the only way left to signal failure is
 	// a terminal event frame. D16 forbids logging the ref alongside the
 	// container's own output — this path never touches LogLine.Line, only
 	// the error.
 	if err := sse.event("", sseEventError, errorBody{Error: msgEngineUnavailable}); err != nil {
-		s.log.Error("stream container logs: write terminal error frame", slog.Any("err", err))
+		// streamErr above was a genuine Engine fault, not a disconnect — so
+		// this write was worth attempting. But the client can still have
+		// vanished in the gap between the Engine dying and this frame going
+		// out, and a failure for THAT reason is the same "no one to hear
+		// this" case one step later: DEBUG, not ERROR. Any other failure to
+		// send the frame is a distinct fault of its own and stays at ERROR.
+		if isClientGone(ctx, err) {
+			s.log.Debug("stream container logs: write terminal error frame", slog.Any("err", err))
+		} else {
+			s.log.Error("stream container logs: write terminal error frame", slog.Any("err", err))
+		}
 	}
 }

--- a/internal/httpapi/logs_test.go
+++ b/internal/httpapi/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -17,6 +18,30 @@ import (
 	"github.com/scnplt/devmon-agent/internal/dockerx"
 	"github.com/scnplt/devmon-agent/internal/policy"
 )
+
+// flushFailingRecorder wraps httptest.ResponseRecorder to make one specific
+// Flush call fail, so a test can force sse.event's "flush sse frame: %w" or
+// "flush sse headers: %w" path without a real disconnected socket.
+// FlushError, not Flush, is the method http.ResponseController looks for
+// first (see net/http's ResponseController.Flush), so implementing that one
+// method is enough to make the whole flush chain return failErr on the
+// failOn'th call and nil on every other call.
+type flushFailingRecorder struct {
+	*httptest.ResponseRecorder
+	failOn     int
+	failErr    error
+	flushCount int
+}
+
+func (f *flushFailingRecorder) SetWriteDeadline(time.Time) error { return nil }
+
+func (f *flushFailingRecorder) FlushError() error {
+	f.flushCount++
+	if f.flushCount == f.failOn {
+		return f.failErr
+	}
+	return nil
+}
 
 // logRoutePaths lists the two log routes, for the tests that assert identical
 // behaviour across both (401, 405, nil-reader, leak checks).
@@ -315,6 +340,136 @@ func TestStreamErrorAfterFirstLine(t *testing.T) {
 	wantSuffix := fmt.Sprintf("event: error\ndata: {\"error\":%q}\n\n", msgEngineUnavailable)
 	if !strings.HasSuffix(body, wantSuffix) {
 		t.Errorf("body = %q, want it to end with %q", body, wantSuffix)
+	}
+}
+
+// TestStreamClientDisconnectLogsNothingAtError is issue #9's regression: a
+// client that disconnects mid-stream must not produce an ERROR line. The
+// agent failing to tell a departed client that it is gone is not an agent
+// fault, so no terminal frame should even be attempted. This asserts on the
+// captured log content, not merely "no panic" — the old behaviour never
+// panicked, it just logged ERROR on every ordinary disconnect.
+func TestStreamClientDisconnectLogsNothingAtError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — the fake cancels the request's own context before returning
+	// its error, exactly as net/http cancels it when the underlying
+	// connection closes (see isClientGone's doc comment), and the recorder's
+	// first Flush call fails with the disconnect text actually observed on
+	// this route, so the error path is exercised the way it happens for
+	// real rather than via a synthetic error value.
+	rec := &flushFailingRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		failOn:           1,
+		failErr:          errors.New("client disconnected"),
+	}
+	var cancelReq context.CancelFunc
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(_ context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			cancelReq()
+			return emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "line before disconnect"})
+		},
+	}
+	log, buf := newCapturingLoggerAtLevel(slog.LevelDebug)
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+	cancelableCtx, cancel := context.WithCancel(req.Context())
+	cancelReq = cancel
+	req = req.WithContext(cancelableCtx)
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("agent log contains an ERROR line for an ordinary client disconnect: %s", buf.String())
+	}
+	if got := strings.Count(rec.Body.String(), "event: error"); got != 0 {
+		t.Errorf("body has %d terminal error frames, want 0: a disconnected client cannot receive one", got)
+	}
+}
+
+// TestStreamGenuineFailureStillSendsTerminalFrameWhenConnected pins the
+// unchanged half of issue #9's fix: a real Engine fault, with the client
+// still connected, must still produce the terminal event: error frame and
+// must not be swallowed as a false-positive "client gone".
+func TestStreamGenuineFailureStillSendsTerminalFrameWhenConnected(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(_ context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			if err := emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "one line before the fault"}); err != nil {
+				return err
+			}
+			return errors.New("engine connection dropped")
+		},
+	}
+	log, buf := newCapturingLoggerAtLevel(slog.LevelDebug)
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	body := rec.Body.String()
+	if got := strings.Count(body, "event: error\n"); got != 1 {
+		t.Errorf("body has %d event: error frames, want 1 for a genuine Engine fault; body: %q", got, body)
+	}
+	// The frame write itself succeeded (deadlineAwareRecorder never fails a
+	// flush), so nothing about the terminal frame should have been logged
+	// at any level.
+	if strings.Contains(buf.String(), "write terminal error frame") {
+		t.Errorf("agent log unexpectedly mentions the terminal frame for a successful send: %s", buf.String())
+	}
+}
+
+// TestStreamTerminalFrameClientGoneFailureLogsDebug is issue #9's second
+// arm: when the terminal frame IS attempted, because streamErr was a genuine
+// Engine fault, but the frame write itself then fails for a client-gone
+// reason, that failure logs at DEBUG rather than ERROR — the client vanished
+// one step later than in the first-arm case, but the argument is identical.
+func TestStreamTerminalFrameClientGoneFailureLogsDebug(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — flush #1 (SSE headers) and #2 (the "log" frame) succeed;
+	// flush #3, the terminal "error" frame, fails with the other disconnect
+	// string actually observed on this route. The request context is never
+	// canceled here, so this exercises isClientGone's string-match fallback
+	// arm specifically, independent of the context-cancellation arm covered
+	// by TestStreamClientDisconnectLogsNothingAtError.
+	rec := &flushFailingRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		failOn:           3,
+		failErr:          errors.New("http2: stream closed"),
+	}
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(_ context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			if err := emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "one line before the fault"}); err != nil {
+				return err
+			}
+			return errors.New("engine connection dropped")
+		},
+	}
+	log, buf := newCapturingLoggerAtLevel(slog.LevelDebug)
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	logged := buf.String()
+	if !strings.Contains(logged, "level=DEBUG") || !strings.Contains(logged, "write terminal error frame") {
+		t.Errorf("log = %q, want a DEBUG line mentioning the terminal frame write", logged)
+	}
+	if strings.Contains(logged, "level=ERROR") {
+		t.Errorf("log = %q, want no ERROR line: the terminal frame failed because the client was gone", logged)
 	}
 }
 

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -217,6 +217,15 @@ func newCapturingLogger() (*slog.Logger, *bytes.Buffer) {
 	return slog.New(slog.NewTextHandler(&buf, nil)), &buf
 }
 
+// newCapturingLoggerAtLevel mirrors newCapturingLogger but with an explicit
+// minimum level, for the tests in logs_test.go that must observe a DEBUG
+// line — slog.NewTextHandler's default level is INFO, so the default helper
+// above would silently drop it and the test would prove nothing.
+func newCapturingLoggerAtLevel(level slog.Level) (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})), &buf
+}
+
 // dockerRouteCase describes one of the eight read routes: how to make its
 // backing fakeDocker method fail, how to make it succeed, and how to verify
 // a successful body.


### PR DESCRIPTION
Release PR for **v0.1.1**. Four changes since v0.1.0, in four merged PRs.

See [CHANGELOG.md](https://github.com/scnplt/devmon-agent/blob/dev/CHANGELOG.md) for the user-facing version.

## What ships

**Fixed — #17, closes #9.** Abandoning a log stream no longer writes an `ERROR` line. Every disconnect was logging, at the agent's highest severity, that it could not deliver a terminal error frame to a client no longer there — on a phone, the dominant line in a size-capped rotated log. A genuine Engine fault with the client still connected is unchanged: the frame is still sent, a failure to send it is still `ERROR`.

**Changed — #18, part of #15.** The `make e2e*` targets run with `-v`. `go test` prints a skip and its reason only under `-v`, so a package whose tests all skipped previously reported a bare `ok`. This suite skips for real reasons and each has to be readable.

**Internal — #19, closes #16.** All seven GitHub Actions moved to majors declaring the Node 24 runtime, ahead of GitHub's removal of Node 20.

**Internal — #14.** The e2e suite passes on a native Linux Engine, not only the WSL2 one the phase checklists used.

**Chore — #20.** `CHANGELOG.md` added, with 0.1.0 recorded retroactively. Version pins moved to 0.1.1.

## What this PR proves that no earlier PR could

The release bar (`lint`, `image`, `gosec`, `shellcheck`, `e2e`) runs only on PRs into `main`, so three things are exercised here for the first time:

- **`make e2e` with `-v`** — the Makefile change from #18 has never run in CI
- **`golangci-lint-action@v9`** — `lint` is a `main`-only job
- **`shellcheck` against the edited `install.sh`** — not installed on the authoring host

Expect `TestContainerListReportsHealth` to **skip** and, unlike before, to say so in the log: GitHub's runners speak Docker API 1.48 and that field arrived in 1.52 (#15).

Still unproven after this merges: the four `docker/*` actions in `release.yml`, which only a `v*` tag push exercises.

## Post-merge

The version pins in `install.sh` and `compose.example.yaml` name an image that does not exist yet. **Tag `v0.1.1` immediately after this merges**, or a clone of `main` installs against a missing tag.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>