### PR TITLE
fix: run the pairing rollback on a context detached from the request

### DIFF
--- a/internal/httpapi/pair.go
+++ b/internal/httpapi/pair.go
@@ -42,6 +42,13 @@ const (
 
 	// pemTypeCertificateRequest is the PEM block type of a PKCS#10 CSR.
 	pemTypeCertificateRequest = "CERTIFICATE REQUEST"
+
+	// deleteOrphanedDeviceTimeout bounds the detached rollback DELETE issued
+	// by deleteOrphanedDevice. The call deliberately runs on a context
+	// independent of the request (see its doc comment), so this timeout — not
+	// the request's own deadline — is what stops a wedged database from
+	// hanging the handler goroutine forever.
+	deleteOrphanedDeviceTimeout = 5 * time.Second
 )
 
 type pairRequest struct {
@@ -122,32 +129,44 @@ func decodeCSRPEM(csrPEM string) ([]byte, bool) {
 // never actually spent, so the deletion is bookkeeping rather than a
 // rollback of a granted credential, but it is identical either way from the
 // caller's point of view: no orphan device row survives.
+//
+// The rollback (deleteOrphanedDevice) never uses ctx. A client that aborts
+// the connection right after CreateDevice commits makes every remaining call
+// in this function fail on a context that is already dying — including the
+// DELETE meant to undo the orphan the abort just created, which would
+// otherwise leave a permanent "pending" row behind on every such abort. The
+// rollback therefore runs on a context detached from the request, the same
+// reason withAudit writes on context.Background() (audit.go): the cleanup
+// must outlive the request that triggered it.
 func (s *Server) pairDevice(ctx context.Context, code string, csrDER []byte) (pairResponse, error) {
 	device, err := s.st.CreateDevice(ctx, pendingDeviceName)
 	if err != nil {
 		return pairResponse{}, fmt.Errorf("create device for pairing: %w", err)
 	}
+	if s.afterCreateHook != nil {
+		s.afterCreateHook()
+	}
 
 	deviceName, err := s.st.RedeemPairingCode(ctx, code, device.ID)
 	if err != nil {
-		s.deleteOrphanedDevice(ctx, device.ID)
+		s.deleteOrphanedDevice(device.ID)
 		return pairResponse{}, fmt.Errorf("redeem pairing code: %w", err)
 	}
 
 	if err := s.st.RenameDevice(ctx, device.ID, deviceName); err != nil {
-		s.deleteOrphanedDevice(ctx, device.ID)
+		s.deleteOrphanedDevice(device.ID)
 		return pairResponse{}, fmt.Errorf("rename paired device: %w", err)
 	}
 
 	now := time.Now()
 	certPEM, serial, notAfter, err := s.ca.IssueDeviceCert(csrDER, device.ID, now)
 	if err != nil {
-		s.deleteOrphanedDevice(ctx, device.ID)
+		s.deleteOrphanedDevice(device.ID)
 		return pairResponse{}, fmt.Errorf("issue device certificate: %w", err)
 	}
 
 	if err := s.st.RecordDeviceCert(ctx, device.ID, serial, now, notAfter); err != nil {
-		s.deleteOrphanedDevice(ctx, device.ID)
+		s.deleteOrphanedDevice(device.ID)
 		return pairResponse{}, fmt.Errorf("record device certificate: %w", err)
 	}
 
@@ -162,7 +181,14 @@ func (s *Server) pairDevice(ctx context.Context, code string, csrDER []byte) (pa
 // deleteOrphanedDevice removes a device row left behind by a failed pairing
 // attempt. The original failure is logged by the caller; this logs only a
 // second failure, if the cleanup itself does not succeed.
-func (s *Server) deleteOrphanedDevice(ctx context.Context, deviceID string) {
+//
+// It takes no context: it always runs detached from the request (see the
+// pairDevice doc comment), bounded by deleteOrphanedDeviceTimeout instead of
+// whatever deadline the request happened to carry.
+func (s *Server) deleteOrphanedDevice(deviceID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), deleteOrphanedDeviceTimeout)
+	defer cancel()
+
 	if err := s.st.DeleteDevice(ctx, deviceID); err != nil {
 		s.log.Error("delete orphaned device after failed pairing",
 			slog.String("device_id", deviceID),

--- a/internal/httpapi/pair_test.go
+++ b/internal/httpapi/pair_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -272,11 +273,61 @@ func TestDeleteOrphanedDeviceLogsSecondFailure(t *testing.T) {
 	}
 
 	// Act — must not panic despite the closed store.
-	s.deleteOrphanedDevice(context.Background(), "orphan-id")
+	s.deleteOrphanedDevice("orphan-id")
 
 	// Assert
 	if !bodyContains(buf.String(), "delete orphaned device after failed pairing") {
 		t.Errorf("log = %q, want it to mention the failed cleanup", buf.String())
+	}
+}
+
+// TestPairDeviceRollbackSurvivesCanceledContext reproduces GH-40: a client
+// that aborts the connection right after CreateDevice commits must not leave
+// a "pending" device row behind, even though the request context it handed
+// pairDevice is already dead by the time the rollback runs.
+//
+// afterCreateHook lets this test land the cancellation at the exact
+// interleaving point a real disconnect would, deterministically and on the
+// same goroutine — racing the SQL layer with a sleep cannot guarantee
+// RedeemPairingCode observes a canceled context instead of simply winning the
+// race and succeeding. The hook lives on this test's own Server instance, so
+// it carries no risk to any other, parallel test.
+func TestPairDeviceRollbackSurvivesCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, _ := testServerForPairing(t)
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	csrDER, ok := decodeCSRPEM(generateCSRPEM(t, "irrelevant"))
+	if !ok {
+		t.Fatal("decodeCSRPEM() rejected a well-formed CSR")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.afterCreateHook = cancel
+
+	// Act — CreateDevice runs on a live context and succeeds; the hook then
+	// cancels ctx before RedeemPairingCode, which pairDevice calls next with
+	// the very same ctx, ever runs.
+	_, err = s.pairDevice(ctx, code, csrDER)
+
+	// Assert
+	if err == nil {
+		t.Fatal("pairDevice() error = nil, want a redeem failure from the canceled context")
+	}
+	if errors.Is(err, state.ErrPairingCodeInvalid) {
+		t.Fatalf("pairDevice() error = %v, want a context failure, not ErrPairingCodeInvalid", err)
+	}
+
+	devices, err := st.ListDevices(context.Background())
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	if len(devices) != 0 {
+		t.Errorf("devices = %+v after a pairing attempt whose request context died mid-flight, want the orphaned row deleted", devices)
 	}
 }
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -84,6 +84,14 @@ type Server struct {
 	deviceLimit  rate.Limit
 
 	http *http.Server
+
+	// afterCreateHook is a test seam, nil in production. pairDevice calls it,
+	// if set, right after CreateDevice succeeds and before RedeemPairingCode
+	// runs, so a test can land a context cancellation at that exact
+	// interleaving point deterministically instead of racing the SQL layer
+	// with a sleep. It is per-instance rather than a package-level var so
+	// setting it on one test's Server can never race a different test's.
+	afterCreateHook func()
 }
 
 // NewServer wires the API. tlsCfg carries the server certificate, so the


### PR DESCRIPTION
Closes #40.

## What

`pairDevice` inserts the device row before validating the pairing code, and every failure path called `deleteOrphanedDevice(ctx, ...)` with the **request** context. A client that sends a pair request and aborts the connection right after the INSERT commits makes `RedeemPairingCode` fail with a context error (not `ErrPairingCodeInvalid`), and the rollback DELETE then failed on that same dead context.

Result: a permanent orphan `pending` device row plus an ERROR log line per attempt — unauthenticated and repeatable at the pair-tier rate limit (5/min/IP, 50/s global backstop). The orphan rows also surfaced as `active` in `device list`, polluting the operator's view of what is actually paired.

`withAudit` already solves this class of problem by writing on `context.Background()` so the record outlives the request; the rollback path did not.

## Changes

- `deleteOrphanedDevice` no longer takes a context. It builds its own from `context.Background()`, bounded by a new `deleteOrphanedDeviceTimeout` (5s) so a wedged database cannot hang the handler goroutine — the request's deadline is exactly what must not apply here.
- `pairDevice`'s doc comment now records *why* the rollback is detached, alongside the existing create-then-redeem ordering rationale. **The ordering is deliberately unchanged** — the issue notes it is documented behavior, and this fix targets only the rollback context.
- The error log still carries device ID and error only; nothing was widened.
- `Server.afterCreateHook`: an unexported, nil-in-production test seam called between `CreateDevice` and `RedeemPairingCode`. It is a field rather than a package-level var so one test's hook can never race another's, and the new test runs under `t.Parallel()`.

## Test plan

- [x] `TestPairDeviceRollbackSurvivesCanceledContext`: cancels the request context exactly between `CreateDevice` and `RedeemPairingCode`, asserts the attempt fails with a context error (not `ErrPairingCodeInvalid`) and that no device row survives. Fails against the old implementation with the orphan `pending` row still present.
- [x] existing pair tests still cover the ordinary failure paths (invalid code, rename, cert issue, record cert) — all still delete the row
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `golangci-lint run ./...` → 0 issues; `gosec ./...` → 0 issues
- [x] `go test ./internal/... ./cmd/... -race -count=1` → all packages ok
- [x] flake check: `./internal/httpapi/... -race -count=10` and `-run TestHandlePair -count=15` clean
- [x] coverage 91.1% total (floor 90%), `internal/httpapi` 97.5%