### PR TITLE
chore: prepare the 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,75 @@ changes nothing about the agent's behaviour, but this is an open repository and
 a contributor reading the history should not have to reconstruct why the build
 moved.
 
+## [0.2.0] - 2026-08-12
+
+The agent can now identify its own container by **name**, which is the first
+form of self-identification that survives a `docker compose up -d`. The knob
+that carries it was renamed in the process, and the old name is not read — see
+the breaking change below before upgrading.
+
+### Changed
+
+- **BREAKING: `DEVMON_SELF_CONTAINER_ID` is now `DEVMON_SELF_CONTAINER`, and it
+  accepts a container name.** The old variable name is no longer read and no
+  longer produces an error; an installation that still sets it is running as
+  though nothing were set at all. That is only fatal where automatic detection
+  fails — the exact case the variable existed for — and it fails the way it
+  always has: an ERROR at startup and 503 on the five lifecycle routes, with
+  reads, logs, pairing and status unaffected.
+
+  The rename is what the widened value forced. The variable took 12- or
+  64-character lowercase hex and nothing else, and an ID is the one form that
+  cannot be set correctly: adding the variable to a compose file changes the
+  container's spec, so the next `docker compose up -d` recreates the container
+  and mints a new ID, and the value just written is stale before it is first
+  read. Copying the new ID and repeating never converges. A name survives
+  recreation and is set once. Keeping `_ID` on a field whose right answer is a
+  name would have documented the trap rather than removed it.
+
+  To upgrade: rename the variable, and give it the container's name.
+
+  ```yaml
+  services:
+    devmon-agent:
+      container_name: devmon-agent
+      environment:
+        DEVMON_SELF_CONTAINER: devmon-agent   # was DEVMON_SELF_CONTAINER_ID: 3f2a91c4e5b8
+  ```
+
+  A value that names nothing the Engine recognises is now discarded with a WARN
+  and the agent falls back to its filesystem candidates, rather than being
+  carried forward as a certainty. A malformed value is still a startup error
+  (exit 2). ([#30](https://github.com/scnplt/devmon-agent/pull/30))
+
+- **`install.sh` and `compose.example.yaml` pin `container_name` and set
+  `DEVMON_SELF_CONTAINER`.** Self-identification was previously left to
+  detection on a fresh install, which is correct on most hosts and silently
+  wrong on the rest. Naming it makes a new installation deterministic instead
+  of merely likely.
+
+### Added
+
+- Documentation for reaching the agent from a host behind CGNAT — an overlay
+  network, a self-hosted hub on a VPS, IPv6, or asking the ISP. A
+  carrier-grade-NAT connection has no inbound port, which reads as
+  disqualifying, but the recommended answer never needs one: on an overlay both
+  ends dial outward. The section also states which shortcut does not work —
+  `tailscale serve` and `funnel` terminate TLS, and terminating TLS is the one
+  thing the agent's authentication cannot survive.
+  ([#31](https://github.com/scnplt/devmon-agent/pull/31),
+  [#34](https://github.com/scnplt/devmon-agent/pull/34))
+
+### Internal
+
+- Two flaky log-rotator tests fixed. One removed its temp directory while the
+  rotator goroutine was still writing under it; the other left compression on,
+  so a rotated file was rewritten asynchronously after the assertion had already
+  read the directory. Both failed only under CI timing, which is the kind of
+  failure that teaches a team to re-run the job instead of reading it.
+  ([#32](https://github.com/scnplt/devmon-agent/pull/32),
+  [#33](https://github.com/scnplt/devmon-agent/pull/33))
+
 ## [0.1.2] - 2026-08-11
 
 The agent's behaviour is unchanged from 0.1.1 — nothing in `cmd/` or
@@ -137,6 +206,7 @@ First public release — the full surface.
   writing a `compose.yaml`, and waiting for the agent to answer.
 - **Multi-arch image.** `linux/amd64` and `linux/arm64`.
 
+[0.2.0]: https://github.com/scnplt/devmon-agent/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/scnplt/devmon-agent/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/scnplt/devmon-agent/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/scnplt/devmon-agent/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.1.2 — the full surface.** The agent is its own certificate
+**Status: 0.2.0 — the full surface.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -68,7 +68,7 @@ docker run -d --name devmon-agent \
   --group-add "$(stat -c '%g' /var/run/docker.sock)" \
   -p 8443:8443 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.1.2
+  ghcr.io/scnplt/devmon-agent:0.2.0
 ```
 
 See `compose.example.yaml` for the equivalent Compose file and a reference for
@@ -78,7 +78,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.1.2","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.2.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 
@@ -283,6 +283,13 @@ written is stale before it is ever read. Copying the new ID and repeating never
 converges. A name survives recreation, so it is set once. `install.sh` and
 `compose.example.yaml` both pin `container_name` and set this variable for
 exactly this reason.
+
+**Upgrading from 0.1.x:** this variable was called `DEVMON_SELF_CONTAINER_ID`
+before 0.2.0 and the old name is no longer read. An installation that set it
+keeps working only as long as the agent detects its own container unaided; where
+it cannot, lifecycle goes back to answering 503 with the ERROR above. Rename the
+variable — and take the opportunity to give it the container's name rather than
+the ID that was there.
 
 A malformed value is a startup configuration error (exit 2), not a warning: this
 is the documented fix for the one case where lifecycle is unavailable, so a typo

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -23,7 +23,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.1.2
+    image: ghcr.io/scnplt/devmon-agent:0.2.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.1.2
+  version: 0.2.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -121,7 +121,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.1.2
+                    agent_version: 0.2.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -855,7 +855,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.1.2"]
+          examples: ["0.2.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.1.2'
+IMAGE_TAG='0.2.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
Version bump and changelog for the 0.2.0 release. No behaviour changes — every
line here is documentation or a version string. Merging this makes `dev`
releasable; the `dev` -> `main` PR follows.

## Why 0.2.0 and not 0.1.3

`DEVMON_SELF_CONTAINER_ID` was renamed to `DEVMON_SELF_CONTAINER` in #30 and the
old name is not read. A host that set it is now running as though nothing were
set: harmless where the agent detects its own container unaided, and a return to
`503` on the five lifecycle routes where it cannot — which is the exact case the
variable existed for. That is a breaking change for operators, so under semver's
pre-1.0 rules it takes the minor bump.

## What changed

- `CHANGELOG.md` — 0.2.0 entry. Leads with the breaking rename, states what
  actually breaks and what does not, and carries the compose snippet to migrate.
- `README.md` — status line, the `docker run` and `/v1/status` examples, and a
  new **Upgrading from 0.1.x** note in the self-identification section.
- `install.sh` — `IMAGE_TAG`.
- `compose.example.yaml` — image tag.
- `docs/openapi.yaml` — `info.version` and both `agent_version` examples.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./internal/... -race` — all packages pass, total coverage 84.9%
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gosec ./...` — clean
- [ ] `shellcheck -s sh install.sh` — not installed locally; CI covers it (the
      only `install.sh` change is a quoted constant)
