### PR TITLE
fix: stop zeroTimeToEmpty panicking on short timestamps

### DIFF
--- a/internal/dockerx/containers.go
+++ b/internal/dockerx/containers.go
@@ -5,6 +5,7 @@ package dockerx
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/moby/moby/api/types/container"
@@ -159,9 +160,11 @@ func toContainerDetail(r container.InspectResponse, selfID string) ContainerDeta
 
 // zeroTimeToEmpty returns "" for a container timestamp that Docker reports as
 // the zero RFC3339Nano value ("0001-01-01T00:00:00Z"), which means "never
-// started" or "never finished" rather than an actual timestamp.
+// started" or "never finished" rather than an actual timestamp. A prefix
+// check is used instead of a fixed-length slice so short strings (which a
+// misbehaving Engine, proxy, or fake can return) never panic.
 func zeroTimeToEmpty(ts string) string {
-	if ts == "" || ts[:4] == "0001" {
+	if ts == "" || strings.HasPrefix(ts, "0001") {
 		return ""
 	}
 	return ts

--- a/internal/dockerx/containers_test.go
+++ b/internal/dockerx/containers_test.go
@@ -471,3 +471,38 @@ func TestListContainersTruncation(t *testing.T) {
 		})
 	}
 }
+
+// TestZeroTimeToEmpty covers short inputs (length 1-3) that must not panic
+// when sliced, alongside the zero-time marker and a real timestamp. An
+// Engine (or a proxy/fake in front of one) that returns a short string for
+// State.StartedAt or State.FinishedAt must not crash the request.
+func TestZeroTimeToEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ts   string
+		want string
+	}{
+		{name: "empty string", ts: "", want: ""},
+		{name: "single char, shorter than zero-time prefix", ts: "0", want: "0"},
+		{name: "three chars, shorter than zero-time prefix", ts: "000", want: "000"},
+		{name: "exact zero-time prefix", ts: "0001", want: ""},
+		{name: "full zero-time value", ts: "0001-01-01T00:00:00Z", want: ""},
+		{name: "real timestamp", ts: "2026-08-19T10:15:30.123456789Z", want: "2026-08-19T10:15:30.123456789Z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := zeroTimeToEmpty(tt.ts)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("zeroTimeToEmpty(%q) = %q, want %q", tt.ts, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #43.

## What

`internal/dockerx/containers.go`'s `zeroTimeToEmpty` guarded the empty string but then did `ts[:4] == "0001"`, which slices out of range for any 1-3 character input. An Engine — or a proxy or fake in front of one — returning e.g. `"0"` for `State.StartedAt` or `State.FinishedAt` panicked; `withRecovery` caught it and the container-detail response became a 500.

## Changes

- `zeroTimeToEmpty` uses `strings.HasPrefix(ts, "0001")` instead of the fixed-length slice; doc comment records why.
- `TestZeroTimeToEmpty`: table-driven, covering `""`, `"0"`, `"000"`, `"0001"`, the full zero-time value, and a real RFC3339Nano timestamp.

Behavior is otherwise unchanged: the zero-time value still maps to `""`, real timestamps still pass through, and `"0"`/`"000"` are not the zero-time marker so they pass through too.

## Test plan

- [x] new test fails against the old implementation with `panic: slice bounds out of range [:4] with length 1`, passes after the fix
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `golangci-lint run ./...` → 0 issues
- [x] `gosec ./...` → 0 issues
- [x] `go test ./internal/... ./cmd/... -race` → all packages ok
- [x] coverage 91.1% total (floor 90%), `dockerx` 96.0%