### PR TITLE
fix: make lint and e2e-lint fail on gofmt and golangci-lint findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,23 @@ fmt:
 	gofmt -l -w .
 
 # golangci-lint is preferred. When it is not installed, `go vet` is the minimum bar.
+# Both steps need an explicit conditional: `gofmt -l` exits 0 even when it lists
+# files, so the output is what fails (the same guard ci.yml uses), and
+# `A && B || C` would print the not-installed message on B's failure rather
+# than A's, swallowing every golangci-lint finding.
 lint:
-	gofmt -l .
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "these files are not gofmt-clean:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 	go vet ./...
-	@command -v golangci-lint >/dev/null 2>&1 \
-		&& golangci-lint run ./... \
-		|| echo "golangci-lint not installed — go vet was the only lint run"
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	else \
+		echo "golangci-lint not installed — go vet was the only lint run"; \
+	fi
 
 sec:
 	gosec ./...
@@ -124,9 +135,11 @@ e2e-clean:
 
 e2e-lint:
 	go vet -tags e2e ./...
-	@command -v golangci-lint >/dev/null 2>&1 \
-		&& golangci-lint run --build-tags e2e $(E2E_PKGS) \
-		|| echo "golangci-lint not installed — go vet -tags e2e was the only lint run"
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run --build-tags e2e $(E2E_PKGS); \
+	else \
+		echo "golangci-lint not installed — go vet -tags e2e was the only lint run"; \
+	fi
 
 image:
 	docker build \


### PR DESCRIPTION
Closes #39.

## What

`make lint` and `make e2e-lint` used `command -v golangci-lint && golangci-lint run || echo "not installed"`. In shell that `||` fires whenever the **middle** command fails, so a golangci-lint run that found issues printed "golangci-lint not installed — go vet was the only lint run" and exited 0. The message stated the opposite of what happened, and the local gate went green on real findings.

`gofmt -l .` had the related problem: it exits 0 even when it lists files, so unformatted code never failed `make lint` either. CI already guards this explicitly (`ci.yml`); the Makefile now uses the same semantics.

## Changes

- `lint`: gofmt step now captures the listing and exits 1 when non-empty; golangci-lint step is an explicit `if/else`.
- `e2e-lint`: same `if/else` rewrite.
- Comment above `lint` records why both steps need explicit handling.

CI is unaffected (it uses `golangci/golangci-lint-action`).

## Test plan

Verified locally:

- [x] failing golangci-lint (stub on PATH) → `make lint` exits non-zero
- [x] failing golangci-lint → `make e2e-lint` exits non-zero
- [x] unformatted file → `make lint` prints the file list and exits non-zero
- [x] `go vet` finding → `make lint` exits non-zero
- [x] golangci-lint absent from PATH → fallback message, exit 0
- [x] clean tree → `make lint`, `make e2e-lint` exit 0