### PR TITLE
fix: enforce retention at startup and prune pairing codes

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -204,6 +204,138 @@ func TestRotatorRunStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+// TestRotatorRunRotatesOnStartupWhenFileHasContent is the regression test for
+// issue #42: a Rotator that has just started must not wait a full interval
+// (24h in production) before its first pass, or DEVMON_LOG_MAX_AGE_DAYS is
+// never enforced on a host that restarts more often than that.
+func TestRotatorRunRotatesOnStartupWhenFileHasContent(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a real log line means the current file is non-empty, the
+	// shape a freshly booted agent's log is in by the time Run starts (see
+	// serve() in cmd/devmon-agent: several lines are logged before runAll
+	// starts the rotator).
+	cfg := testConfig(t, 8)
+	s, err := NewSink(cfg)
+	if err != nil {
+		t.Fatalf("NewSink() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	s.lj.Compress = false
+	s.Logger.Info("line written before Run starts")
+
+	// Arrange — interval far longer than the test timeout proves any rotated
+	// backup found below cannot be explained by a tick firing.
+	r := NewRotator(s.lj, time.Hour, s.Logger)
+	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	done := make(chan struct{})
+
+	// Act
+	go func() {
+		defer close(done)
+		_ = r.Run(runCtx)
+	}()
+
+	// Assert
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, _ := filepath.Glob(filepath.Join(cfg.LogsDir(), "agent-*"))
+		if len(entries) > 0 {
+			cancel()
+			<-done
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	t.Error("Run() never produced a rotated backup within the test window; the startup pass regressed")
+}
+
+// TestRotatorRunSkipsStartupRotationOnEmptyOrMissingFile guards against the
+// behavior the issue warned about: a crash-looping agent must not spray
+// empty rotated backups on every boot. lumberjack's Rotate (via openNew)
+// stats the current filename and, when it does not exist, creates it fresh
+// with no rename at all — that path alone is harmless. The unsafe case is a
+// current file that exists but is empty: Rotate would still rename it aside,
+// producing a useless backup file. Verified by reading
+// gopkg.in/natefinch/lumberjack.v2's openNew: it renames whenever os.Stat on
+// the current filename succeeds, regardless of size. The startup pass must
+// therefore skip rotation itself whenever the current file is missing or
+// zero bytes, rather than relying on lumberjack.
+func TestRotatorRunSkipsStartupRotationOnEmptyOrMissingFile(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a fresh sink whose current log file has not been written to
+	// yet, so it does not exist on disk (lumberjack opens lazily on first
+	// Write).
+	cfg := testConfig(t, 8)
+	s, err := NewSink(cfg)
+	if err != nil {
+		t.Fatalf("NewSink() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	s.lj.Compress = false
+
+	r := NewRotator(s.lj, time.Hour, s.Logger)
+	runCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	done := make(chan struct{})
+
+	// Act
+	go func() {
+		defer close(done)
+		_ = r.Run(runCtx)
+	}()
+	<-runCtx.Done()
+	cancel()
+	<-done
+
+	// Assert — no current file and no backup: the startup pass must not have
+	// invented one.
+	entries, err := filepath.Glob(filepath.Join(cfg.LogsDir(), "agent*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("logs dir contains %v after a startup pass on an unwritten sink, want no files", entries)
+	}
+}
+
+// TestRotatorRunDoesNothingWhenContextAlreadyCancelled proves the startup
+// pass is skipped entirely when ctx is already dead on entry.
+func TestRotatorRunDoesNothingWhenContextAlreadyCancelled(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testConfig(t, 8)
+	s, err := NewSink(cfg)
+	if err != nil {
+		t.Fatalf("NewSink() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	s.lj.Compress = false
+	s.Logger.Info("line written before Run is ever called")
+
+	r := NewRotator(s.lj, time.Hour, s.Logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Act
+	err = r.Run(ctx)
+
+	// Assert
+	if err != context.Canceled {
+		t.Errorf("Run() = %v, want context.Canceled", err)
+	}
+	entries, globErr := filepath.Glob(filepath.Join(cfg.LogsDir(), "agent-*"))
+	if globErr != nil {
+		t.Fatalf("glob: %v", globErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("logs dir contains rotated backups %v, want none: Run() must not rotate when ctx is already cancelled", entries)
+	}
+}
+
 func TestRotatorRotatesOnTick(t *testing.T) {
 	t.Parallel()
 

--- a/internal/logging/rotator.go
+++ b/internal/logging/rotator.go
@@ -5,6 +5,7 @@ package logging
 import (
 	"context"
 	"log/slog"
+	"os"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -33,11 +34,38 @@ func NewRotator(lj *lumberjack.Logger, interval time.Duration, log *slog.Logger)
 	return &Rotator{lj: lj, interval: interval, log: log}
 }
 
-// Run rotates on each tick until ctx is cancelled, returning ctx.Err().
+// Run rotates once immediately and then on each tick until ctx is cancelled,
+// returning ctx.Err().
+//
+// The immediate pass matters for the same reason the Rotator exists at all:
+// lumberjack only applies MaxAge at the moment a rotation happens, and an
+// agent restarted more often than r.interval (a redeploy, a host reboot, a
+// crash loop) would otherwise never rotate — and so never enforce
+// DEVMON_LOG_MAX_AGE_DAYS — before being replaced again. It runs
+// synchronously before the loop rather than on a shortened first delay
+// because runAll (cmd/devmon-agent/main.go) already starts this alongside
+// the HTTP listener as an independent goroutine, so it overlaps with, and
+// never blocks, the agent coming up. If ctx is already cancelled on entry,
+// Run returns immediately without touching the log file.
+//
+// The startup pass calls startupRotate, not rotateOnce directly, to avoid
+// spraying empty rotated backups on a crash-looping agent: verified against
+// lumberjack v2.2.1's Logger.openNew, Rotate renames the current file aside
+// whenever os.Stat on it succeeds, with no check on size — a zero-byte
+// current file would still be renamed into a useless backup on every boot.
+// A missing current file is harmless on its own (openNew just creates it,
+// no rename), but skipping both missing and empty files here keeps a
+// crash-looping agent's logs directory from accumulating backups no tick
+// would ever have produced.
 //
 // A failed rotation is logged and the loop continues: losing retention is bad,
 // but taking the agent down over it is worse.
 func (r *Rotator) Run(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	r.startupRotate()
+
 	t := time.NewTicker(r.interval)
 	defer t.Stop()
 
@@ -49,6 +77,17 @@ func (r *Rotator) Run(ctx context.Context) error {
 			r.rotateOnce()
 		}
 	}
+}
+
+// startupRotate performs the startup rotation pass, skipping it when the
+// current log file is missing or empty — see the rationale in Run's doc
+// comment.
+func (r *Rotator) startupRotate() {
+	info, err := os.Stat(r.lj.Filename)
+	if err != nil || info.Size() == 0 {
+		return
+	}
+	r.rotateOnce()
 }
 
 func (r *Rotator) rotateOnce() {

--- a/internal/state/pruner.go
+++ b/internal/state/pruner.go
@@ -37,11 +37,24 @@ func NewPruner(store *Store, maxAge time.Duration, maxRows int, log *slog.Logger
 	}
 }
 
-// Run prunes on each tick until ctx is cancelled, returning ctx.Err().
+// Run prunes once immediately and then on each tick until ctx is cancelled,
+// returning ctx.Err().
 //
-// A failed prune is logged and the loop continues: an over-budget audit table is
-// a disk problem, not a reason to stop serving.
+// The immediate pass at the top matters because an agent restarted more often
+// than the interval — a redeploy, a host reboot, a crash loop — would
+// otherwise never enforce retention at all: a ticker that only fires after
+// defaultPruneInterval never gets there before the process is replaced again.
+// It runs synchronously before the loop rather than on a shortened first
+// delay because runAll (cmd/devmon-agent/main.go) already starts this
+// alongside the HTTP listener as an independent goroutine, so this pass
+// overlaps with — and never blocks — the agent coming up. If ctx is already
+// cancelled on entry, Run returns immediately without touching the store.
 func (p *Pruner) Run(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	p.pruneOnce(ctx)
+
 	t := time.NewTicker(p.interval)
 	defer t.Stop()
 
@@ -55,7 +68,17 @@ func (p *Pruner) Run(ctx context.Context) error {
 	}
 }
 
+// pruneOnce enforces both retention policies. Each prune is attempted
+// independently — a failure in one must not skip the other, since audit
+// retention and pairing-code retention protect different things (disk budget
+// vs. an unbounded pairing_codes table) and neither's failure implies
+// anything about the other's health.
 func (p *Pruner) pruneOnce(ctx context.Context) {
+	p.pruneAudit(ctx)
+	p.prunePairingCodes(ctx)
+}
+
+func (p *Pruner) pruneAudit(ctx context.Context) {
 	removed, err := p.store.PruneAudit(ctx, p.maxAge, p.maxRows)
 	if err != nil {
 		p.log.Error("audit prune failed", slog.Any("err", err))
@@ -63,5 +86,20 @@ func (p *Pruner) pruneOnce(ctx context.Context) {
 	}
 	if removed > 0 {
 		p.log.Info("audit rows pruned", slog.Int64("removed", removed))
+	}
+}
+
+// prunePairingCodes removes expired pairing codes so a minted code — used,
+// unused, or expired — does not stay in the table forever. Only the count is
+// ever logged: pairing codes themselves must never appear in logs, at any
+// level.
+func (p *Pruner) prunePairingCodes(ctx context.Context) {
+	removed, err := p.store.PrunePairingCodes(ctx)
+	if err != nil {
+		p.log.Error("pairing code prune failed", slog.Any("err", err))
+		return
+	}
+	if removed > 0 {
+		p.log.Info("pairing codes pruned", slog.Int64("removed", removed))
 	}
 }

--- a/internal/state/pruner_test.go
+++ b/internal/state/pruner_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package state
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newCapturingLoggerForTest mirrors the pattern used across this repo's other
+// packages: a text-handler logger writing into a buffer a test can inspect.
+func newCapturingLoggerForTest() (*slog.Logger, *strings.Builder) {
+	var buf strings.Builder
+	return slog.New(slog.NewTextHandler(&buf, nil)), &buf
+}
+
+// newCapturingPruner wires a Pruner to a fresh store and a logger a test can
+// inspect.
+func newCapturingPruner(t *testing.T, maxAge time.Duration, maxRows int) (*Pruner, *Store, *strings.Builder) {
+	t.Helper()
+	s := openStore(t, tempDBPath(t))
+	log, buf := newCapturingLoggerForTest()
+	return NewPruner(s, maxAge, maxRows, log), s, buf
+}
+
+// seedExpiredPairingCode mints a pairing code for deviceName and immediately
+// expires it, since there is no way to observe expiry through the public API
+// alone within a fast test.
+func seedExpiredPairingCode(t *testing.T, ctx context.Context, s *Store, deviceName string) {
+	t.Helper()
+	if _, _, err := s.MintPairingCode(ctx, deviceName); err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE pairing_codes SET expires_at = ? WHERE device_name = ?`,
+		time.Now().Add(-time.Minute).Unix(), deviceName,
+	); err != nil {
+		t.Fatalf("seed expired pairing code: %v", err)
+	}
+}
+
+func countPairingCodes(t *testing.T, ctx context.Context, s *Store) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pairing_codes`).Scan(&n); err != nil {
+		t.Fatalf("count pairing_codes: %v", err)
+	}
+	return n
+}
+
+// TestPruneOnceRemovesExpiredPairingCodes proves PrunePairingCodes is wired
+// into pruneOnce: before this fix, an expired pairing code survived forever
+// because nothing in production code ever called it.
+func TestPruneOnceRemovesExpiredPairingCodes(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	p, s, buf := newCapturingPruner(t, 365*24*time.Hour, 1000)
+	ctx := context.Background()
+	seedExpiredPairingCode(t, ctx, s, "Expired Phone")
+
+	// Act
+	p.pruneOnce(ctx)
+
+	// Assert
+	if got := countPairingCodes(t, ctx, s); got != 0 {
+		t.Errorf("pairing_codes rows = %d after pruneOnce(), want 0", got)
+	}
+	if !strings.Contains(buf.String(), "pairing codes pruned") {
+		t.Errorf("log = %q, want it to mention pairing codes pruned", buf.String())
+	}
+	if strings.Contains(buf.String(), "Expired Phone") {
+		t.Error("log contains the device name from a pruned pairing code; pairing codes must never be logged")
+	}
+}
+
+// TestPruneOnceContinuesPairingPruneWhenAuditPruneFails proves a failing
+// PruneAudit does not skip PrunePairingCodes: dropping the audit table makes
+// PruneAudit fail deterministically while leaving pairing_codes untouched.
+func TestPruneOnceContinuesPairingPruneWhenAuditPruneFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	p, s, buf := newCapturingPruner(t, 365*24*time.Hour, 1000)
+	ctx := context.Background()
+	seedExpiredPairingCode(t, ctx, s, "Expired Phone")
+	if _, err := s.db.ExecContext(ctx, `DROP TABLE audit`); err != nil {
+		t.Fatalf("drop audit table: %v", err)
+	}
+
+	// Act
+	p.pruneOnce(ctx)
+
+	// Assert
+	if got := countPairingCodes(t, ctx, s); got != 0 {
+		t.Errorf("pairing_codes rows = %d after pruneOnce(), want 0 despite the audit prune failing", got)
+	}
+	if !strings.Contains(buf.String(), "audit prune failed") {
+		t.Errorf("log = %q, want it to mention the audit prune failure", buf.String())
+	}
+}
+
+// TestPruneOnceContinuesAuditPruneWhenPairingPruneFails proves the reverse:
+// a failing PrunePairingCodes does not skip PruneAudit.
+func TestPruneOnceContinuesAuditPruneWhenPairingPruneFails(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	p, s, buf := newCapturingPruner(t, time.Hour, 0)
+	ctx := context.Background()
+	if err := s.AppendAudit(ctx, AuditEntry{Operation: "start", Outcome: OutcomeSuccess}); err != nil {
+		t.Fatalf("AppendAudit() unexpected error: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `DROP TABLE pairing_codes`); err != nil {
+		t.Fatalf("drop pairing_codes table: %v", err)
+	}
+
+	// Act
+	p.pruneOnce(ctx)
+
+	// Assert
+	var auditRows int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit`).Scan(&auditRows); err != nil {
+		t.Fatalf("count audit: %v", err)
+	}
+	if auditRows != 0 {
+		t.Errorf("audit rows = %d after pruneOnce(), want 0 despite the pairing prune failing", auditRows)
+	}
+	if !strings.Contains(buf.String(), "pairing code prune failed") {
+		t.Errorf("log = %q, want it to mention the pairing code prune failure", buf.String())
+	}
+}
+
+// TestPrunerRunPrunesOnStartup is the regression test for issue #42: a Pruner
+// that has just started must not wait a full interval before its first pass.
+func TestPrunerRunPrunesOnStartup(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — an interval far longer than the test timeout proves the
+	// removal below cannot be explained by a tick firing.
+	p, s, _ := newCapturingPruner(t, 365*24*time.Hour, 1000)
+	p.interval = time.Hour
+	ctx := context.Background()
+	seedExpiredPairingCode(t, ctx, s, "Expired Phone")
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	done := make(chan error, 1)
+
+	// Act
+	go func() { done <- p.Run(runCtx) }()
+
+	// Assert
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if countPairingCodes(t, ctx, s) == 0 {
+			cancel()
+			<-done
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	t.Error("Run() never pruned the expired pairing code within the test window; the startup pass regressed")
+}
+
+// TestPrunerRunReturnsOnContextCancel proves Run still reports cancellation
+// once its startup pass is added.
+func TestPrunerRunReturnsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	p, _, _ := newCapturingPruner(t, time.Hour, 100)
+	p.interval = time.Hour
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	// Act
+	go func() { done <- p.Run(ctx) }()
+	cancel()
+
+	// Assert
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Run() = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return after the context was cancelled")
+	}
+}
+
+// TestPrunerRunDoesNothingWhenContextAlreadyCancelled proves the startup pass
+// is skipped entirely when ctx is already dead on entry — a cancelled Run
+// must not touch the store at all.
+func TestPrunerRunDoesNothingWhenContextAlreadyCancelled(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	p, s, _ := newCapturingPruner(t, 365*24*time.Hour, 1000)
+	p.interval = time.Hour
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	seedExpiredPairingCode(t, context.Background(), s, "Expired Phone")
+
+	// Act
+	err := p.Run(ctx)
+
+	// Assert
+	if err != context.Canceled {
+		t.Errorf("Run() = %v, want context.Canceled", err)
+	}
+	if got := countPairingCodes(t, context.Background(), s); got != 1 {
+		t.Errorf("pairing_codes rows = %d, want 1: Run() must not prune when ctx is already cancelled", got)
+	}
+}


### PR DESCRIPTION
Closes #42.

## What

Two gaps left configured retention silently unenforced.

**1. `PrunePairingCodes` was never called from production code.** It was written and tested, but `state.Pruner` only ran `PruneAudit`. Every minted pairing code — used, unused, expired — was retained forever, so `pairing_codes` grew one row per operator mint.

**2. Neither the pruner nor the rotator ran a pass at startup.** The first tick landed after 6h (pruner) and 24h (rotator), so an agent restarted more often than that — redeploy, host reboot, crash loop — never enforced `DEVMON_AUDIT_MAX_AGE_DAYS`, `DEVMON_AUDIT_MAX_ROWS`, or `DEVMON_LOG_MAX_AGE_DAYS` at all. That matters most for the rotator: lumberjack applies `MaxAge` only at the moment a rotation happens and rotates on size only, which is the entire reason `rotator.go` exists.

## Changes

- `Pruner.pruneOnce` now runs both prunes, split into `pruneAudit`/`prunePairingCodes` so a failure in one never skips the other. Counts only in the log — pairing codes themselves are never logged, at any level.
- `Pruner.Run` and `Rotator.Run` make one pass before entering the ticker loop, and return `ctx.Err()` immediately without touching the store/log file if ctx is already cancelled. Synchronous rather than a shortened first tick, because `runAll` already starts both as goroutines alongside the HTTP listener, so the pass overlaps with startup and never blocks it. Rationale is in both doc comments.
- The rotator's startup pass skips a missing or zero-byte current file. Verified against lumberjack v2.2.1's `openNew`: `Rotate()` renames the current file aside whenever `os.Stat` succeeds, with **no** size check (the size check only exists on `Write()`'s size-triggered path). Unguarded, a crash-looping agent would leave a useless empty backup on every boot.
- No constructor signatures changed, so `cmd/devmon-agent/main.go` and `internal/logging/logging.go` needed no edits.

### Behavior change worth knowing

A restart of an agent with a non-empty log now rotates once at boot. With `maxBackups = 3`, a crash loop therefore retains the last three boots' logs rather than three older files — the crash evidence is kept, deeper history is not. That is the intended trade for `DEVMON_LOG_MAX_AGE_DAYS` meaning anything on a frequently restarted host.

## Test plan

New tests, each confirmed failing against the current implementation first:

- [x] `pruneOnce` removes expired pairing codes, and does not log the device name
- [x] a failing `PruneAudit` still lets `PrunePairingCodes` run, and vice versa (tables dropped to force deterministic failures)
- [x] `Pruner.Run` prunes on startup with the interval set to 1h, so no tick can explain it
- [x] `Rotator.Run` rotates on startup with the interval set to 1h
- [x] `Rotator.Run` produces no files at all against an unwritten sink
- [x] both `Run` methods return `context.Canceled` and do nothing when ctx is already cancelled on entry
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `golangci-lint run ./...` → 0 issues; `gosec ./...` → 0 issues
- [x] `go test ./internal/... ./cmd/... -race -count=1` → all packages ok
- [x] coverage 91.1% total (floor 90%)