### PR TITLE
feat: identify the agent's own container by name, not only by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ file, or signal that can widen what was granted here.
 | `DEVMON_PUBLIC_ADDR` | comma list | *(required)* | ≥1 entry; each a DNS name or IP; used as server-certificate SANs |
 | `DEVMON_POLICY_MODE` | enum | `default` | One of `read-only`, `default`, `full` |
 | `DEVMON_DOCKER_HOST` | URL | `unix:///var/run/docker.sock` | Scheme `unix` or `tcp` |
-| `DEVMON_SELF_CONTAINER_ID` | hex | *(auto-detected)* | 12 or 64 lowercase hex characters |
+| `DEVMON_SELF_CONTAINER` | name or ID | *(auto-detected)* | A Docker container name, or a 12/64-character hex ID |
 | `DEVMON_LOG_LEVEL` | enum | `info` | One of `debug`, `info`, `warn`, `error` |
 | `DEVMON_LOG_MAX_AGE_DAYS` | int | `1` | ≥1 |
 | `DEVMON_LOG_MAX_TOTAL_MB` | int | `64` | ≥8 |
@@ -223,28 +223,42 @@ ID is refused identically. Its row in `GET /v1/containers` carries
 `"protected": true`; every other row carries `"protected": false`, so the app
 can grey out those controls and explain why.
 
-To identify itself, the agent checks `DEVMON_SELF_CONTAINER_ID` first, then
-looks for a container ID in `/proc/self/mountinfo` and `/proc/self/cgroup`, then
-falls back to `$HOSTNAME`. Each candidate is confirmed against the Engine before
-it is accepted, because no single source is reliable — cgroup v2 with a private
+To identify itself, the agent checks `DEVMON_SELF_CONTAINER` first, then looks
+for a container ID in `/proc/self/mountinfo` and `/proc/self/cgroup`, then falls
+back to `$HOSTNAME`. Each candidate is confirmed against the Engine before it is
+accepted, because no single source is reliable — cgroup v2 with a private
 namespace reports nothing useful, and `$HOSTNAME` stops being the container ID
 the moment anyone passes `--hostname`. The resolved ID is logged once at
 startup, so an operator can confirm it protected the right thing.
 
 If the agent is containerised but **no** candidate is confirmed, it logs an
-ERROR naming `DEVMON_SELF_CONTAINER_ID` and answers **503 on the five lifecycle
-routes only**. Reads, logs, pairing, and status keep working. The fix is one
-line — take the ID from `docker ps` and set it:
+ERROR naming `DEVMON_SELF_CONTAINER` and answers **503 on the five lifecycle
+routes only**. Reads, logs, pairing, and status keep working. The fix is to name
+the container and tell the agent that name:
 
 ```yaml
-environment:
-  DEVMON_SELF_CONTAINER_ID: "3f2a91c4e5b8"   # 12 or 64 lowercase hex chars
+services:
+  devmon-agent:
+    container_name: devmon-agent
+    environment:
+      DEVMON_SELF_CONTAINER: devmon-agent
 ```
+
+**Give it a name, not an ID.** The variable accepts either — the Engine resolves
+both — but an ID copied out of `docker ps` is worthless here. Adding a variable
+to a compose file changes the container's spec, so the next `docker compose up
+-d` recreates the container and mints a new ID, and the value that was just
+written is stale before it is ever read. Copying the new ID and repeating never
+converges. A name survives recreation, so it is set once. `install.sh` and
+`compose.example.yaml` both pin `container_name` and set this variable for
+exactly this reason.
 
 A malformed value is a startup configuration error (exit 2), not a warning: this
 is the documented fix for the one case where lifecycle is unavailable, so a typo
-must surface at start rather than when the button stays grey. Setting it to a
-valid but *wrong* ID protects that container instead — the override is trusted.
+must surface at start rather than when the button stays grey. A value that is
+well-formed but names some *other* container protects that one instead — the
+override is trusted. One that names nothing the Engine knows is discarded with a
+WARN, and the agent falls back to the filesystem candidates as if it were unset.
 
 Running the agent directly on the host rather than in a container is fine: there
 is no container to protect, so lifecycle works normally and the agent says so

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -163,7 +163,7 @@ func serve(ctx context.Context, cfg config.Config, sink *logging.Sink, log *slog
 		return err
 	}
 
-	dc, err := dockerx.New(ctx, cfg.DockerHost, cfg.SelfContainerID, log)
+	dc, err := dockerx.New(ctx, cfg.DockerHost, cfg.SelfContainer, log)
 	if err != nil {
 		return err
 	}

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -24,6 +24,11 @@
 services:
   devmon-agent:
     image: ghcr.io/scnplt/devmon-agent:0.1.2
+
+    # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
+    # Without it compose derives the container name from the project directory,
+    # which changes if this file moves.
+    container_name: devmon-agent
     restart: unless-stopped
 
     ports:
@@ -53,6 +58,13 @@ services:
       # read-only | default | full. Fixed at startup and immutable thereafter —
       # a client can never widen what is granted here.
       DEVMON_POLICY_MODE: default
+
+      # How the agent recognises its own container, so it can refuse to stop or
+      # delete itself. It can usually work this out unaided; setting it makes
+      # that deterministic. Give it the container's NAME, not its ID — an ID
+      # changes every time the container is recreated, which is exactly what
+      # `docker compose up -d` does after any edit to this file.
+      DEVMON_SELF_CONTAINER: devmon-agent
 
       DEVMON_LOG_MAX_AGE_DAYS: "1"
       DEVMON_LOG_MAX_TOTAL_MB: "64"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -823,7 +823,8 @@ components:
       description: |
         The agent is running in a container but could not determine which one,
         so it cannot enforce its own exclusion and every mutating route fails
-        closed. Resolvable on the host by setting `DEVMON_SELF_CONTAINER_ID`.
+        closed. Resolvable on the host by setting `DEVMON_SELF_CONTAINER` to
+        the agent container's name.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }

--- a/install.sh
+++ b/install.sh
@@ -472,6 +472,11 @@ compose_file_contents() {
 services:
   $SERVICE_NAME:
     image: $IMAGE_REPO:$IMAGE_TAG
+
+    # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
+    # Without it compose derives the container name from the project directory,
+    # which changes if this file moves.
+    container_name: $SERVICE_NAME
     restart: unless-stopped
 
     ports:
@@ -496,6 +501,12 @@ services:
     environment:
       DEVMON_PUBLIC_ADDR: "$PUBLIC_ADDR"
       DEVMON_POLICY_MODE: "$POLICY_MODE"
+
+      # How the agent recognises its own container, so it can refuse to stop
+      # or delete itself. It can usually work this out unaided, but the name
+      # pinned above is the one form that stays true across a recreate — an ID
+      # would be stale the next time this file changes.
+      DEVMON_SELF_CONTAINER: "$SERVICE_NAME"
 
       DEVMON_LOG_MAX_AGE_DAYS: "$LOG_MAX_AGE_DAYS"
       DEVMON_LOG_MAX_TOTAL_MB: "$LOG_MAX_TOTAL_MB"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ const (
 	envLogMaxTotalMB   = "DEVMON_LOG_MAX_TOTAL_MB"
 	envAuditMaxAgeDays = "DEVMON_AUDIT_MAX_AGE_DAYS"
 	envAuditMaxRows    = "DEVMON_AUDIT_MAX_ROWS"
-	envSelfContainerID = "DEVMON_SELF_CONTAINER_ID"
+	envSelfContainer   = "DEVMON_SELF_CONTAINER"
 
 	envRateStatusPerMin  = "DEVMON_RATE_STATUS_PER_MIN"
 	envRatePairPerMin    = "DEVMON_RATE_PAIR_PER_MIN"
@@ -87,14 +87,13 @@ const (
 
 const hoursPerDay = 24
 
-// shortContainerIDPattern and fullContainerIDPattern match Docker's short
-// (12-character) and full (64-character) hex container IDs. Docker always
-// lower-cases these; an uppercase value is treated as a typo rather than
-// silently normalized, so the operator finds out at start.
-var (
-	shortContainerIDPattern = regexp.MustCompile(`^[0-9a-f]{12}$`)
-	fullContainerIDPattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
-)
+// containerRefPattern matches Docker's container-name grammar: it must start
+// with an alphanumeric character and may continue with alphanumerics,
+// underscores, periods, or hyphens. This also admits 12- and 64-character hex
+// container IDs as a byproduct, which is intended — ContainerInspect resolves
+// both names and IDs through the same "name or ID" lookup, so one pattern
+// covers everything this knob accepts.
+var containerRefPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
 
 // Config is the fully parsed, validated startup configuration.
 type Config struct {
@@ -113,10 +112,14 @@ type Config struct {
 	RatePairPerMin    int
 	RateGuardedPerSec int
 
-	// SelfContainerID is an operator-supplied override for the agent's own
-	// container ID, used when the agent cannot detect it automatically. Empty
-	// is the normal case; it has no default.
-	SelfContainerID string
+	// SelfContainer is an operator-supplied name-or-ID override for the
+	// agent's own container, used when the agent cannot detect it
+	// automatically. A container name (container_name: / --name) is the form
+	// worth using: docker compose up -d recreates the container whenever the
+	// compose file changes and mints a new ID, so an ID copied out of docker
+	// ps is stale on the very next boot, while a name survives recreation.
+	// Empty is the normal case; it has no default.
+	SelfContainer string
 }
 
 // Derived paths live here as methods so no other package ever concatenates a
@@ -172,7 +175,7 @@ func Load(getenv func(string) string) (Config, error) {
 		RatePairPerMin:    l.boundedInt(envRatePairPerMin, defaultRatePairPerMin, minRatePerX),
 		RateGuardedPerSec: l.boundedInt(envRateGuardedPerSec, defaultRateGuardedPerSec, minRatePerX),
 
-		SelfContainerID: l.selfContainerID(),
+		SelfContainer: l.selfContainer(),
 	}
 
 	l.checkRetentionOrder(cfg)
@@ -270,21 +273,23 @@ func (l *loader) dockerHost() string {
 	return host
 }
 
-// selfContainerID parses the optional self-identification override. Absent is
-// the normal path: the agent detects its own container ID by other means and
+// selfContainer parses the optional self-identification override. Absent is
+// the normal path: the agent detects its own container by other means and
 // this variable exists only as the documented fallback. A value that is
 // present but malformed is a startup configuration error, not a warning — an
 // operator who typos it must find out at start rather than when the delete
-// button stays greyed out.
-func (l *loader) selfContainerID() string {
-	id := l.raw(envSelfContainerID, "")
-	if id == "" {
+// button stays greyed out. The value is used exactly as given: Docker
+// container names are case-sensitive, so it is never lower-cased or
+// otherwise normalized here.
+func (l *loader) selfContainer() string {
+	ref := l.raw(envSelfContainer, "")
+	if ref == "" {
 		return ""
 	}
-	if !shortContainerIDPattern.MatchString(id) && !fullContainerIDPattern.MatchString(id) {
-		l.fail(envSelfContainerID, "%q is not a valid container ID (want 12 or 64 lowercase hex characters)", id)
+	if !containerRefPattern.MatchString(ref) {
+		l.fail(envSelfContainer, "%q is not a valid container name or ID (want a container name or a 12/64-character hex ID)", ref)
 	}
-	return id
+	return ref
 }
 
 func (l *loader) logLevel() slog.Level {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,32 +163,41 @@ func TestLoadOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "self container id override, short form",
-			env:  map[string]string{envSelfContainerID: "0123456789ab"},
+			name: "self container override, name form",
+			env:  map[string]string{envSelfContainer: "devmon-agent"},
 			check: func(t *testing.T, cfg Config) {
-				if cfg.SelfContainerID != "0123456789ab" {
-					t.Errorf("SelfContainerID = %q, want 0123456789ab", cfg.SelfContainerID)
+				if cfg.SelfContainer != "devmon-agent" {
+					t.Errorf("SelfContainer = %q, want devmon-agent", cfg.SelfContainer)
 				}
 			},
 		},
 		{
-			name: "self container id override, full form",
+			name: "self container override, short hex ID form",
+			env:  map[string]string{envSelfContainer: "0123456789ab"},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.SelfContainer != "0123456789ab" {
+					t.Errorf("SelfContainer = %q, want 0123456789ab", cfg.SelfContainer)
+				}
+			},
+		},
+		{
+			name: "self container override, full hex ID form",
 			env: map[string]string{
-				envSelfContainerID: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				envSelfContainer: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			},
 			check: func(t *testing.T, cfg Config) {
 				want := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-				if cfg.SelfContainerID != want {
-					t.Errorf("SelfContainerID = %q, want %s", cfg.SelfContainerID, want)
+				if cfg.SelfContainer != want {
+					t.Errorf("SelfContainer = %q, want %s", cfg.SelfContainer, want)
 				}
 			},
 		},
 		{
-			name: "self container id absent is the normal path",
+			name: "self container absent is the normal path",
 			env:  map[string]string{},
 			check: func(t *testing.T, cfg Config) {
-				if cfg.SelfContainerID != "" {
-					t.Errorf("SelfContainerID = %q, want empty", cfg.SelfContainerID)
+				if cfg.SelfContainer != "" {
+					t.Errorf("SelfContainer = %q, want empty", cfg.SelfContainer)
 				}
 			},
 		},
@@ -267,19 +276,29 @@ func TestLoadRejections(t *testing.T) {
 			wantKey: envAuditMaxAgeDays,
 		},
 		{
-			name:    "self container id uppercase",
-			env:     map[string]string{envSelfContainerID: "0123456789AB"},
-			wantKey: envSelfContainerID,
+			name:    "self container leading hyphen",
+			env:     map[string]string{envSelfContainer: "-devmon-agent"},
+			wantKey: envSelfContainer,
 		},
 		{
-			name:    "self container id wrong length",
-			env:     map[string]string{envSelfContainerID: "0123456789abc"},
-			wantKey: envSelfContainerID,
+			name:    "self container leading period",
+			env:     map[string]string{envSelfContainer: ".devmon-agent"},
+			wantKey: envSelfContainer,
 		},
 		{
-			name:    "self container id non-hex",
-			env:     map[string]string{envSelfContainerID: "0123456789zz"},
-			wantKey: envSelfContainerID,
+			name:    "self container with embedded slash",
+			env:     map[string]string{envSelfContainer: "devmon/agent"},
+			wantKey: envSelfContainer,
+		},
+		{
+			name:    "self container with a space",
+			env:     map[string]string{envSelfContainer: "devmon agent"},
+			wantKey: envSelfContainer,
+		},
+		{
+			name:    "self container single character",
+			env:     map[string]string{envSelfContainer: "a"},
+			wantKey: envSelfContainer,
 		},
 		{"non-integer status rate", map[string]string{envRateStatusPerMin: "many"}, envRateStatusPerMin},
 		{"zero status rate", map[string]string{envRateStatusPerMin: "0"}, envRateStatusPerMin},

--- a/internal/dockerx/client.go
+++ b/internal/dockerx/client.go
@@ -36,7 +36,7 @@ type Client struct {
 // is a fatal startup error rather than a degraded mode: an agent that starts and
 // then fails every request is harder to diagnose than one that refuses to start.
 //
-// selfOverride is the operator's DEVMON_SELF_CONTAINER_ID, or "" when unset.
+// selfOverride is the operator's DEVMON_SELF_CONTAINER, or "" when unset.
 // It is the escape hatch for the rare host where every filesystem-derived
 // candidate is wrong (D2).
 func New(ctx context.Context, host string, selfOverride string, log *slog.Logger) (*Client, error) {

--- a/internal/dockerx/self.go
+++ b/internal/dockerx/self.go
@@ -69,12 +69,12 @@ func (c *Client) confirmSelf(ctx context.Context, detected selfid.Result) selfIn
 			}
 			// The override is the operator's explicit configuration, not a
 			// best-effort filesystem guess like mountinfo or cgroup — losing
-			// it silently leaves no signal that DEVMON_SELF_CONTAINER_ID was
+			// it silently leaves no signal that DEVMON_SELF_CONTAINER was
 			// discarded. detected.Override appears in Candidates at most
 			// once (selfid.Detect dedupes), so this fires exactly once.
 			if detected.Override != "" && candidate == detected.Override {
-				c.log.Warn("discarding DEVMON_SELF_CONTAINER_ID: the Engine does not recognise it",
-					slog.String("container_id", detected.Override),
+				c.log.Warn("discarding DEVMON_SELF_CONTAINER: the Engine does not recognise it",
+					slog.String("self_container", detected.Override),
 				)
 			}
 			continue
@@ -90,7 +90,7 @@ func (c *Client) confirmSelf(ctx context.Context, detected selfid.Result) selfIn
 
 	if detected.Containerized {
 		c.log.Error("agent could not identify its own container; " +
-			"set DEVMON_SELF_CONTAINER_ID to the agent's container ID and restart")
+			"set DEVMON_SELF_CONTAINER to the agent's container name or ID and restart")
 	} else {
 		c.log.Info("agent is not running in a container; self-exclusion is inapplicable")
 	}

--- a/internal/dockerx/self_test.go
+++ b/internal/dockerx/self_test.go
@@ -141,7 +141,7 @@ func TestResolveSelfNoneConfirmed(t *testing.T) {
 }
 
 // TestConfirmSelfWarnsOnDiscardedOverride proves that an unrecognised
-// DEVMON_SELF_CONTAINER_ID override is not silently dropped: confirmSelf
+// DEVMON_SELF_CONTAINER override is not silently dropped: confirmSelf
 // still falls through to the next candidate and resolves it (control flow is
 // unchanged — Finding 1's security posture stays sound), but it now logs a
 // warning naming the discarded override. This covers the not-found case,
@@ -173,14 +173,14 @@ func TestConfirmSelfWarnsOnDiscardedOverride(t *testing.T) {
 		t.Fatalf("id = %q, want %q (resolution must still fall through to the next candidate)", got.id, wantID)
 	}
 	logText := logBuf.String()
-	if !strings.Contains(logText, "discarding DEVMON_SELF_CONTAINER_ID") {
+	if !strings.Contains(logText, "discarding DEVMON_SELF_CONTAINER") {
 		t.Errorf("log does not contain the discard warning, want it present: %s", logText)
 	}
 	if !strings.Contains(logText, override) {
 		t.Errorf("log does not name the discarded override %q: %s", override, logText)
 	}
-	if strings.Count(logText, "discarding DEVMON_SELF_CONTAINER_ID") != 1 {
-		t.Errorf("discard warning appeared %d times, want exactly 1", strings.Count(logText, "discarding DEVMON_SELF_CONTAINER_ID"))
+	if strings.Count(logText, "discarding DEVMON_SELF_CONTAINER") != 1 {
+		t.Errorf("discard warning appeared %d times, want exactly 1", strings.Count(logText, "discarding DEVMON_SELF_CONTAINER"))
 	}
 }
 
@@ -210,7 +210,7 @@ func TestConfirmSelfNoWarningWhenOverrideConfirmed(t *testing.T) {
 	if got.id != wantID {
 		t.Fatalf("id = %q, want %q", got.id, wantID)
 	}
-	if strings.Contains(logBuf.String(), "discarding DEVMON_SELF_CONTAINER_ID") {
+	if strings.Contains(logBuf.String(), "discarding DEVMON_SELF_CONTAINER") {
 		t.Errorf("log unexpectedly contains the discard warning: %s", logBuf.String())
 	}
 }

--- a/internal/e2e/api/contract_startup_test.go
+++ b/internal/e2e/api/contract_startup_test.go
@@ -38,8 +38,8 @@ func TestConfigFaultsReportedTogether(t *testing.T) {
 		a := harness.StartAgent(t, harness.AgentOptions{
 			PolicyMode: "bogus", // invalid DEVMON_POLICY_MODE
 			Env: map[string]string{
-				"DEVMON_LOG_MAX_AGE_DAYS":  "x",               // not an integer
-				"DEVMON_SELF_CONTAINER_ID": "not-a-hex-id!!!", // matches neither container ID pattern
+				"DEVMON_LOG_MAX_AGE_DAYS": "x",               // not an integer
+				"DEVMON_SELF_CONTAINER":   "not-a-hex-id!!!", // matches neither the name nor the ID grammar
 			},
 			ExpectFailure: true,
 		})
@@ -48,7 +48,7 @@ func TestConfigFaultsReportedTogether(t *testing.T) {
 		if exitCode != 2 {
 			t.Errorf("exit code = %d, want 2 (config fault)", exitCode)
 		}
-		for _, name := range []string{"DEVMON_POLICY_MODE", "DEVMON_LOG_MAX_AGE_DAYS", "DEVMON_SELF_CONTAINER_ID"} {
+		for _, name := range []string{"DEVMON_POLICY_MODE", "DEVMON_LOG_MAX_AGE_DAYS", "DEVMON_SELF_CONTAINER"} {
 			if !strings.Contains(stderr, name) {
 				t.Errorf("stderr does not name %s; stderr = %s", name, stderr)
 			}

--- a/internal/e2e/incontainer/contract_selfid_test.go
+++ b/internal/e2e/incontainer/contract_selfid_test.go
@@ -16,7 +16,7 @@ import (
 // This file covers the self-IDENTIFICATION half of Phase 5's outstanding
 // checklist (lifecycle-policy-and-audit.plan.md:1086-1126): proving the
 // agent finds its own container through /proc/self/mountinfo rather than
-// $HOSTNAME, that an explicit DEVMON_SELF_CONTAINER_ID override is honoured
+// $HOSTNAME, that an explicit DEVMON_SELF_CONTAINER override is honoured
 // ahead of that auto-detection, and that a well-formed but unresolvable
 // override degrades the agent's lifecycle routes rather than crashing it or
 // silently disabling self-protection.
@@ -92,10 +92,14 @@ func TestSelfIDResolvesWithOverriddenHostname(t *testing.T) {
 	}
 }
 
-// TestExplicitSelfIDOverrideIsHonoured proves DEVMON_SELF_CONTAINER_ID is
+// TestExplicitSelfIDOverrideIsHonoured proves DEVMON_SELF_CONTAINER is
 // honoured ahead of mountinfo/cgroup auto-detection, the moment the Engine
 // confirms it names a real container — WITHOUT needing the override to
-// equal the agent's OWN Docker-assigned ID.
+// equal the agent's OWN Docker-assigned ID. It covers both forms the knob
+// promises to accept: a container name and a full hex ID. The name form is
+// the one an operator can actually apply once and have survive
+// `docker compose up -d` recreation — see config.go's SelfContainer doc
+// comment for why an ID copied out of `docker ps` is stale on the next boot.
 //
 // That equality cannot be constructed at all: a container's ID does not
 // exist until client.ContainerCreate returns it, and the SAME call must
@@ -119,38 +123,43 @@ func TestExplicitSelfIDOverrideIsHonoured(t *testing.T) {
 
 	bystander := harness.StartFixture(t, e, harness.FixtureOptions{NameSuffix: "override-target"})
 	waitFixtureRunning(t, e, bystander)
+	bystanderRefs := refForms(t, e, bystander)
 
-	c := harness.RunAgentContainer(t, e, harness.ContainerAgentOptions{
-		Image:      selfIDImageTag,
-		PolicyMode: "full",
-		Env:        map[string]string{"DEVMON_SELF_CONTAINER_ID": bystander},
-	})
-	device := harness.PairDeviceInContainer(t, c, "explicit-override-device")
+	for _, form := range []string{"name", "full"} {
+		t.Run(form, func(t *testing.T) {
+			c := harness.RunAgentContainer(t, e, harness.ContainerAgentOptions{
+				Image:      selfIDImageTag,
+				PolicyMode: "full",
+				Env:        map[string]string{"DEVMON_SELF_CONTAINER": bystanderRefs[form]},
+			})
+			device := harness.PairDeviceInContainer(t, c, "explicit-override-device-"+form)
 
-	status, obj := device.JSON(t, http.MethodGet, "/v1/containers?all=true")
-	if status != http.StatusOK {
-		t.Fatalf("GET /v1/containers?all=true: status = %d, want %d", status, http.StatusOK)
-	}
-	items, ok := obj["items"].([]any)
-	if !ok {
-		t.Fatalf("GET /v1/containers?all=true: items is not a JSON array: %#v", obj["items"])
-	}
+			status, obj := device.JSON(t, http.MethodGet, "/v1/containers?all=true")
+			if status != http.StatusOK {
+				t.Fatalf("GET /v1/containers?all=true: status = %d, want %d", status, http.StatusOK)
+			}
+			items, ok := obj["items"].([]any)
+			if !ok {
+				t.Fatalf("GET /v1/containers?all=true: items is not a JSON array: %#v", obj["items"])
+			}
 
-	bystanderRow := findRowByID(t, items, bystander)
-	if protected, ok := bystanderRow["protected"]; !ok || protected != true {
-		t.Errorf("bystander row (the DEVMON_SELF_CONTAINER_ID target): protected = %v, want true — the override was not honoured", protected)
-	}
+			bystanderRow := findRowByID(t, items, bystander)
+			if protected, ok := bystanderRow["protected"]; !ok || protected != true {
+				t.Errorf("bystander row (the DEVMON_SELF_CONTAINER %s-form target): protected = %v, want true — the override was not honoured", form, protected)
+			}
 
-	agentRow := findRowByID(t, items, c.ID)
-	if protected, ok := agentRow["protected"]; !ok || protected != false {
-		t.Errorf("agent's own real row: protected = %v, want false — "+
-			"the agent self-identified as its OWN container despite the override naming a different one", protected)
+			agentRow := findRowByID(t, items, c.ID)
+			if protected, ok := agentRow["protected"]; !ok || protected != false {
+				t.Errorf("agent's own real row: protected = %v, want false — "+
+					"the agent self-identified as its OWN container despite the override naming a different one", protected)
+			}
+		})
 	}
 }
 
 // TestUnresolvableSelfIDFailsClosed is the case where the agent starts
 // successfully and DEGRADES, rather than refusing to start: a well-formed
-// but non-existent DEVMON_SELF_CONTAINER_ID is not a configuration error
+// but non-existent DEVMON_SELF_CONTAINER is not a configuration error
 // (internal/config/config.go validates only the override's SHAPE — the
 // Engine is not reachable yet at config-parse time). Per
 // internal/dockerx/lifecycle.go's resolveTarget, once the agent ends up
@@ -193,7 +202,7 @@ func TestUnresolvableSelfIDFallsBackToDetection(t *testing.T) {
 	c := harness.RunAgentContainer(t, e, harness.ContainerAgentOptions{
 		Image:      selfIDImageTag,
 		PolicyMode: "full",
-		Env:        map[string]string{"DEVMON_SELF_CONTAINER_ID": unresolvableSelfID},
+		Env:        map[string]string{"DEVMON_SELF_CONTAINER": unresolvableSelfID},
 	})
 	device := harness.PairDeviceInContainer(t, c, "unresolvable-override-device")
 
@@ -249,7 +258,7 @@ func TestUnresolvableSelfIDFallsBackToDetection(t *testing.T) {
 	// must log both the warning naming it as discarded and the override
 	// value itself, or an operator who pins the wrong container ID still
 	// gets no signal that their explicit configuration was thrown away.
-	if !strings.Contains(logText, "discarding DEVMON_SELF_CONTAINER_ID") {
+	if !strings.Contains(logText, "discarding DEVMON_SELF_CONTAINER") {
 		t.Errorf("agent.log does not contain the discard warning for the unrecognised override")
 	}
 	if !strings.Contains(logText, unresolvableSelfID) {

--- a/internal/selfid/selfid.go
+++ b/internal/selfid/selfid.go
@@ -39,7 +39,7 @@ type Result struct {
 	// Candidates are container-ID candidates in priority order, longest and
 	// most trustworthy first. May be empty even when Containerized is true.
 	Candidates []string
-	// Override is the operator-supplied DEVMON_SELF_CONTAINER_ID, or "" when
+	// Override is the operator-supplied DEVMON_SELF_CONTAINER, or "" when
 	// none was set. Carried alongside Candidates (rather than requiring the
 	// caller to remember it separately) so internal/dockerx's confirmSelf can
 	// tell whether a skipped candidate was the operator's explicit choice and
@@ -49,7 +49,7 @@ type Result struct {
 
 // Detect gathers candidates. root is the filesystem root to read under ("/"
 // in production, a temp dir in tests). override, when non-empty, is the
-// operator's DEVMON_SELF_CONTAINER_ID and always sorts first. getenv is a
+// operator's DEVMON_SELF_CONTAINER and always sorts first. getenv is a
 // parameter rather than a call to os.Getenv so callers can inject a fake
 // environment in tests without t.Setenv, which forbids t.Parallel.
 func Detect(root, override string, getenv func(string) string) Result {


### PR DESCRIPTION
## Summary

`DEVMON_SELF_CONTAINER_ID` accepted only a hex container ID, which made it unusable in the one situation it was written for. Adding the variable to a compose file changes the container's spec, so the next `docker compose up -d` recreates the container and mints a new ID — the value copied out of `docker ps` is stale before it is ever read, and repeating the cycle never converges.

This replaces it with `DEVMON_SELF_CONTAINER`, which takes a container **name** or an ID. A name (`container_name:` / `--name`) survives recreation, so it is set once and stays true. `ContainerInspect` already resolves "name or ID" through one lookup, so a single knob covers both.

Clean break — no alias, no deprecation path. The released 0.1.x line has no users of this knob.

## Changes

- **`internal/config`** — `DEVMON_SELF_CONTAINER` replaces `DEVMON_SELF_CONTAINER_ID`; `Config.SelfContainer` replaces `Config.SelfContainerID`. The two hex patterns collapse into Docker's container-name grammar (`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`), which admits 12- and 64-hex IDs as a byproduct. The value is no longer case-normalized: Docker names are case-sensitive.
- **`internal/dockerx`, `internal/selfid`** — operator-facing log messages and doc comments name the new variable; the discarded-override warning's attribute is now `self_container` rather than `container_id`, since the value may be a name.
- **`install.sh`, `compose.example.yaml`** — both pin `container_name: devmon-agent` and set `DEVMON_SELF_CONTAINER` to it, so self-exclusion resolves deterministically instead of depending on whether `/proc/self/mountinfo` happens to expose an ID on that host.
- **`README.md`, `docs/openapi.yaml`** — document the name-first form and why an ID is the wrong value to put there.

Behaviour that did **not** change: the override is still one candidate rather than the sole one, a malformed value is still a startup error (exit 2), and a well-formed value the Engine does not recognise is still discarded with a WARN before falling back to the filesystem candidates.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags e2e ./internal/e2e/...`
- [x] `go test ./internal/... -race` — green, coverage 84.9% (floor 80%)
- [x] `golangci-lint run ./...` — 0 issues; `gosec ./...` — 0 issues
- [x] `gofmt -l` clean on touched files
- [x] `sh -n install.sh`
- [ ] `shellcheck -s sh install.sh` — not installed locally, left to CI
- [x] Config table tests cover the name form, both hex ID forms, and rejection of leading `-`, leading `.`, embedded `/`, embedded space, and a too-short value
- [x] `internal/e2e/incontainer` self-ID contract now exercises the override in both name and full-ID form (compiles under `-tags e2e`; not run locally — needs a Docker host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)