### PR TITLE
feat: write audit rows for pair, renew, and self-revoke

### DIFF
--- a/internal/httpapi/audit.go
+++ b/internal/httpapi/audit.go
@@ -16,17 +16,72 @@ import (
 // deviceCtxKey is (middleware.go:20).
 type auditCtxKey struct{}
 
+// Identity operation names for the audit `operation` column. These are not
+// policy.Operation values: pairing, renewal, and self-revocation are never
+// gated by policy.Mode (handleUnpairSelf's own doc comment explains why for
+// self-revoke; pairing and renewal are identity bootstrapping, not container
+// control), so they never pass through requireOp and have no place in
+// policy's minMode map. They exist here, as plain strings, purely to name the
+// row.
+const (
+	opPair       = "pair"
+	opRenew      = "renew"
+	opUnpairSelf = "unpair_self"
+)
+
 // auditEntry is the mutable record for one in-flight mutating request. Inner
-// layers refine Outcome and Detail; withAudit writes exactly one row on the
-// way out, whatever happened (D14).
+// layers refine Outcome, Detail, and — for the one pre-authentication route,
+// pair — DeviceID; withAudit and its identity-route siblings write exactly
+// one row on the way out, whatever happened (D14).
 type auditEntry struct {
-	operation policy.Operation
+	operation string
 	target    string
 	outcome   string
 	detail    string
+	// deviceID carries the device ID for routes that run before a device is
+	// resolved in the request context. handlePair sets it via
+	// setAuditDeviceID once it knows the newly created device's ID; every
+	// other audited route leaves it empty and recordAudit reads DeviceFrom
+	// instead.
+	deviceID string
 }
 
-// withAudit records one audit row per mutating request.
+// recordAudit writes entry as one row, attributing it to the request's
+// resolved device if one is present in ctx and to entry.deviceID otherwise —
+// the latter is how the pre-authentication pair route (which has no device
+// in context) still attributes a successful pairing to the device it just
+// created.
+//
+// It is called after next returns, never in a defer: a defer would also fire
+// on a panic path where withRecovery has already written a 500, and a
+// missing row there is better than one claiming an outcome that never
+// happened.
+func (s *Server) recordAudit(ctx context.Context, entry *auditEntry) {
+	deviceID := entry.deviceID
+	if device, ok := DeviceFrom(ctx); ok {
+		deviceID = device.ID
+	}
+
+	row := state.AuditEntry{
+		DeviceID:  deviceID,
+		Operation: entry.operation,
+		Target:    entry.target,
+		Outcome:   entry.outcome,
+		Detail:    entry.detail,
+	}
+	// An AppendAudit failure is logged and never changes the response (D16):
+	// the act already happened, so a 500 here would tell the caller it did
+	// not, when it did.
+	if err := s.st.AppendAudit(context.Background(), row); err != nil {
+		s.log.Error("append audit entry",
+			slog.String("operation", entry.operation),
+			slog.String("device_id", deviceID),
+			slog.Any("err", err),
+		)
+	}
+}
+
+// withAudit records one audit row per mutating container-lifecycle request.
 //
 // Placement is load-bearing (D15). It sits INSIDE requireDevice, so every row
 // carries a real device — an unauthenticated caller is unattributable, and
@@ -36,36 +91,51 @@ type auditEntry struct {
 func (s *Server) withAudit(op policy.Operation, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		entry := &auditEntry{
-			operation: op,
+			operation: string(op),
 			target:    r.PathValue("id"),
 			outcome:   state.OutcomeSuccess,
 		}
 
 		ctx := context.WithValue(r.Context(), auditCtxKey{}, entry)
 		next.ServeHTTP(w, r.WithContext(ctx))
+		s.recordAudit(ctx, entry)
+	})
+}
 
-		// The row is written here, after next returns, not in a defer: a defer
-		// would also fire on a panic path where withRecovery has already written
-		// a 500, and a missing row there is better than one claiming an outcome
-		// that never happened.
-		device, _ := DeviceFrom(ctx)
-		row := state.AuditEntry{
-			DeviceID:  device.ID,
-			Operation: string(entry.operation),
-			Target:    entry.target,
-			Outcome:   entry.outcome,
-			Detail:    entry.detail,
-		}
-		// An AppendAudit failure is logged and never changes the response (D16):
-		// the act already happened, so a 500 here would tell the caller it did
-		// not, when it did.
-		if err := s.st.AppendAudit(context.Background(), row); err != nil {
-			s.log.Error("append audit entry",
-				slog.String("operation", string(entry.operation)),
-				slog.String("device_id", device.ID),
-				slog.Any("err", err),
-			)
-		}
+// withIdentityAudit records one audit row per request for the two guarded
+// identity routes, renew and self-revoke. It mirrors withAudit exactly
+// except for two things neither route has: a policy.Operation (neither is
+// gated by policy.Mode, see the opRenew/opUnpairSelf doc comment) and a
+// path-value target (both act on the caller's own identity, never on a path
+// parameter). It still sits inside requireDevice and withDeviceLimit, so
+// D7 and D15 hold the same way they do for withAudit.
+func (s *Server) withIdentityAudit(operation string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entry := &auditEntry{operation: operation, outcome: state.OutcomeSuccess}
+
+		ctx := context.WithValue(r.Context(), auditCtxKey{}, entry)
+		next.ServeHTTP(w, r.WithContext(ctx))
+		s.recordAudit(ctx, entry)
+	})
+}
+
+// withPairAudit records one audit row per call to the pre-authentication
+// pair route. It must sit INSIDE both the global unauthenticated limiter and
+// the per-IP pair limiter (D7): a request either of those rejects must never
+// reach here, or a throttled scanner could still fill the audit table.
+//
+// Unlike withAudit and withIdentityAudit, there is no device in the request
+// context at any point — the caller has no certificate yet. handlePair
+// itself calls setAuditDeviceID once pairing succeeds, so the row it
+// produces carries the newly created device's ID on success and an empty
+// device ID on every failure path.
+func (s *Server) withPairAudit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entry := &auditEntry{operation: opPair, outcome: state.OutcomeSuccess}
+
+		ctx := context.WithValue(r.Context(), auditCtxKey{}, entry)
+		next.ServeHTTP(w, r.WithContext(ctx))
+		s.recordAudit(ctx, entry)
 	})
 }
 
@@ -78,4 +148,16 @@ func setAuditOutcome(ctx context.Context, outcome, detail string) {
 	}
 	entry.outcome = outcome
 	entry.detail = detail
+}
+
+// setAuditDeviceID records the ID of a device created during this request,
+// for the one route that runs before authentication (pair) and therefore has
+// no device in context for recordAudit to read via DeviceFrom. A no-op
+// outside an audited request, for the same reason setAuditOutcome is.
+func setAuditDeviceID(ctx context.Context, deviceID string) {
+	entry, ok := ctx.Value(auditCtxKey{}).(*auditEntry)
+	if !ok {
+		return
+	}
+	entry.deviceID = deviceID
 }

--- a/internal/httpapi/device.go
+++ b/internal/httpapi/device.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/scnplt/devmon-agent/internal/state"
 )
 
 // Limits and messages for the two routes an already-paired device uses on
@@ -56,11 +58,13 @@ func (s *Server) handleRenew(w http.ResponseWriter, r *http.Request) {
 
 	req, ok := s.decodeRenewRequest(w, r)
 	if !ok {
+		setAuditOutcome(r.Context(), state.OutcomeInvalid, "malformed request body")
 		return
 	}
 
 	csrDER, ok := decodeCSRPEM(req.CSRPEM)
 	if !ok {
+		setAuditOutcome(r.Context(), state.OutcomeInvalid, "malformed csr")
 		s.writeError(w, http.StatusUnauthorized, msgRenewFailed)
 		return
 	}
@@ -71,6 +75,7 @@ func (s *Server) handleRenew(w http.ResponseWriter, r *http.Request) {
 			slog.String("device_id", device.ID),
 			slog.Any("err", err),
 		)
+		setAuditOutcome(r.Context(), state.OutcomeInternalError, "")
 		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
 		return
 	}
@@ -140,6 +145,7 @@ func (s *Server) handleUnpairSelf(w http.ResponseWriter, r *http.Request) {
 			slog.String("device_id", device.ID),
 			slog.Any("err", err),
 		)
+		setAuditOutcome(r.Context(), state.OutcomeInternalError, "")
 		s.writeError(w, http.StatusInternalServerError, msgDeviceInternalError)
 		return
 	}

--- a/internal/httpapi/device_test.go
+++ b/internal/httpapi/device_test.go
@@ -11,11 +11,13 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/scnplt/devmon-agent/internal/certs"
+	"github.com/scnplt/devmon-agent/internal/config"
 	"github.com/scnplt/devmon-agent/internal/policy"
 	"github.com/scnplt/devmon-agent/internal/state"
 )
@@ -277,6 +279,147 @@ func TestHandleUnpairSelfSucceedsUnderEveryPolicyMode(t *testing.T) {
 				t.Errorf("status = %d, want 204 under %s policy; body: %s", rec.Code, tt.mode, rec.Body.String())
 			}
 		})
+	}
+}
+
+// TestHandleRenewWritesAuditRowWithAuthenticatedDeviceID is issue #44's renew
+// coverage: a renewal must write exactly one audit row, carrying the
+// authenticated caller's own device ID (D15), never a path parameter (the
+// route has none).
+func TestHandleRenewWritesAuditRowWithAuthenticatedDeviceID(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+	req := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", mustMarshalRenew(t), paired.serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	entries, err := st.ListAudit(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListAudit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Operation != opRenew {
+		t.Errorf("operation = %q, want %q", entries[0].Operation, opRenew)
+	}
+	if entries[0].Outcome != state.OutcomeSuccess {
+		t.Errorf("outcome = %q, want %q", entries[0].Outcome, state.OutcomeSuccess)
+	}
+	if entries[0].DeviceID != paired.device.ID {
+		t.Errorf("device_id = %q, want the authenticated device's ID %q", entries[0].DeviceID, paired.device.ID)
+	}
+}
+
+// TestHandleUnpairSelfWritesAuditRowWithAuthenticatedDeviceID is issue #44's
+// self-revoke coverage: revoking one's own access is the highest-value
+// identity event, and must always leave an audit trail carrying the
+// authenticated caller's own device ID.
+func TestHandleUnpairSelfWritesAuditRowWithAuthenticatedDeviceID(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, ca := testServerForPairing(t)
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+	req := requestWithPeerSerial(http.MethodDelete, "/v1/device/self", nil, paired.serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", rec.Code, rec.Body.String())
+	}
+	entries, err := st.ListAudit(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListAudit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Operation != opUnpairSelf {
+		t.Errorf("operation = %q, want %q", entries[0].Operation, opUnpairSelf)
+	}
+	if entries[0].Outcome != state.OutcomeSuccess {
+		t.Errorf("outcome = %q, want %q", entries[0].Outcome, state.OutcomeSuccess)
+	}
+	if entries[0].DeviceID != paired.device.ID {
+		t.Errorf("device_id = %q, want the authenticated device's ID %q", entries[0].DeviceID, paired.device.ID)
+	}
+}
+
+// TestHandleRenewRateLimitedWritesNoAuditRow proves D7's ordering holds for
+// the guarded identity routes too: withDeviceLimit sits inside requireDevice
+// but outside withIdentityAudit, so a throttled renewal must never write a
+// row.
+func TestHandleRenewRateLimitedWritesNoAuditRow(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a guarded tier of burst 2 (guardedPerSec 1 x
+	// guardedBurstMultiplier 2), so the third request in a row is throttled
+	// before withIdentityAudit ever runs.
+	dir := t.TempDir()
+	cfg := config.Config{
+		StateDir:          dir,
+		ListenAddr:        ":8443",
+		PolicyMode:        policy.ModeDefault,
+		RateGuardedPerSec: 1,
+	}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), testLogger())
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ca, _, err := certs.LoadOrCreateCA(t.TempDir(), testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA: %v", err)
+	}
+	s := NewServer(cfg, st, ca, nil, nil, testLogger())
+	ctx := context.Background()
+	paired := pairDeviceForTest(t, ctx, st, ca, "Pixel 9")
+
+	// Act — drain the device's burst of 2 with successful renewals.
+	for i := 0; i < 2; i++ {
+		req := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", mustMarshalRenew(t), paired.serial)
+		rec := httptest.NewRecorder()
+		s.routes().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("renewal %d status = %d, want 200; body: %s", i, rec.Code, rec.Body.String())
+		}
+	}
+	rowsBeforeThrottle, err := st.ListAudit(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListAudit before throttle: %v", err)
+	}
+
+	// Act — a third request, past the burst.
+	req := requestWithPeerSerial(http.MethodPost, "/v1/device/renew", mustMarshalRenew(t), paired.serial)
+	rec := httptest.NewRecorder()
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("third renewal status = %d, want 429", rec.Code)
+	}
+	rowsAfterThrottle, err := st.ListAudit(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListAudit after throttle: %v", err)
+	}
+	if len(rowsAfterThrottle) != len(rowsBeforeThrottle) {
+		t.Errorf("audit rows after throttled request = %d, want unchanged from %d",
+			len(rowsAfterThrottle), len(rowsBeforeThrottle))
 	}
 }
 

--- a/internal/httpapi/pair.go
+++ b/internal/httpapi/pair.go
@@ -75,6 +75,9 @@ func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
 
 	csrDER, ok := decodeCSRPEM(req.CSRPEM)
 	if !ok {
+		// state.OutcomeInvalid, never the submitted code or CSR bytes: the
+		// audit row must never carry key material or pairing codes.
+		setAuditOutcome(r.Context(), state.OutcomeInvalid, "malformed csr")
 		s.writeError(w, http.StatusUnauthorized, msgPairFailed)
 		return
 	}
@@ -82,14 +85,20 @@ func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
 	resp, err := s.pairDevice(r.Context(), req.PairingCode, csrDER)
 	if err != nil {
 		if errors.Is(err, state.ErrPairingCodeInvalid) {
+			setAuditOutcome(r.Context(), state.OutcomeInvalid, "invalid or expired pairing code")
 			s.writeError(w, http.StatusUnauthorized, msgPairFailed)
 			return
 		}
 		s.log.Error("pair device", slog.Any("err", err))
+		setAuditOutcome(r.Context(), state.OutcomeInternalError, "")
 		s.writeError(w, http.StatusInternalServerError, msgPairInternalError)
 		return
 	}
 
+	// On success the audit row must carry the identity that pairing just
+	// granted (issue #44), which withPairAudit has no other way to learn —
+	// the request that produced it never carried a client certificate.
+	setAuditDeviceID(r.Context(), resp.DeviceID)
 	s.writeJSON(w, http.StatusCreated, resp)
 }
 

--- a/internal/httpapi/pair_test.go
+++ b/internal/httpapi/pair_test.go
@@ -331,6 +331,170 @@ func TestPairDeviceRollbackSurvivesCanceledContext(t *testing.T) {
 	}
 }
 
+// testServerForPairingWithRate mirrors testServerForPairing but lets a test
+// set a deliberately tiny RatePairPerMin, for driving the pair rate limiter
+// to exhaustion without dozens of requests.
+func testServerForPairingWithRate(t *testing.T, pairPerMin int) (*Server, *state.Store, *certs.CA) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Config{
+		StateDir:       dir,
+		ListenAddr:     ":8443",
+		PolicyMode:     policy.ModeDefault,
+		RatePairPerMin: pairPerMin,
+	}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), testLogger())
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ca, _, err := certs.LoadOrCreateCA(t.TempDir(), testLogger())
+	if err != nil {
+		t.Fatalf("LoadOrCreateCA: %v", err)
+	}
+	return NewServer(cfg, st, ca, nil, nil, testLogger()), st, ca
+}
+
+// TestHandlePairSuccessWritesAuditRowWithNewDeviceID is the pair-success half
+// of issue #44: the audit row for a successful pairing must carry the newly
+// created device's ID, learned only from the response — the request that
+// produced it never carried a client certificate.
+func TestHandlePairSuccessWritesAuditRowWithNewDeviceID(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, _ := testServerForPairing(t)
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	body, err := json.Marshal(pairRequest{
+		PairingCode: code,
+		CSRPEM:      generateCSRPEM(t, "irrelevant"),
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// Act
+	rec := postPair(s, body)
+
+	// Assert
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp pairResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	entries, err := st.ListAudit(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListAudit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Operation != opPair {
+		t.Errorf("operation = %q, want %q", entries[0].Operation, opPair)
+	}
+	if entries[0].Outcome != state.OutcomeSuccess {
+		t.Errorf("outcome = %q, want %q", entries[0].Outcome, state.OutcomeSuccess)
+	}
+	if entries[0].DeviceID != resp.DeviceID {
+		t.Errorf("device_id = %q, want the newly created device's ID %q", entries[0].DeviceID, resp.DeviceID)
+	}
+}
+
+// TestHandlePairFailureWritesAuditRowWithEmptyDeviceID is the pair-failure
+// half of issue #44: an invalid pairing code writes a row with a failure
+// outcome and an empty device ID (no device was ever created), and the
+// submitted code must never appear in the row.
+func TestHandlePairFailureWritesAuditRowWithEmptyDeviceID(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st, _ := testServerForPairing(t)
+	const badCode = "unknown-pairing-code"
+	body, err := json.Marshal(pairRequest{
+		PairingCode: badCode,
+		CSRPEM:      generateCSRPEM(t, "irrelevant"),
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// Act
+	rec := postPair(s, body)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+	}
+
+	entries, err := st.ListAudit(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListAudit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Operation != opPair {
+		t.Errorf("operation = %q, want %q", entries[0].Operation, opPair)
+	}
+	if entries[0].DeviceID != "" {
+		t.Errorf("device_id = %q, want empty (pairing failed, no device created)", entries[0].DeviceID)
+	}
+	if entries[0].Outcome == state.OutcomeSuccess {
+		t.Error("outcome = success, want a failure outcome")
+	}
+	if strings.Contains(entries[0].Detail, badCode) {
+		t.Errorf("detail = %q, must never contain the submitted pairing code", entries[0].Detail)
+	}
+	if strings.Contains(entries[0].Target, badCode) {
+		t.Errorf("target = %q, must never contain the submitted pairing code", entries[0].Target)
+	}
+}
+
+// TestHandlePairRateLimitedWritesNoAuditRow is the D7-ordering regression
+// test for issue #44: a pair attempt refused by the per-IP pair limiter must
+// never reach withPairAudit, so it must write zero rows regardless of how
+// many attempts preceded it.
+func TestHandlePairRateLimitedWritesNoAuditRow(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a pair tier of burst 1, so the second request is refused by
+	// the limiter before withPairAudit ever runs.
+	s, st, _ := testServerForPairingWithRate(t, 1)
+	body, err := json.Marshal(pairRequest{PairingCode: "irrelevant", CSRPEM: "not a pem csr"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// Act — first request consumes the burst (and still fails pairing, but
+	// that is not what this test is about).
+	first := postPair(s, body)
+	if first.Code == http.StatusTooManyRequests {
+		t.Fatalf("first request status = 429, want the burst to admit it")
+	}
+
+	// Act — second request past the burst.
+	second := postPair(s, body)
+
+	// Assert
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request status = %d, want 429", second.Code)
+	}
+
+	entries, err := st.ListAudit(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListAudit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1 (only the first, non-throttled attempt)", len(entries))
+	}
+}
+
 func TestHandlePairOversizedBodyFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -187,15 +187,24 @@ func (s *Server) routes() http.Handler {
 
 	// Unauthenticated by design (D2): the device has no certificate yet, so
 	// the pairing code itself is what authenticates this one call.
+	// withPairAudit sits inside both rate-limit tiers (D7): a request either
+	// one refuses must never reach it, or a throttled scanner could fill the
+	// audit table (issue #44).
 	mux.Handle("POST /v1/pair",
-		s.withGlobalUnauthLimit(s.withIPLimit(s.pairLimits, s.pairLimit, "pair", http.HandlerFunc(s.handlePair))))
+		s.withGlobalUnauthLimit(s.withIPLimit(s.pairLimits, s.pairLimit, "pair", s.withPairAudit(http.HandlerFunc(s.handlePair)))))
 
 	// Guarded: both act on the calling device's own identity, resolved by
 	// requireDevice from its client certificate — never from the request.
 	// withDeviceLimit sits immediately inside requireDevice, before anything
 	// else, exactly as it does for the read/logs/mutate helpers below.
-	mux.Handle("POST /v1/device/renew", s.requireDevice(s.withDeviceLimit(http.HandlerFunc(s.handleRenew))))
-	mux.Handle("DELETE /v1/device/self", s.requireDevice(s.withDeviceLimit(http.HandlerFunc(s.handleUnpairSelf))))
+	// withIdentityAudit sits inside withDeviceLimit for the same reason
+	// withAudit does on the mutate routes below (D7, D15, issue #44): a
+	// throttled call must never write a row, and every row must carry a real,
+	// authenticated device.
+	mux.Handle("POST /v1/device/renew",
+		s.requireDevice(s.withDeviceLimit(s.withIdentityAudit(opRenew, http.HandlerFunc(s.handleRenew)))))
+	mux.Handle("DELETE /v1/device/self",
+		s.requireDevice(s.withDeviceLimit(s.withIdentityAudit(opUnpairSelf, http.HandlerFunc(s.handleUnpairSelf)))))
 
 	// Read operations. Every one is guarded three times: requireDevice proves
 	// who is calling, withDeviceLimit bounds how often, requireOp proves the

--- a/internal/state/audit.go
+++ b/internal/state/audit.go
@@ -29,6 +29,11 @@ const (
 	OutcomeConflict     = "conflict"
 	OutcomeUnavailable  = "unavailable" // self ID unknown (D3)
 	OutcomeEngineError  = "engine_error"
+	// OutcomeInternalError covers a failure on the agent's own side that is
+	// neither the caller's fault nor a Docker Engine error — for example a
+	// store write that failed while issuing or recording a device
+	// certificate during pairing or renewal.
+	OutcomeInternalError = "internal_error"
 )
 
 // AppendAudit records one mutating operation. It is called once per mutating


### PR DESCRIPTION
## Summary

Fixes #44 (Wave 3 of tracking issue #60).

`/v1/pair`, `/v1/device/renew`, and `DELETE /v1/device/self` bypassed `withAudit` entirely, so the highest-value identity events left no audit rows and were recoverable only from the shorter-retention operational log.

- New `withIdentityAudit` middleware for renew/self-revoke (inside `requireDevice` + `withDeviceLimit`, D15/D7 preserved); rows carry the authenticated device ID with new operation names `renew` / `unpair_self`.
- New `withPairAudit` for the pre-auth pair route, sitting inside both rate limiters (D7: throttled attempts write no rows). Success rows carry the newly created device ID via `setAuditDeviceID`; failure rows have an empty device ID and an outcome/detail that never contains the submitted code or CSR.
- Shared row-writing extracted into `recordAudit`; container-lifecycle `withAudit` behavior unchanged.
- New `state.OutcomeInternalError` for agent-side failures (audit columns are plain TEXT, no schema change).

## Test plan

- [x] Pair success row carries new device ID; pair failure row has empty device ID and failure outcome; code never appears in target/detail
- [x] Rate-limited pair and throttled renew write zero rows (D7)
- [x] Renew / self-revoke rows carry the authenticated device ID
- [x] `go test ./internal/... ./cmd/... -race` green, coverage 95.4% (floor 90%)
- [x] `go vet`, `golangci-lint run`, `gosec` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)