### PR TITLE
chore: prepare v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,63 @@ changes nothing about the agent's behaviour, but this is an open repository and
 a contributor reading the history should not have to reconstruct why the build
 moved.
 
+## [0.1.2] - 2026-08-11
+
+The agent's behaviour is unchanged from 0.1.1 — nothing in `cmd/` or
+`internal/` moved. This release exists so the documentation and the published
+image carry the same version, and so the new API description ships alongside
+the agent it describes rather than trailing it.
+
+### Added
+
+- **`docs/openapi.yaml` — an OpenAPI 3.1 description of the whole `/v1`
+  surface.** The client ships independently of the agent, so the contract
+  between them needed to exist as something a machine can read: it generates
+  client types, and it diffs between releases, which is how a breaking change
+  gets noticed before a user finds it. Until now the only definition was README
+  prose and the end-to-end contract tests.
+
+  It also writes down the sharp edge nothing had documented: object references
+  are validated against `^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$` before reaching the
+  Engine, and the pattern excludes `:`. An image ID read from a list response is
+  digest-prefixed (`sha256:…`) and must have that prefix stripped before
+  `GET /v1/images/{id}` will accept it; a tagged reference is a 400, not a
+  lookup.
+
+### Changed
+
+- The client is described platform-neutrally throughout the documentation. The
+  agent has never had an Android-specific line in it, and saying "the Android
+  app" implied a constraint the API does not have.
+  ([#24](https://github.com/scnplt/devmon-agent/pull/24))
+
+### Fixed
+
+- The restore command in `docs/BACKUP.md` was wrong — a `tar` invocation that
+  could not have worked as written. Backup documentation is read exactly once,
+  by someone whose state directory is already gone, which is the worst possible
+  moment to find a typo.
+  ([#23](https://github.com/scnplt/devmon-agent/pull/23))
+
+### Internal
+
+- **`govulncheck` runs on the release bar.** `gosec` and `govulncheck` answer
+  different questions: one looks for faults in the code written here, the other
+  for known vulnerabilities in the dependencies and the Go toolchain underneath
+  it. Nothing in CI asked the second. Its single manual run, during the Phase 7
+  security review, reported GO-2026-5856 and produced the Go 1.26.5 bump — a
+  finding that arrived only because someone remembered to run it by hand.
+  `make vuln` is the local counterpart.
+- **Dependabot version updates** for `gomod`, `github-actions`, and `docker`.
+  Alerts were already on; version updates are configuration and exist only where
+  they are committed, so nothing was watching any of the three. The `docker`
+  ecosystem is the one no Go gate can cover: `govulncheck` reads the module
+  graph, not the base-image layers underneath it.
+- Documentation records why an HTTPS-terminating proxy cannot front the agent.
+  Three separate parts of the design read the TLS connection itself, so this is
+  not a configuration problem with a setting that recovers it.
+  ([#22](https://github.com/scnplt/devmon-agent/pull/22))
+
 ## [0.1.1] - 2026-08-11
 
 ### Fixed
@@ -80,5 +137,6 @@ First public release — the full surface.
   writing a `compose.yaml`, and waiting for the agent to answer.
 - **Multi-arch image.** `linux/amd64` and `linux/arm64`.
 
+[0.1.2]: https://github.com/scnplt/devmon-agent/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/scnplt/devmon-agent/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/scnplt/devmon-agent/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.1.1 — the full surface.** The agent is its own certificate
+**Status: 0.1.2 — the full surface.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -68,7 +68,7 @@ docker run -d --name devmon-agent \
   --group-add "$(stat -c '%g' /var/run/docker.sock)" \
   -p 8443:8443 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.1.1
+  ghcr.io/scnplt/devmon-agent:0.1.2
 ```
 
 See `compose.example.yaml` for the equivalent Compose file and a reference for
@@ -78,7 +78,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.1.1","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.1.2","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -23,7 +23,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.1.1
+    image: ghcr.io/scnplt/devmon-agent:0.1.2
     restart: unless-stopped
 
     ports:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.1.1
+  version: 0.1.2
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -121,7 +121,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.1.1
+                    agent_version: 0.1.2
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -854,7 +854,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.1.1"]
+          examples: ["0.1.2"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.1.1'
+IMAGE_TAG='0.1.2'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
## What

CHANGELOG entry for 0.1.2 and the four version pins moved together: `install.sh`'s `IMAGE_TAG`, `compose.example.yaml`, the README's status line and `docker run` example, and `docs/openapi.yaml`'s `info.version` plus the two `agent_version` examples that quote it.

## Why a release at all

Everything since v0.1.1 is documentation, CI, and repository configuration — nothing in `cmd/` or `internal/` moved, so **the agent behaves exactly as 0.1.1 does**. The release exists so the docs and the published image carry the same version, and so the new OpenAPI description ships with the agent it describes rather than trailing it by a version.

The CHANGELOG says this in its first line, so nobody upgrades expecting a behaviour change.

## Stacking

Based on `docs/openapi-contract` (#27), because it bumps `info.version` in the file that PR adds. **Merge #27 first**, then this one. #25 and #26 are independent and can go in any order.

## Test plan

- [x] `sh -n install.sh` parses after the `IMAGE_TAG` change.
- [x] `npx @redocly/cli lint docs/openapi.yaml` still valid after the version bump.
- [x] `grep -rn '0\.1\.1'` over the shipped files returns nothing but the CHANGELOG's own history section.
- [ ] After `v0.1.2` is tagged, `ghcr.io/scnplt/devmon-agent:0.1.2` exists with both architectures — the documented install path names it and fails until it does.