### PR TITLE
ci: run the release bar on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,15 @@
 name: CI
 
 # Two bars, scaled to the target branch:
-#   PR -> dev  : `test` only, for fast feedback on the integration branch.
-#   PR -> main : `test` plus `lint`, `image`, `shellcheck`, `gosec`, `govulncheck`
-#                and `e2e` — the release bar.
-# The main-only jobs are gated on `github.base_ref`, so they never queue on a dev PR.
-# Branch protection is per branch, so `dev` requires `test` and `main` requires all seven.
+#   PR -> dev     : `test` only, for fast feedback on the integration branch.
+#   PR -> main    : `test` plus `lint`, `image`, `shellcheck`, `gosec`, `govulncheck`
+#                   and `e2e` — the release bar.
+#   push -> main  : the same release bar, so main's HEAD carries its own result.
+# The main-only jobs are gated on `github.base_ref == 'main'` (populated on
+# pull_request only) or `github.ref == 'refs/heads/main'` (the push of the merge
+# commit), so they never queue on a dev PR but always run on what main actually
+# holds. Branch protection is per branch, so `dev` requires `test` and `main`
+# requires all seven.
 
 on:
   pull_request:
@@ -77,7 +81,9 @@ jobs:
 
   lint:
     name: lint
-    if: github.base_ref == 'main'
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -108,7 +114,9 @@ jobs:
 
   image:
     name: image
-    if: github.base_ref == 'main'
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -129,7 +137,9 @@ jobs:
   # needs no install step and no third-party action.
   shellcheck:
     name: shellcheck
-    if: github.base_ref == 'main'
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -139,7 +149,9 @@ jobs:
 
   gosec:
     name: gosec
-    if: github.base_ref == 'main'
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -169,7 +181,9 @@ jobs:
   # Installed from source and pinned, for the same supply-chain reason gosec is.
   govulncheck:
     name: govulncheck
-    if: github.base_ref == 'main'
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -193,7 +207,9 @@ jobs:
   # rather than taxing every integration PR into dev.
   e2e:
     name: e2e
-    if: github.base_ref == 'main'
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -859,18 +859,24 @@ branch a pull request targets:
 
 | Job | Runs on | What it does |
 |---|---|---|
-| `test` | every PR, and pushes to `dev`/`main` | `go build ./...`, race tests over the whole module, and the 90% coverage floor over `./internal/...` |
-| `lint` | PRs into `main` only | `gofmt`, `go vet`, `golangci-lint` |
-| `image` | PRs into `main` only | `docker build` of the release image |
-| `gosec` | PRs into `main` only | `gosec ./...` |
-| `govulncheck` | PRs into `main` only | `govulncheck ./...` — known vulnerabilities in the dependencies and the Go toolchain, which `gosec` does not look for |
-| `shellcheck` | PRs into `main` only | `shellcheck -s sh install.sh` |
-| `e2e` | PRs into `main` only | `make e2e` against the runner's Docker Engine, with `DEVMON_E2E_REQUIRE=1`, plus `make e2e-lint` |
+| `test` | every PR, and pushes to `main` | `go build ./...`, race tests over the whole module, and the 90% coverage floor over `./internal/...` |
+| `lint` | PRs into `main`, and pushes to `main` | `gofmt`, `go vet`, `golangci-lint` |
+| `image` | PRs into `main`, and pushes to `main` | `docker build` of the release image |
+| `gosec` | PRs into `main`, and pushes to `main` | `gosec ./...` |
+| `govulncheck` | PRs into `main`, and pushes to `main` | `govulncheck ./...` — known vulnerabilities in the dependencies and the Go toolchain, which `gosec` does not look for |
+| `shellcheck` | PRs into `main`, and pushes to `main` | `shellcheck -s sh install.sh` |
+| `e2e` | PRs into `main`, and pushes to `main` | `make e2e` against the runner's Docker Engine, with `DEVMON_E2E_REQUIRE=1`, plus `make e2e-lint` |
 
 `dev` is the integration branch, so a PR into it gets fast feedback from `test`
 alone; the full release bar applies on the way into `main`. The six
-`main`-only jobs are gated on `github.base_ref` and are skipped, not queued, on
-a `dev` PR.
+`main`-only jobs are gated on `github.base_ref == 'main'`, which GitHub
+populates for `pull_request` events only, **or** `github.ref ==
+'refs/heads/main'`, which covers the push of the merge commit. Neither is true
+on a `dev` PR, so they are skipped there — not queued. The second half of the
+gate is what makes `main`'s HEAD carry its own release-bar result: `main`'s
+ruleset is not strict, so the merge commit can differ from the tree the PR
+tested, and without it that commit would only ever have been checked by
+`test`.
 
 Toolchain versions come from `go.mod`, and the linter and scanner versions are
 pinned in the workflow's `env` block — bump them there, deliberately, rather


### PR DESCRIPTION
## Summary

`github.base_ref` is populated only for `pull_request` events, so the six release-bar jobs (`lint`, `image`, `shellcheck`, `gosec`, `govulncheck`, `e2e`) never ran on the `push:` trigger — including the merge commit that lands a PR on `main`. Since `main`'s ruleset is not strict, that commit can differ from the tree the PR tested, and it carried only the `test` result.

This takes option 1 from #53: encode the contract the workflow header already claimed, and run the release bar on `push` to `main` as well.

## Changes

- `.github/workflows/ci.yml`: each of the six gates becomes `if: github.base_ref == 'main' || github.ref == 'refs/heads/main'`, with a short comment on why both halves are needed. Header comment updated.
- `README.md`: CI table and the surrounding paragraph updated. The table also claimed `test` runs on pushes to `dev`, which the `push:` trigger (`branches: [main]`) never covered.

A PR into `dev` matches neither half of the condition, so the jobs are still skipped — not queued — on the fast integration bar.

The double-run note in #53 does not apply as written: `push` fires only on `main`, and the merge commit is a different SHA from the PR head, so there is no duplicated `test` run to deduplicate.

## Test plan

- [x] `ci.yml` parses and still declares all seven jobs
- [ ] This PR (into `dev`) shows `test` only — the six release-bar jobs skipped
- [ ] The next `dev` -> `main` release PR, and the push of its merge commit, both show all seven

Closes #53. Task 1 of Wave 4 in #60.