### PR TITLE
docs: keep the CGNAT section neutral about what the client runs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ is forwarded, no dynamic-DNS record is needed, and the agent is never on the
 public internet at all.
 
 - **An overlay network — Tailscale, NetBird, ZeroTier.** Nothing else to run.
-  Install it on the server and on the phone, then point `DEVMON_PUBLIC_ADDR` at
-  the overlay address the device dials. Do not use a feature that fronts the
+  Install it on the server and wherever the client runs, then point
+  `DEVMON_PUBLIC_ADDR` at the overlay address the client dials. Do not use a feature that fronts the
   agent with its own HTTPS listener — `tailscale serve` and `funnel` terminate
   TLS, which is the case above.
 - **Your own hub on a cheap VPS**, if you would rather not depend on a hosted
@@ -161,7 +161,7 @@ public internet at all.
 - **IPv6**, which is often overlooked: CGNAT is usually IPv4-only, and the same
   connection may carry a routable IPv6 prefix. Then no tunnel is needed, only a
   firewall rule and a DDNS AAAA record. Keep one of the options above as well,
-  because the phone will sometimes be on an IPv4-only network.
+  because the client will sometimes be on an IPv4-only network.
 - **Ask the ISP.** Many will hand out a public address on request or for a small
   fee. The fewest moving parts of anything here.
 


### PR DESCRIPTION
## Summary

The "Behind CGNAT" section was written from a worked example involving a phone, and it kept the word — "install it on the server and on the phone", "the phone will sometimes be on an IPv4-only network". That reads as a statement that the agent is for a mobile app. Nothing in the protocol is: any client that terminates TLS with a paired certificate works, whether that is a mobile app, a web backend, or something an operator wrote themselves.

Both occurrences now say "client", matching the vocabulary the rest of the API surface already uses.

## Note

Eight other pre-existing uses of "phone" remain elsewhere in the README (rate limiting, pairing, the read-operations discussion). Most are concrete illustrations rather than claims about the supported client, so they are left alone here rather than swept up in a docs PR about the CGNAT section — worth a separate pass if the same neutrality is wanted throughout.

## Test plan

- [x] Documentation only — no code, config, or build files touched
- [ ] `test` on CI, which is the whole bar for a PR into `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)