### PR TITLE
fix: map dockerx.ErrNotModified to 204 instead of 502

### DIFF
--- a/internal/dockerx/lifecycle.go
+++ b/internal/dockerx/lifecycle.go
@@ -48,7 +48,10 @@ func (c *Client) resolveTarget(ctx context.Context, ref string) (string, error) 
 // StartContainer starts a stopped container. Starting an already-running
 // container answers 304 from the Engine, which this SDK version treats as a
 // successful status and returns with a nil error — so D9's "already in the
-// requested state is success" holds here with no special case.
+// requested state is success" holds here with no special case. If a future
+// SDK version surfaces the 304 as an error instead, classify maps it to
+// ErrNotModified and httpapi.writeDockerError answers 204 for it too, so the
+// caller-visible behavior does not change either way.
 func (c *Client) StartContainer(ctx context.Context, ref string) error {
 	id, err := c.resolveTarget(ctx, ref)
 	if err != nil {
@@ -83,7 +86,8 @@ func (c *Client) RestartContainer(ctx context.Context, ref string) error {
 // StopContainer stops a running container, waiting up to stopGraceSeconds
 // for it to exit on its own before SIGKILL. Stopping an already-stopped
 // container answers 304, which returns nil for the same reason described on
-// StartContainer (D9).
+// StartContainer (D9), with the same ErrNotModified/204 fallback if that
+// SDK behavior ever changes.
 func (c *Client) StopContainer(ctx context.Context, ref string) error {
 	id, err := c.resolveTarget(ctx, ref)
 	if err != nil {

--- a/internal/httpapi/lifecycle.go
+++ b/internal/httpapi/lifecycle.go
@@ -31,9 +31,11 @@ type ContainerController interface {
 //
 // Success carries no body (D8): every Engine lifecycle call is asynchronous
 // at the edges, so any state returned here would already be stale. That
-// includes the Engine's "already in the requested state" answer (D9), which
-// this SDK version treats as a nil error at the client layer — there is no
-// separate branch to write because the success path already covers it.
+// includes the Engine's "already in the requested state" answer (D9): this
+// SDK version treats it as a nil error at the client layer, so it reaches
+// the success path below, and writeDockerError's dockerx.ErrNotModified
+// branch answers the same 204 if a future SDK version ever surfaces it as an
+// error instead.
 func (s *Server) handleLifecycle(op string, act func(context.Context, string) error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !s.requireDocker(w) {

--- a/internal/httpapi/lifecycle_test.go
+++ b/internal/httpapi/lifecycle_test.go
@@ -101,6 +101,7 @@ func TestLifecycleRoutesStatusMatrix(t *testing.T) {
 		wantBody   string // empty means no error body is expected (success)
 	}{
 		{name: "success", err: nil, wantStatus: http.StatusNoContent},
+		{name: "not modified", err: dockerx.ErrNotModified, wantStatus: http.StatusNoContent},
 		{name: "self protected", err: dockerx.ErrSelfProtected, wantStatus: http.StatusForbidden, wantBody: msgSelfProtected},
 		{name: "self unknown", err: dockerx.ErrSelfUnknown, wantStatus: http.StatusServiceUnavailable, wantBody: msgSelfUnknown},
 		{name: "conflict", err: dockerx.ErrConflict, wantStatus: http.StatusConflict, wantBody: msgContainerConflict},
@@ -144,6 +145,48 @@ func TestLifecycleRoutesStatusMatrix(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestLifecycleNotModifiedAuditsAsSuccess asserts that a dockerx.ErrNotModified
+// result — the Engine reporting the object was already in the requested
+// state — audits as OutcomeSuccess with no engine_error row, matching the
+// 204 status writeDockerError answers for it (issue #45, D9). Without this
+// branch the error would fall into writeDockerError's default case, turning
+// "start an already-running container" into a false Engine-outage report.
+func TestLifecycleNotModifiedAuditsAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	for _, route := range lifecycleRouteCases() {
+		t.Run(route.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			route.setErr(fd, dockerx.ErrNotModified)
+			s, st := testServerWithDocker(t, policy.ModeFull, fd)
+			serial := pairDeviceForRead(t, st)
+			handler := auditChain(s, route.op, route.handler(s))
+			rec := httptest.NewRecorder()
+
+			// Act
+			handler.ServeHTTP(rec, lifecycleRequest(serial))
+
+			// Assert
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+			}
+			entries, err := st.ListAudit(context.Background(), 10)
+			if err != nil {
+				t.Fatalf("ListAudit: %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("len(entries) = %d, want 1", len(entries))
+			}
+			if entries[0].Outcome != state.OutcomeSuccess {
+				t.Errorf("outcome = %q, want %q", entries[0].Outcome, state.OutcomeSuccess)
+			}
+		})
 	}
 }
 

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -100,12 +100,17 @@ const (
 
 // writeDockerError maps a dockerx failure onto a status code. ErrInvalidRef
 // and ErrConflict are client mistakes (400, 409), ErrNotFound is an answer
-// (404), ErrSelfProtected and ErrSelfUnknown are the self-exclusion rule
-// refusing an operation (403, 503), and everything else is the Engine
-// failing upstream of us (502) — never 500, which must keep meaning "the
-// agent itself broke". r carries the in-flight audit entry (a no-op outside
-// a mutating route, via setAuditOutcome), so every failure path — including
-// the pre-existing not-found and invalid-ref branches — is recorded.
+// (404), ErrNotModified is a no-op success (204: the object was already in
+// the requested state, D9), ErrSelfProtected and ErrSelfUnknown are the
+// self-exclusion rule refusing an operation (403, 503), and everything else
+// is the Engine failing upstream of us (502) — never 500, which must keep
+// meaning "the agent itself broke". r carries the in-flight audit entry (a
+// no-op outside a mutating route, via setAuditOutcome), so every failure
+// path — including the pre-existing not-found and invalid-ref branches — is
+// recorded. The ErrNotModified branch deliberately leaves the audit outcome
+// untouched: withAudit seeds it as OutcomeSuccess, and a container already
+// in the requested state is success from the caller's viewpoint, not a
+// failure to record over.
 func (s *Server) writeDockerError(w http.ResponseWriter, r *http.Request, op string, err error) {
 	switch {
 	case errors.Is(err, dockerx.ErrInvalidRef):
@@ -114,6 +119,8 @@ func (s *Server) writeDockerError(w http.ResponseWriter, r *http.Request, op str
 	case errors.Is(err, dockerx.ErrNotFound):
 		setAuditOutcome(r.Context(), state.OutcomeNotFound, "")
 		s.writeError(w, http.StatusNotFound, msgNotFound)
+	case errors.Is(err, dockerx.ErrNotModified):
+		w.WriteHeader(http.StatusNoContent)
 	case errors.Is(err, dockerx.ErrSelfProtected):
 		setAuditOutcome(r.Context(), state.OutcomeDeniedSelf, "")
 		s.writeError(w, http.StatusForbidden, msgSelfProtected)


### PR DESCRIPTION
## Summary

Fixes #45 (Wave 3 of tracking issue #60) — the last open Wave 3 item.

`classify` mapped `cerrdefs.IsNotModified` to `dockerx.ErrNotModified`, but `writeDockerError` had no case for it, so it fell into `default`: 502 "docker engine unavailable" plus a false `engine_error` audit row. Unreachable today (the moby SDK returns nil for 304), but the half-wired state was the worst of both options.

- `writeDockerError` now maps `ErrNotModified` to **204 No Content** and deliberately leaves the audit outcome at the success value `withAudit` seeds, so no `engine_error` row is written (D9).
- Stale comments in `internal/dockerx/lifecycle.go` and `internal/httpapi/lifecycle.go` asserting the branch was unreachable/unwired are updated.

## Test plan

- [x] `not modified` case added to `TestLifecycleRoutesStatusMatrix` (204, empty body)
- [x] New `TestLifecycleNotModifiedAuditsAsSuccess` across all five lifecycle routes: 204 and exactly one audit row with `OutcomeSuccess`
- [x] `go test ./internal/... ./cmd/... -race` green, coverage 95.4% (floor 90%)
- [x] `go vet`, `golangci-lint run`, `gosec` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)