### PR TITLE
fix: disable log compression in the tests that rotate

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -150,6 +150,13 @@ func TestRotateProducesBackup(t *testing.T) {
 		t.Fatalf("NewSink() unexpected error: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
+	// lumberjack starts a background "mill" goroutine on the first rotation to
+	// compress rotated files, and Close never stops or waits for it. With
+	// compression on, that goroutine can still be writing a .gz into the logs
+	// dir after this test returns and t.TempDir removes it, which fails
+	// cleanup with "directory not empty". Compression itself isn't the
+	// behaviour under test here, so turn it off.
+	s.lj.Compress = false
 	s.Logger.Info("line before rotation")
 
 	// Act
@@ -205,6 +212,14 @@ func TestRotatorRotatesOnTick(t *testing.T) {
 		t.Fatalf("NewSink() unexpected error: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
+	// lumberjack starts a background "mill" goroutine on the first rotation to
+	// compress rotated files, and Close never stops or waits for it. With
+	// compression on and a 10ms tick, that goroutine can still be writing a
+	// .gz into the logs dir after t.TempDir starts removing it, which fails
+	// cleanup with "directory not empty". Compression itself isn't the
+	// behaviour under test here (the ticker driving rotation is), so turn it
+	// off.
+	s.lj.Compress = false
 	s.Logger.Info("seed line so there is something to rotate")
 
 	r := NewRotator(s.lj, 10*time.Millisecond, s.Logger)


### PR DESCRIPTION
## Summary

Follow-up to #32, which fixed one of two races in `TestRotatorRotatesOnTick`. CI kept failing with the identical error afterwards, because draining the rotator goroutine cannot drain the other writer.

```
--- FAIL: TestRotatorRotatesOnTick (0.02s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat /tmp/.../logs: directory not empty
```

`NewSink` configures lumberjack with `Compress: true`. In `lumberjack.v2@v2.2.1`, `rotate()` calls `mill()`, which starts a `millRun` goroutine behind a `sync.Once`; with compression on, `millRunOnce` calls `compressLogFile` and **creates a `.gz` in the logs directory**. `Logger.Close()` closes the current file and neither closes `millCh` nor waits for that goroutine, and the package exposes no way to wait for it. A 10ms tick queues plenty of files for it, so it was still writing while `t.TempDir` was removing the directory.

## Fix

Test-only. Both tests that trigger a real rotation set `s.lj.Compress = false` before rotating. With compression off the miller only ever removes files, never creates one, so it cannot collide with teardown.

- `TestRotatorRotatesOnTick` — the flaky test. Its assertion is unchanged: the *ticker*, not a manual `rotateOnce`, is still what must produce the rotated file.
- `TestRotateProducesBackup` — calls `rotateOnce()` against a sink with production settings, so it carries the identical exposure and was fixed alongside it.

Production `Compress: true` is untouched. Compression is lumberjack's behaviour, not a property either test exists to prove.

## Test plan

The bug survived one fix already, so a single green run proves nothing:

- [x] `go test ./internal/logging/ -race -run TestRotator -count=500` — green
- [x] `go test ./internal/logging/ -race -count=200` — green
- [x] `go test ./internal/... -race -count=5` — green
- [x] `go test ./internal/... -race -coverprofile=coverage.out` — 84.9% (floor 80%)
- [x] `gofmt -l internal/logging` clean, `go vet ./...`, `golangci-lint run ./...` 0 issues, `gosec ./...` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)