### PR TITLE
docs: explain why an HTTPS-terminating proxy cannot front the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,51 @@ fingerprint your phone shows during pairing against the one you recorded at
 install is what makes the pairing exchange safe over an untrusted network. If
 you only ever read it from the server you are about to trust, it proves nothing.
 
+### Reaching it from outside
+
+The documented deployment is **direct inbound TLS**: the device's connection
+terminates in the agent process. That is not a default to be overridden — three
+separate parts of the design read the TLS connection itself, so anything that
+terminates TLS in front of the agent breaks them.
+
+This rules out Cloudflare Tunnel's HTTP/HTTPS ingress, and every reverse proxy
+run in HTTP mode: nginx `proxy_pass`, Caddy, Traefik, an ALB. Not as a
+configuration problem — there is no setting on either side that recovers what
+the termination discarded.
+
+| What breaks | Why | What you see |
+|---|---|---|
+| Device authentication | The client certificate belongs to the device's TLS connection. The proxy opens its own connection to the agent, which carries no certificate. | `401 client certificate required` on every guarded route |
+| CA pinning | The app pins the agent's own CA. The proxy presents its certificate, not the agent's. | The app fails during the handshake, before any HTTP response |
+| Rate limiting | Both pre-authentication tiers key on the peer address, which is now the proxy's for every caller. `X-Forwarded-For` is deliberately never consulted — see [Rate limiting](#rate-limiting). | `GET /v1/status` and `POST /v1/pair` share one budget across all devices |
+
+Cloudflare Access mTLS does not bridge this. It verifies the certificate at the
+edge and forwards the result as a signed header; the agent authenticates from
+`r.TLS.PeerCertificates` and reads no such header.
+
+**What does work** is anything that moves bytes without terminating TLS:
+
+- A VPN or overlay network — WireGuard, Tailscale — with the agent bound to the
+  private interface and no published port. Simplest, and the agent is then not
+  on the public internet at all.
+- Cloudflare Zero Trust with `warp-routing`, where the tunnel carries the
+  private network rather than proxying HTTP, and the device joins over WARP.
+- TCP passthrough: nginx `stream`, HAProxy in `tcp` mode, or Cloudflare
+  Spectrum.
+
+Two things to get right on any of them. `DEVMON_PUBLIC_ADDR` must contain the
+address the device actually dials, because it becomes the server certificate's
+SAN — a private IP behind a VPN belongs there just as much as a public hostname.
+And passthrough still hides the caller's address: the guarded tier is unaffected
+because it keys on the device, but the status and pair tiers will see only the
+forwarding host, so size those limits for the whole fleet rather than one phone.
+
+Putting the agent behind an HTTPS proxy would mean replacing its authentication
+model, not configuring it. That is a deliberate trade: request signing survives
+a proxy, but a terminating proxy also reads every container name and log line in
+the clear, and can alter a response the device has no way to verify. See
+[docs/THREAT-MODEL.md](docs/THREAT-MODEL.md).
+
 ---
 
 ## Configuration
@@ -246,6 +291,8 @@ asserted by a packet header. For the same reason `X-Forwarded-For` is never
 consulted: the documented deployment is direct inbound, and honouring a
 client-supplied forwarding header would let any caller mint a fresh limiter key
 per request, which is worse than no limiter because it looks like protection.
+What that costs you behind a forwarding host is
+[Reaching it from outside](#reaching-it-from-outside).
 
 Limits are startup configuration like everything else, so a client can never
 raise its own ceiling, and the values are advertised nowhere — telling a scanner

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -25,7 +25,7 @@ $DEVMON_STATE_DIR/                 bind mount — not a named volume        0700
     └── agent-….log.gz             rotated and compressed                 0600
 ```
 
-— [`README.md:191-206`](../README.md) (`## State directory`).
+— [`README.md:310-329`](../README.md) (`## State directory`).
 
 `logs/` is operational output, not identity, and does not need to survive a
 restore for the agent to run — but back it up anyway if you are diagnosing
@@ -54,7 +54,7 @@ In the README's own words, which this document does not restate differently:
 > the host and restart. The agent then creates a new CA, every paired device
 > is unpaired, and the fingerprint changes.
 >
-> — [`README.md:212-221`](../README.md)
+> — [`README.md:331-340`](../README.md)
 
 Concretely, that means:
 
@@ -88,7 +88,7 @@ sudo tar czf devmon-backup.tgz -C /var/lib/devmon
 docker start devmon-agent
 ```
 
-— [`README.md:229-236`](../README.md). This checkpoints the write-ahead log
+— [`README.md:346-355`](../README.md). This checkpoints the write-ahead log
 before the copy runs, so the archive holds a single consistent state rather
 than a snapshot mid-write.
 
@@ -135,7 +135,7 @@ the restored database is a readable, uncorrupted SQLite file at open —
 "Restore by extracting to the same path with the same ownership. The agent
 detects a truncated or corrupt `devmon.db` at startup and refuses to run
 rather than failing obscurely at the first query."
-([`README.md:238-240`](../README.md)).
+([`README.md:357-359`](../README.md)).
 
 ## If `certs/` is lost
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -118,6 +118,33 @@ would let any caller mint a fresh limiter key per request:
 [`internal/httpapi/ratelimit.go:67-81`](../internal/httpapi/ratelimit.go)
 (`clientIP`).
 
+### intermediary → listening port
+
+The boundary above assumes the device's TLS connection ends in the agent
+process. A TLS-terminating intermediary — Cloudflare Tunnel's HTTP/HTTPS
+ingress, or any reverse proxy in HTTP mode — moves that endpoint, and three
+properties this model depends on do not survive the move.
+
+Device authentication reads the certificate off the connection itself
+([`internal/httpapi/middleware.go:44-50`](../internal/httpapi/middleware.go)),
+and the intermediary's own connection to the agent carries none, so every
+guarded route answers 401. The device's pinning of the agent's CA stops
+describing what it is actually talking to, so an intermediary that is
+compromised — or merely misconfigured — can answer for the agent without the
+device being able to detect it. And `clientIP` resolves every caller to the
+intermediary's address
+([`internal/httpapi/ratelimit.go:67-81`](../internal/httpapi/ratelimit.go)),
+collapsing both pre-authentication tiers into one budget shared by every
+device.
+
+An edge that verifies the client certificate on the agent's behalf and forwards
+the result as a signed header does not restore the boundary; it relocates the
+authority to that edge, whose configuration is not the operator's startup
+configuration and therefore not the property the agent is built on
+([`internal/config/config.go:3-9`](../internal/config/config.go)). The
+operator-facing version of this, including what does work, is
+[`README.md`](../README.md) under "Reaching it from outside".
+
 ### listening port → mTLS
 
 The TLS listener uses `VerifyClientCertIfGiven`, not
@@ -227,6 +254,11 @@ substance, because the two documents describe the same boundary:
   in front of it.** `install.sh`'s own closing message says so directly: "Do
   not expose this port to the open internet without a VPN or a firewall in
   front of it." ([`install.sh:622-623`](../install.sh)).
+- **A deployment that terminates TLS in front of the agent.** The agent
+  authenticates from the connection it terminates itself; an HTTPS reverse
+  proxy or tunnel ingress is not a supported configuration and is outside this
+  model, not a hardened case within it (see *intermediary → listening port*
+  above).
 - **Side-channel and timing attacks.**
 - **Denial of service beyond what the rate limiter is documented to bound.**
   The limiter's constants — a 50 req/s global unauthenticated backstop, a
@@ -249,7 +281,7 @@ substance, because the two documents describe the same boundary:
 > by nothing else. It is therefore present, in the clear, in every host backup
 > and every VPS snapshot of this directory.
 >
-> — [`README.md:212-221`](../README.md)
+> — [`README.md:331-340`](../README.md)
 
 The PRD records this as an accepted risk rather than a defect: "CA private key
 readable in host backups and VPS snapshots" is Likelihood M, mitigated by
@@ -264,7 +296,7 @@ only `s.cfg.PolicyMode`, the same value for every device
 The README states the same property from the operator's side: "The mode is
 fixed at startup and read once. No client can widen it... Changing the mode
 means changing `DEVMON_POLICY_MODE` on the host and restarting the agent."
-([`README.md:129-132`](../README.md)). A general operator-defined per-device
+([`README.md:203-206`](../README.md)). A general operator-defined per-device
 permission set is out of scope for this release
 ([`.claude/PRPs/prds/devmon-agent.prd.md:164`](../.claude/PRPs/prds/devmon-agent.prd.md)).
 


### PR DESCRIPTION
## Why

Operators reach for Cloudflare Tunnel or an nginx/Caddy reverse proxy to avoid publishing a port, hit `401 client certificate required` on every guarded route, and find nothing in the docs explaining it. The agent reads the TLS connection itself in three places, so terminating TLS in front of it is not a configuration problem with a configuration fix — but that was tribal knowledge until now.

## What changed

**`README.md` — new `### Reaching it from outside`**, placed at the end of the install flow where the deployment decision is actually made:

- A symptom table: what breaks, why, and the literal error text an operator will search for.
- Why Cloudflare Access mTLS does not bridge the gap — it verifies at the edge and forwards a header the agent does not read.
- The options that do work: VPN/overlay, Cloudflare Zero Trust `warp-routing`, TCP passthrough.
- Two footguns: `DEVMON_PUBLIC_ADDR` is the server certificate's SAN and must match what the device dials; passthrough still collapses both pre-authentication rate-limit tiers onto the forwarding host.

**`docs/THREAT-MODEL.md`** — a matching `intermediary → listening port` trust boundary, plus an entry under *What is explicitly NOT defended*, so this is recorded as a scope statement rather than an unhardened case.

**Stale reference repair** — the `README.md:NNN` citations in `THREAT-MODEL.md` and `BACKUP.md` had already drifted by roughly 70 lines before this change; the new section moved them further. All six now point at the right passages.

## Notes

- Docs only — no code, no behaviour change.
- Deliberately does not propose an alternative auth model. Request signing would survive a proxy, but that is an unmade design decision and the README should not read as though it were settled.

## Test plan

- [x] **Anchors resolve.** `### Reaching it from outside` (README:103) and `### Rate limiting` (README:263) both exist, and no heading in the file duplicates another case-insensitively — so GitHub appends no `-1` suffix and `#reaching-it-from-outside` / `#rate-limiting` both land. The only other link in the new section, `docs/THREAT-MODEL.md`, resolves from the repo root.
- [x] **All six repaired `README.md:NNN` references check out** against the passages the citing documents quote:

  | Citation | Cited from | Lands on |
  |---|---|---|
  | `README.md:331-340` | THREAT-MODEL, BACKUP | the `ca.key` unencrypted blockquote |
  | `README.md:203-206` | THREAT-MODEL | "The mode is fixed at startup and read once…" |
  | `README.md:310-329` | BACKUP | `## State directory` heading + tree + bind-mount paragraph |
  | `README.md:346-355` | BACKUP | `### Backup` + the stop/tar/start block |
  | `README.md:357-359` | BACKUP | "Restore by extracting to the same path…" |

- [x] **The three code references added to THREAT-MODEL land on what they claim:** `internal/httpapi/middleware.go:44-50` (the `r.TLS.PeerCertificates` read), `internal/httpapi/ratelimit.go:67-81` (`clientIP` and the `X-Forwarded-For` rationale), `internal/config/config.go:3-9` (the package comment stating the startup-configuration boundary).

## Follow-up spotted, not fixed here

`docs/BACKUP.md:88` has `sudo tar czf devmon-backup.tgz -C /var/lib/devmon` with no path operand — `README.md:353` has the correct `-C / var/lib/devmon`. The BACKUP.md form looks like it would fail. Left alone to keep this PR to one concern; happy to fix separately.
