### PR TITLE
fix: repair the backup tar command in docs/BACKUP.md

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -84,7 +84,7 @@ splits a transaction across files. Stop first:
 
 ```bash
 docker stop devmon-agent
-sudo tar czf devmon-backup.tgz -C /var/lib/devmon
+sudo tar czf devmon-backup.tgz -C / var/lib/devmon
 docker start devmon-agent
 ```
 


### PR DESCRIPTION
## The bug

[`docs/BACKUP.md:87`](https://github.com/scnplt/devmon-agent/blob/dev/docs/BACKUP.md#L87) dropped the space before its path operand:

```bash
sudo tar czf devmon-backup.tgz -C /var/lib/devmon
```

GNU tar reads that as `-C /var/lib/devmon` with nothing left to archive:

```
tar: Cowardly refusing to create an empty archive
exit=2
```

An operator following the documented backup procedure stops the agent, gets no archive, and starts it again — believing they now hold a backup of the one directory that *is* the agent's identity. It fails loudly rather than silently, which is the only mercy here, but the failure sits between `docker stop` and `docker start` where it is easy to scroll past.

## The fix

One character. Change to `/` and archive the mount by relative path:

```bash
sudo tar czf devmon-backup.tgz -C / var/lib/devmon
```

This is not a judgement call — three things in the repo already agree on this form:

- The prose four lines below the command: *"keep `-C /` and the mount's absolute path, so the archive extracts back to an absolute path rather than depending on the working directory of whoever runs the restore."*
- [`README.md:353`](https://github.com/scnplt/devmon-agent/blob/dev/README.md#L353), which has always had the correct form.
- The restore command at [`docs/BACKUP.md:115`](https://github.com/scnplt/devmon-agent/blob/dev/docs/BACKUP.md#L115) — `tar xzf devmon-backup.tgz -C / var/lib/devmon` — which can only resolve `var/lib/devmon` if the archive members carry that prefix.

## Verification

Run against GNU tar 1.35 on a fixture mirroring the documented layout.

**Old form** — refuses:

```
$ tar czf old.tgz -C <root>/var/lib/devmon
tar: Cowardly refusing to create an empty archive
exit=2
```

**New form** — produces the members the restore step expects:

```
$ tar czf new.tgz -C <root> var/lib/devmon
exit=0
$ tar tzf new.tgz
var/lib/devmon/
var/lib/devmon/certs/
var/lib/devmon/certs/ca.key
var/lib/devmon/devmon.db
```

**Round-trip through the documented restore command** — contents and layout intact:

```
$ tar xzf new.tgz -C <restore> var/lib/devmon
exit=0
<restore>/var/lib/devmon/certs/ca.key
<restore>/var/lib/devmon/devmon.db
```

## Test plan

- [x] Old form reproduces the failure on GNU tar 1.35
- [x] New form archives the correct members
- [x] Documented restore command round-trips the new archive
- [x] Fix matches `README.md:353` and the prose immediately below the command

## Notes

- Docs only, one line, no code touched.
- Independent of #22 — different hunk in the same file, both cut from `dev`, so they merge in either order. #22 renumbers the `README.md:NNN` citations in this file but does not touch line 87.
