### PR TITLE
docs: explain how to reach the agent from behind CGNAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,37 @@ And passthrough still hides the caller's address: the guarded tier is unaffected
 because it keys on the device, but the status and pair tiers will see only the
 forwarding host, so size those limits for the whole fleet rather than one phone.
 
+### Behind CGNAT, with no port to forward
+
+A home server on a carrier-grade-NAT connection has no inbound port and no
+stable address. That sounds like it rules the agent out, but it does not: what
+CGNAT blocks is an *incoming* connection, and the first option above never needs
+one. On an overlay network both ends dial outward to meet each other, so no port
+is forwarded, no dynamic-DNS record is needed, and the agent is never on the
+public internet at all.
+
+- **An overlay network — Tailscale, NetBird, ZeroTier.** Nothing else to run.
+  Install it on the server and on the phone, then point `DEVMON_PUBLIC_ADDR` at
+  the overlay address the device dials. Do not use a feature that fronts the
+  agent with its own HTTPS listener — `tailscale serve` and `funnel` terminate
+  TLS, which is the case above.
+- **Your own hub on a cheap VPS**, if you would rather not depend on a hosted
+  coordination service: WireGuard, Headscale, or a raw TCP tunnel such as
+  `ssh -R`, `frp`, or `rathole`. Both ends dial the VPS. A TCP tunnel does put
+  the agent back on the public internet, so firewall it, and remember the two
+  pre-authentication rate-limit tiers will see one address for every caller.
+- **IPv6**, which is often overlooked: CGNAT is usually IPv4-only, and the same
+  connection may carry a routable IPv6 prefix. Then no tunnel is needed, only a
+  firewall rule and a DDNS AAAA record. Keep one of the options above as well,
+  because the phone will sometimes be on an IPv4-only network.
+- **Ask the ISP.** Many will hand out a public address on request or for a small
+  fee. The fewest moving parts of anything here.
+
+`DEVMON_PUBLIC_ADDR` accepts a list, so a home server can carry both its LAN
+address and its overlay name and be reachable either way. Adding an address
+later is safe: the server certificate is re-issued to cover it and the CA is
+untouched, so no device has to pair again.
+
 Putting the agent behind an HTTPS proxy would mean replacing its authentication
 model, not configuring it. That is a deliberate trade: request signing survives
 a proxy, but a terminating proxy also reads every container name and log line in


### PR DESCRIPTION
## Summary

"Reaching it from outside" lists the transports that preserve end-to-end TLS, but it assumes the reader can publish a port. A self-hoster on carrier-grade NAT has no inbound port and no stable address, and can reasonably read the section as "this is not for me".

Adds a short **Behind CGNAT, with no port to forward** subsection stating the opposite: CGNAT blocks *incoming* connections, and the overlay-network option already listed never needs one — both ends dial outward, so nothing is forwarded and no DDNS record is required.

## What it covers

Four options with a one-line rationale each, deliberately without setup steps or compose snippets — the goal is to point people at the right shape, not to become a Tailscale tutorial:

- an overlay network (Tailscale, NetBird, ZeroTier)
- your own hub on a cheap VPS, for operators who would rather not depend on a hosted coordination service
- IPv6, which the same connection may already carry since CGNAT is usually IPv4-only
- asking the ISP for a public address

Two caveats did make the cut, because both fail quietly rather than loudly: `tailscale serve` / `funnel` terminate TLS and land you in the unsupported case described directly above, and a raw TCP tunnel leaves both pre-authentication rate-limit tiers seeing one address for every caller. Closes with the note that `DEVMON_PUBLIC_ADDR` takes a list and that adding an address later re-issues the leaf without touching the CA, so no device has to pair again.

## Test plan

- [x] Documentation only — no code, config, or build files touched
- [x] Section renders correctly and its internal links resolve
- [ ] `test` on CI, which is the whole bar for a PR into `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)