### PR TITLE
chore: add .dockerignore so the build context excludes runtime state

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Keep this list in sync with .gitignore: gitignored is not dockerignored, and
+# `COPY . .` in the Dockerfile would otherwise sweep an operator's runtime state
+# — CA private keys included — into the local build context and layer cache.
+
+# Version control and agent/editor metadata.
+.git/
+.gitattributes
+.gitignore
+.github/
+.claude/
+
+# Build output and local test artifacts.
+bin/
+coverage.out
+
+# Runtime state — never enters an image. Mirrors .gitignore; these are produced
+# on the operator's host under $DEVMON_STATE_DIR and contain device records and
+# private key material.
+*.db
+*.db-wal
+*.db-shm
+*.key
+*.crt
+.env
+
+# Docs and policy files: not compiled, and every edit would bust the build cache.
+*.md
+docs/
+LICENSE
+compose.example.yaml
+install.sh
+Dockerfile
+.dockerignore
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /bin/
 
+# Keep the runtime-state patterns below in sync with .dockerignore: gitignored
+# is not dockerignored, and the Dockerfile copies the whole tree.
+
 # Runtime state — never commit. These are produced on the operator's host under
 # $DEVMON_STATE_DIR and contain device records and private key material.
 *.db


### PR DESCRIPTION
Closes #52.

## What

`Dockerfile:8` is `COPY . .` and there was no `.dockerignore`, so the build context was the entire working tree: `.git/`, `bin/devmon-agent`, `coverage.out`, and every runtime-state pattern `.gitignore` protects (`*.key`, `*.crt`, `*.db`, `.env`). Gitignored is not dockerignored — an operator building on a host that also runs the agent sweeps their CA private key into the build context and layer cache. Unrelated file edits also busted the cache on every build.

The shipped image was always clean (only the binary leaves the build stage); this closes the local build-cache exposure.

## Changes

- New `.dockerignore`: VCS/agent metadata, build output, the runtime-state patterns mirrored from `.gitignore`, and non-build files (docs, installer, compose sample).
- `.gitignore`: comment pointing at `.dockerignore` so the two secret-pattern lists stay in sync.

## Test plan

- [x] `docker build` succeeds unchanged
- [x] with a planted `test.key` in the repo root, a probe image copying the context shows the context is exactly `cmd/ internal/ go.mod go.sum` — no `test.key`, no `.git`
- [x] build context transfer drops to ~988 kB