### PR TITLE
docs: describe the client platform-neutrally

### DIFF
--- a/.claude/PRPs/prds/devmon-agent.prd.md
+++ b/.claude/PRPs/prds/devmon-agent.prd.md
@@ -32,7 +32,7 @@ We'll know we're right when **an operator can complete a full pair → inspect �
 - **Metrics, dashboards, alerting, historical retention** — this is a control plane, not a monitoring stack.
 - **Persisting the logs of the containers being managed** — Docker's own log driver owns those, and they disappear when a container is removed. Mirroring them into agent storage means continuous ingestion, disk budgeting, and retention policy: a separate product surface. Only the agent's own logs and audit log are persisted.
 - **A managed/hosted service** — self-hosted only.
-- **The Android application itself** — a separate project; this PRD covers only the server-side agent and the contract it exposes.
+- **The client application itself** — a separate project; this PRD covers only the server-side agent and the contract it exposes.
 
 ## Success Metrics
 
@@ -103,7 +103,7 @@ When **something breaks on my server and I only have my phone**, I want to **see
 | Must | Operation policy fixed at container startup, expressed as named modes | A production host and a test host want different powers. Binding the policy to the agent's startup configuration means a compromised or misused phone cannot escalate beyond what the operator granted — the policy can only be changed with host access. Named modes are chosen over per-operation lists because an operator must be able to state a host's posture in one word. |
 | Must | Safe default policy: destructive operations denied unless explicitly enabled | The operator who reads no documentation gets the conservative behavior. Anyone who wants to delete containers from a phone has to say so deliberately. |
 | Must | Agent advertises its policy and API version to connected clients | The app must disable what the host forbids instead of offering buttons that fail, and must detect an incompatible agent before the user hits an error. |
-| Must | Versioned API contract | The Android app ships independently; unversioned drift will break users. |
+| Must | Versioned API contract | The client app ships independently; unversioned drift will break users. |
 | Must | Proactive device certificate renewal over the authenticated channel | Renewal must happen while the existing certificate is still valid — once it expires there is no authenticated channel left to renew it on. Silent to the user by design. |
 | Must | Unauthenticated status endpoint (informational only) | When a client cannot complete a mutually authenticated handshake, it must still be able to distinguish "my credential expired" from "this server's identity changed", because those need opposite user guidance. It exposes version, CA fingerprint, server time, and policy — never host data, and never credentials. |
 | Must | Distribution as a container image with an **automated installer**, covering the state mount, policy mode, and retention limits | Installation is the first thing every user meets and the moment every durable decision is made at once. A hand-assembled command line is where operators will omit the state mount and later lose every pairing. |
@@ -124,14 +124,14 @@ When **something breaks on my server and I only have my phone**, I want to **see
 
 ### MVP Scope
 
-The minimum that tests the hypothesis: an agent that installs as a container on a VPS, pairs with an Android device once, and from then on serves that device — and any additional paired device — the full read set (containers, images, networks, volumes: list and inspect), container logs including live streaming, and the full container lifecycle set (start, restart, stop, kill, delete), with every mutating call recorded in an audit log. Anything that does not serve the pair → inspect → read logs → act loop is not MVP.
+The minimum that tests the hypothesis: an agent that installs as a container on a VPS, pairs with a client device once, and from then on serves that device — and any additional paired device — the full read set (containers, images, networks, volumes: list and inspect), container logs including live streaming, and the full container lifecycle set (start, restart, stop, kill, delete), with every mutating call recorded in an audit log. Anything that does not serve the pair → inspect → read logs → act loop is not MVP.
 
 ### User Flow
 
 **Critical path — first use:**
 1. Operator runs the agent container on the host and opens its port (their responsibility).
 2. Agent generates its identity on first start and displays a short-lived pairing code/QR in its console output.
-3. Operator adds the server in the Android app and supplies the pairing code.
+3. Operator adds the server in the client app and supplies the pairing code.
 4. Agent verifies the code, issues that device its own credential, and records it as a paired device.
 5. App lists the host's containers.
 
@@ -189,7 +189,7 @@ Every operation requested maps directly onto a well-documented Docker Engine API
 | A device that stays offline past its certificate expiry cannot renew and requires host access to recover | M | Renewal window set to a fraction of certificate lifetime so ordinary use always renews in time; expiry period long enough to tolerate a normally-used device being idle; the unauthenticated endpoint explains the situation instead of showing a bare failure |
 | Future email notifications leak security-relevant information, or are misused to deliver pairing credentials | M | Notifications only, never credentials; treat as a post-MVP feature with its own review |
 | Internet-exposed port attracts automated scanning and abuse | H | Rate limiting; reject non-authenticated connections cheaply; document VPN as the recommended hardening step |
-| Android app and agent version drift breaks users | M | Versioned API contract from the first release |
+| Client app and agent version drift breaks users | M | Versioned API contract from the first release |
 
 ---
 
@@ -240,9 +240,9 @@ Every operation requested maps directly onto a well-documented Docker Engine API
 - **Success signal**: Every permitted lifecycle operation succeeds against a real container and produces a correct, attributed audit entry; an agent started with a restrictive mode refuses forbidden operations regardless of what the client sends; the agent itself resists deletion even in the most permissive mode; the client is told what is available rather than discovering it through failures.
 
 **Phase 6: Client-independent end-to-end suite**
-- **Goal**: Turn the manual validation checklists of Phases 1-5 into an executable, client-independent contract suite, so the API is proven against a real Docker Engine without an Android device — and so any future client, mobile or web, has a machine-checkable definition of what the agent promises.
+- **Goal**: Turn the manual validation checklists of Phases 1-5 into an executable, client-independent contract suite, so the API is proven against a real Docker Engine without a client device — and so any future client, mobile or web, has a machine-checkable definition of what the agent promises.
 - **Scope**: A build-tagged Go test package that starts the real binary against a real Engine, completes pairing over the host-side command path, and drives every endpoint over mTLS: pairing and revocation, the full read set, historical logs plus live streaming with resume across an abrupt connection loss, the five lifecycle routes, all three policy modes, and the audit rows each call produces. Plus a second group that builds the image and runs the agent as a container, which is the only way to exercise self-identification through mountinfo and the self-exclusion guarantee. Long-running endurance is part of the suite but excluded from the default run.
-- **Success signal**: Every item on the Phase 4 and Phase 5 manual checklists — including the headline metric, the agent surviving a delete attempt in the most permissive mode — passes unattended in one command against a real Engine, with no phone and no emulator involved. Anything genuinely untestable without a client device is explicitly named as belonging to the Android app's own suite rather than left as an unticked box here.
+- **Success signal**: Every item on the Phase 4 and Phase 5 manual checklists — including the headline metric, the agent surviving a delete attempt in the most permissive mode — passes unattended in one command against a real Engine, with no phone and no emulator involved. Anything genuinely untestable without a client device is explicitly named as belonging to the client app's own suite rather than left as an unticked box here.
 
 **Phase 7: Hardening & OSS release**
 - **Goal**: Safe to point at the public internet and to publish.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # devmon-agent
 
-Go agent that exposes a narrow, mTLS-authenticated Docker control API so an Android
+Go agent that exposes a narrow, mTLS-authenticated Docker control API so a paired
 client can inspect and restart containers without SSH and without exposing the Docker socket.
 
 - Module: `github.com/scnplt/devmon-agent`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # devmon-agent
 
-A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so an
-Android client can inspect and restart containers without SSH and without
+A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
+paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
 **Status: 0.1.1 — the full surface.** The agent is its own certificate
@@ -557,7 +557,7 @@ single `UPDATE`, and the next request the revoked device makes is already
 rejected.
 
 TLS 1.3 is the floor. Both peers are ours, so there is nothing to negotiate down
-to, and Android has supported it since API 29.
+to, and every current client TLS stack supports it.
 
 ---
 
@@ -583,7 +583,7 @@ a lost code is minted again rather than recovered.
 
 ### 2. Redeem it
 
-The Android app does this. To do it by hand:
+The client app does this. To do it by hand:
 
 ```bash
 openssl ecparam -name prime256v1 -genkey -noout -out device.key

--- a/internal/certs/ca.go
+++ b/internal/certs/ca.go
@@ -218,7 +218,7 @@ func readFileInRoot(root *os.Root, name string) ([]byte, error) {
 }
 
 // Fingerprint is the hex SHA-256 digest over the CA certificate's DER bytes.
-// It is the pinning anchor an Android client records at pairing time and is
+// It is the pinning anchor a client records at pairing time and is
 // published on GET /v1/status — publishing it is the point, and nothing else
 // about the CA may join it.
 func (c *CA) Fingerprint() string {

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -64,7 +64,7 @@ func TestGenerateServerCert(t *testing.T) {
 		t.Error("SerialNumber is zero, want random entropy")
 	}
 
-	// The key must be PKCS#8 — the portable form for the Android client.
+	// The key must be PKCS#8 — the portable form across client platforms.
 	keyBlock, _ := pem.Decode(keyPEM)
 	if keyBlock == nil || keyBlock.Type != pemTypePrivateKey {
 		t.Fatalf("key PEM block = %v, want %s", keyBlock, pemTypePrivateKey)

--- a/internal/certs/selfsigned.go
+++ b/internal/certs/selfsigned.go
@@ -28,7 +28,7 @@ const (
 	// serverCertValidity is the CA/Browser Forum maximum for a leaf certificate.
 	// It is not a round number by accident: modern mobile TLS stacks reject
 	// longer-lived leaves outright, so a "convenient" 10-year self-signed cert
-	// would fail on the Android client with an opaque error.
+	// would fail on the client with an opaque error.
 	serverCertValidity = 398 * 24 * time.Hour
 
 	// certCommonName is cosmetic. Verification uses SANs; CN has been ignored by
@@ -44,7 +44,7 @@ const (
 const (
 	pemTypeCertificate = "CERTIFICATE"
 	// PKCS#8 rather than SEC1 ("EC PRIVATE KEY"): both work with Go, but PKCS#8
-	// is the portable form for the Android client.
+	// is the portable form across client platforms.
 	pemTypePrivateKey = "PRIVATE KEY"
 )
 

--- a/internal/dockerx/list.go
+++ b/internal/dockerx/list.go
@@ -20,8 +20,8 @@ func truncate[T any](items []T) ([]T, bool) {
 }
 
 // defaultLabels returns m unchanged, or a non-nil empty map when m is nil. A
-// nil map marshals to JSON null rather than {}, which would force the Android
-// client to handle both a map and a null for the same field.
+// nil map marshals to JSON null rather than {}, which would force the client
+// to handle both a map and a null for the same field.
 func defaultLabels(m map[string]string) map[string]string {
 	if m == nil {
 		return map[string]string{}

--- a/internal/e2e/api/contract_logs_test.go
+++ b/internal/e2e/api/contract_logs_test.go
@@ -25,7 +25,7 @@ import (
 // depends on and can be asserted without a radio: the stream tears down
 // cleanly after an RST (D15), and ?since=<last id> resumes with at most one
 // repeated line, never a gap. The client half — actually performing a
-// network handover — is named as belonging to the Android app's own suite
+// network handover — is named as belonging to the client app's own suite
 // (the phase plan's Coverage Map).
 //
 // It also covers the historical log route's bounds (?tail=, ?since=) and the

--- a/internal/httpapi/status.go
+++ b/internal/httpapi/status.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scnplt/devmon-agent/internal/version"
 )
 
-// APIVersion is the contract version the Android app negotiates against. The app
+// APIVersion is the contract version the client app negotiates against. The app
 // ships independently of the agent, so it must be able to detect an incompatible
 // agent before the user hits an error rather than after.
 const APIVersion = "v1"

--- a/internal/tlsconf/tlsconf.go
+++ b/internal/tlsconf/tlsconf.go
@@ -34,7 +34,7 @@ func Build(cert tls.Certificate, clientCAs *x509.CertPool) *tls.Config {
 
 		// Both peers are ours, so there is nothing to negotiate down to. TLS 1.3
 		// removes the entire downgrade and cipher-negotiation surface, and
-		// Android has supported it since API 29.
+		// every current client TLS stack supports it.
 		//
 		// CipherSuites is deliberately unset: it is ignored for TLS 1.3.
 		MinVersion: tls.VersionTLS13,


### PR DESCRIPTION
## Summary

The agent's contract never depended on the client being an Android app. This replaces the wording that named Android specifically with platform-neutral client wording, so a future mobile or web client reads as in scope rather than as an exception.

Prose and comments only — no behavior, no API surface, no test logic changed. The diff is 21 insertions / 21 deletions across 10 files.

## What changed

| File | Before → After |
|---|---|
| `README.md:3`, `CLAUDE.md:3` | "an Android client can inspect…" → "a paired client…" |
| `README.md:560`, `internal/tlsconf/tlsconf.go:37` | "Android has supported it since API 29" → "every current client TLS stack supports it" |
| `README.md:586` | "The Android app does this" → "The client app does this" |
| `internal/certs/ca.go:221` | pinning anchor "an Android client records" → "a client records" |
| `internal/certs/selfsigned.go:31,47`, `certs_test.go:67` | PKCS#8 "portable form for the Android client" → "across client platforms" |
| `internal/dockerx/list.go:23`, `internal/httpapi/status.go:12`, `internal/e2e/api/contract_logs_test.go:28` | "the Android client/app" → "the client/client app" |
| `.claude/PRPs/prds/devmon-agent.prd.md` | 7 references to our own app (non-goals, MVP scope, user flow, risk table, Phase 6 goal) generalized |

## Deliberately left alone

- **PRD lines 9, 10, 293** — market-research citations about *competitors* (Portainer Mobile, AndroTainer, `Docker-Manager`). Those are factual observations about the Android market, not claims about this product; rewriting them would falsify the evidence section.
- **Completed plans, reports, and reviews** under `.claude/PRPs/` — historical records of what was decided at the time.
- **~40 occurrences of "phone" / "mobile"** (e.g. `ratelimit.go:147`, `install.sh:65`) — not Android-specific, so out of scope here. Worth a follow-up if a desktop or web client is planned, since that wording still narrows the product.

## Test plan

All gates pass locally:

- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags e2e ./internal/e2e/...`
- [x] `gofmt -l` on every edited file — clean
- [x] `golangci-lint run ./...`
- [x] `gosec ./...` — 0 issues
- [x] `go test ./internal/... -race` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)