### PR TITLE
fix: wait for the rotator goroutine before the test temp dir is removed

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -209,10 +209,22 @@ func TestRotatorRotatesOnTick(t *testing.T) {
 
 	r := NewRotator(s.lj, 10*time.Millisecond, s.Logger)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	// The test returns as soon as it sees one rotated file, but the ticker
+	// keeps firing until it is told to stop. Cancelling is not enough: a tick
+	// already inside rotateOnce would create a file while t.TempDir is removing
+	// the directory, which fails the run with "directory not empty". Registered
+	// after the cleanups above so LIFO waits for the goroutine before either.
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
 	// Act
-	go func() { _ = r.Run(ctx) }()
+	go func() {
+		defer close(done)
+		_ = r.Run(ctx)
+	}()
 
 	// Assert
 	deadline := time.Now().Add(2 * time.Second)


### PR DESCRIPTION
## Summary

`TestRotatorRotatesOnTick` fails intermittently on `dev`. It surfaced on #31, a README-only PR, which is how a flake announces itself:

```
--- FAIL: TestRotatorRotatesOnTick (0.02s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat /tmp/TestRotatorRotatesOnTick851895725/001/logs: directory not empty
```

The test starts the rotator on a 10ms tick, polls until it sees one rotated file, and returns the moment it finds one — while the ticker is still firing and nothing waits for `Run` to exit. `defer cancel()` only signals: a tick already inside `rotateOnce` can create a file while `t.TempDir`'s `RemoveAll` is walking the directory. Whether CI was green was a race.

## Fix

Test-only. The goroutine closes a `done` channel, and a `t.Cleanup` cancels and blocks on it. That cleanup is registered after the two already in place, so LIFO drains the goroutine before the sink is closed and before the temp directory is removed.

`Rotator.Run` was checked and is not at fault: its select loop returns on `ctx.Done()` without a further tick, so it performs no writes after it returns. No production code changed, and the assertion is untouched — the test still proves the *ticker* produces a rotated file, which is what age-based retention depends on.

## Test plan

- [x] `go test ./internal/logging/ -race -run TestRotator -count=200` — green (the fix is against a race; one green run would prove nothing)
- [x] `go test ./internal/logging/ -race -count=20` — green
- [x] `go test ./internal/... -race` — green, coverage 84.9% (floor 80%)
- [x] `gofmt -l internal/logging` clean, `go vet ./...`, `golangci-lint`, `gosec` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)