### PR TITLE
docs: make the SECURITY.md supported-versions table drift-proof

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,11 +11,18 @@ management bug"; it is a host compromise. Reports are treated accordingly.
 
 | Version | Supported |
 |---|---|
-| 0.1.x | Yes |
-| < 0.1.0 | No — pre-release, never published |
+| Latest published minor version | Yes |
+| Any earlier version | No |
 
 Only the latest published minor version receives fixes. There is no long-term
 support branch.
+
+This table names no number on purpose: which minor is current changes on every
+release, and a hardcoded one silently tells readers the wrong thing between
+releases. The authoritative answer is the
+[latest release](https://github.com/scnplt/devmon-agent/releases/latest);
+`CHANGELOG.md` records what each one contained. Builds before 0.1.0 were
+pre-release and never published.
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Closes #47.

## What

`SECURITY.md` still listed `0.1.x | Yes` while the project ships 0.2.0 (`README.md`, `CHANGELOG.md`, `compose.example.yaml`, `docs/openapi.yaml`, tag `v0.2.0`). Combined with "Only the latest published minor version receives fixes", the policy of a host-root-equivalent daemon told readers a superseded minor was supported, and said nothing about the version they are actually running.

## Changes

Instead of bumping `0.1.x` to `0.2.x` — which goes stale again at 0.3.0 — the table now states the rule rather than a number:

| Version | Supported |
|---|---|
| Latest published minor version | Yes |
| Any earlier version | No |

with a paragraph pointing at the releases page as the authoritative answer and `CHANGELOG.md` for contents. No number to maintain, so no CI check or release-checklist step is needed to keep it honest.

## Test plan

- [x] Docs-only change; no code, build, or test surface touched
- [x] Links resolve (`/releases/latest`, `CHANGELOG.md`)