### PR TITLE
fix: cancel in-flight request contexts on graceful shutdown

### DIFF
--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -85,6 +86,19 @@ type Server struct {
 
 	http *http.Server
 
+	// lifecycleCtx is the server's own lifetime signal, wired in as
+	// http.Server's BaseContext (issue #41). Every request's r.Context() is
+	// derived from it, so cancelling it cancels every in-flight request's
+	// context in one step — chiefly the one long-lived handler,
+	// handleStreamContainerLogs, whose stream is otherwise bounded only by
+	// the client. shutdown cancels it before calling http.Server.Shutdown,
+	// so a live stream unwinds immediately instead of pinning Shutdown for
+	// the full shutdownGrace window. Client-initiated disconnects are
+	// unaffected: they still cancel r.Context() the same way they always
+	// did, independent of this context's own lifetime.
+	lifecycleCtx    context.Context
+	cancelLifecycle context.CancelFunc
+
 	// afterCreateHook is a test seam, nil in production. pairDevice calls it,
 	// if set, right after CreateDevice succeeds and before RedeemPairingCode
 	// runs, so a test can land a context cancellation at that exact
@@ -105,6 +119,7 @@ type Server struct {
 // instead of panicking.
 func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger) *Server {
 	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log, streams: make(chan struct{}, maxConcurrentStreams)}
+	s.lifecycleCtx, s.cancelLifecycle = context.WithCancel(context.Background())
 
 	s.unauthGlobal = rate.NewLimiter(rate.Limit(unauthGlobalPerSec), unauthGlobalBurst)
 
@@ -146,6 +161,11 @@ func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader
 		IdleTimeout:       idleTimeout,
 		MaxHeaderBytes:    maxHeaderBytes,
 		ErrorLog:          slog.NewLogLogger(log.Handler(), slog.LevelWarn),
+		// BaseContext parents every request's r.Context(): cancelling
+		// lifecycleCtx in shutdown cancels every in-flight request's context
+		// in one step, which is how a live SSE stream (issue #41) learns to
+		// stop without Shutdown having to wait out the client.
+		BaseContext: func(net.Listener) context.Context { return s.lifecycleCtx },
 	}
 	return s
 }
@@ -244,6 +264,12 @@ func (s *Server) Run(ctx context.Context) error {
 
 func (s *Server) shutdown() error {
 	s.log.Info("shutting down http server")
+
+	// Cancel the shared lifecycle context first, before asking http.Server
+	// to drain: it is the parent of every in-flight request's context, so
+	// this is what makes a live SSE log stream (issue #41) return promptly
+	// instead of pinning Shutdown below for the full shutdownGrace window.
+	s.cancelLifecycle()
 
 	// A fresh context: ctx is already cancelled, and Shutdown needs a live
 	// deadline to drain against.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -4,11 +4,19 @@ package httpapi
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -16,6 +24,7 @@ import (
 	"github.com/scnplt/devmon-agent/internal/config"
 	"github.com/scnplt/devmon-agent/internal/dockerx"
 	"github.com/scnplt/devmon-agent/internal/policy"
+	"github.com/scnplt/devmon-agent/internal/state"
 	"github.com/scnplt/devmon-agent/internal/tlsconf"
 )
 
@@ -282,5 +291,178 @@ func TestRunReportsListenFailure(t *testing.T) {
 	}
 	if !bodyContains(err.Error(), "serve https on") {
 		t.Errorf("error %q does not identify the failing step", err)
+	}
+}
+
+// issueMTLSClientCert issues a real device client certificate against ca and
+// records it in st, mirroring pairDevice's own sequence, and returns a
+// tls.Certificate a real net/http client can present at the handshake — the
+// counterpart pairDeviceForTest and pairDeviceForRead deliberately skip by
+// driving requireDevice without a real TLS connection. This helper exists
+// only for the shutdown test below, which needs a genuine in-flight
+// connection to prove Shutdown actually unblocks it, not merely a fake
+// r.TLS.PeerCertificates value.
+func issueMTLSClientCert(t *testing.T, ctx context.Context, st *state.Store, ca *certs.CA) tls.Certificate {
+	t.Helper()
+
+	device, err := st.CreateDevice(ctx, "shutdown test device")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate client key: %v", err)
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "irrelevant"},
+	}, key)
+	if err != nil {
+		t.Fatalf("create CSR: %v", err)
+	}
+
+	now := time.Now()
+	certPEM, serialHex, notAfter, err := ca.IssueDeviceCert(csrDER, device.ID, now)
+	if err != nil {
+		t.Fatalf("IssueDeviceCert: %v", err)
+	}
+	if err := st.RecordDeviceCert(ctx, device.ID, serialHex, now, notAfter); err != nil {
+		t.Fatalf("RecordDeviceCert: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal client key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	clientCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("build client key pair: %v", err)
+	}
+	return clientCert
+}
+
+// TestShutdownEndsLiveStreamPromptlyAndReturnsNil is issue #41's regression:
+// a live SSE log stream, held open by a real client over a real connection,
+// must not pin Shutdown for the full shutdownGrace window. Before the fix,
+// nothing cancelled the stream handler's context on shutdown, so Shutdown
+// blocked until shutdownGrace elapsed, returned context.DeadlineExceeded, and
+// Run propagated it — turning an ordinary `docker stop` into a reported
+// failure. After the fix the stream's context is cancelled as soon as
+// shutdown starts, the handler returns immediately, and Shutdown (and Run)
+// complete well under the grace period with a nil error.
+func TestShutdownEndsLiveStreamPromptlyAndReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a real server with a real listener, real CA-backed mTLS, and
+	// a fake Docker stream that blocks until its context is cancelled, just
+	// like the real Engine SDK call does while a client is watching logs.
+	addr := freeTCPAddr(t)
+	dir := t.TempDir()
+	log := testLogger()
+
+	ca, _, err := certs.LoadOrCreateCA(t.TempDir(), log)
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA: %v", err)
+	}
+	certPEM, keyPEM, err := certs.GenerateServerCert([]string{"127.0.0.1"}, time.Now())
+	if err != nil {
+		t.Fatalf("generate server cert: %v", err)
+	}
+	serverPair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("build server key pair: %v", err)
+	}
+	tlsCfg := tlsconf.Build(serverPair, ca.Pool())
+
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), log)
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	streamStarted := make(chan struct{})
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(ctx context.Context, _ string, _ dockerx.LogOptions, emit func(dockerx.LogLine) error) error {
+			// Emit one line first so the SSE response headers commit
+			// immediately, rather than waiting on the 20s keepalive ticker
+			// for the client's Do() to see a response at all.
+			if err := emit(dockerx.LogLine{Timestamp: "t1", Stream: "stdout", Line: "watching"}); err != nil {
+				return err
+			}
+			close(streamStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	cfg := config.Config{StateDir: dir, ListenAddr: addr, PolicyMode: policy.ModeDefault}
+	s := NewServer(cfg, st, ca, fd, tlsCfg, log)
+
+	clientCert := issueMTLSClientCert(t, context.Background(), st, ca)
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(runCtx) }()
+	time.Sleep(50 * time.Millisecond) // let the listener bind
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates:       []tls.Certificate{clientCert},
+				InsecureSkipVerify: true, //nolint:gosec // test-only, talks to our own ephemeral server
+			},
+		},
+	}
+	reqCtx, cancelReq := context.WithTimeout(context.Background(), shutdownGrace+5*time.Second)
+	defer cancelReq()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, "https://"+addr+"/v1/containers/c1/logs/stream", nil)
+	if err != nil {
+		t.Fatalf("build stream request: %v", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200", resp.StatusCode)
+	}
+
+	select {
+	case <-streamStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream did not reach the fake Docker call in time")
+	}
+
+	streamEnded := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		close(streamEnded)
+	}()
+
+	// Act
+	shutdownStart := time.Now()
+	cancelRun()
+
+	// Assert — Shutdown completes well under shutdownGrace, and Run reports
+	// no error: a stream terminated by shutdown is a clean termination.
+	select {
+	case runErr := <-done:
+		if runErr != nil {
+			t.Errorf("Run() = %v, want nil after shutdown with a live stream", runErr)
+		}
+		if elapsed := time.Since(shutdownStart); elapsed >= shutdownGrace {
+			t.Errorf("shutdown took %v, want well under the %v grace period", elapsed, shutdownGrace)
+		}
+	case <-time.After(shutdownGrace + 5*time.Second):
+		t.Fatal("Run() did not return after shutdown with a live stream")
+	}
+
+	select {
+	case <-streamEnded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the client's stream read did not end after shutdown")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #41 (Wave 3 of tracking issue #60).

`http.Server.Shutdown` waits for in-flight requests but never cancels their contexts, so a live SSE log stream pinned `Shutdown` for the full 5s `shutdownGrace`: `Run` returned `context.DeadlineExceeded`, `main` exited 1 on every ordinary `docker stop`, and the deferred `dc.Close()`/`st.Close()` raced the still-running stream goroutine.

- Add a server-lifetime context (`lifecycleCtx`) wired in as `http.Server.BaseContext`, parenting every request's `r.Context()`.
- `shutdown()` cancels it before calling `http.Server.Shutdown`, so live streams unwind immediately and Shutdown drains within the grace period.
- No change needed in `logs.go` or `main.go`: the stream handler already treats context cancellation as a clean client disconnect, and `Shutdown`'s wait-for-idle contract now guarantees stream goroutines finish before the deferred closes run.

## Test plan

- [x] New `TestShutdownEndsLiveStreamPromptlyAndReturnsNil`: real mTLS listener, live SSE stream, shutdown completes promptly and `Run` returns nil
- [x] `go test ./internal/... ./cmd/... -race` green, coverage 95.3% (floor 90%)
- [x] `go vet`, `golangci-lint run`, `gosec` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)