### PR TITLE
test: synchronize on observable state instead of sleeping

### DIFF
--- a/cmd/devmon-agent/main_test.go
+++ b/cmd/devmon-agent/main_test.go
@@ -62,6 +62,24 @@ func waitForRunAll(t *testing.T, ctx context.Context, components ...func(context
 	}
 }
 
+// waitForStartedCount polls started until it reaches want or deadline
+// elapses, so a test can synchronize on components actually having run
+// instead of sleeping a fixed amount of wall-clock time before cancelling.
+func waitForStartedCount(t *testing.T, started *atomic.Int32, want int32, deadline time.Duration) {
+	t.Helper()
+
+	giveUpAt := time.Now().Add(deadline)
+	for {
+		if got := started.Load(); got >= want {
+			return
+		}
+		if time.Now().After(giveUpAt) {
+			t.Fatalf("started count = %d after %s, want >= %d", started.Load(), deadline, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestRunAllReturnsNilOnCleanShutdown(t *testing.T) {
 	t.Parallel()
 
@@ -69,17 +87,27 @@ func TestRunAllReturnsNilOnCleanShutdown(t *testing.T) {
 	// as SIGTERM does in production.
 	var started atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
-
-	// Act
+	done := make(chan error, 1)
 	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
+		done <- runAll(ctx,
+			blockUntilCancelled(&started),
+			blockUntilCancelled(&started),
+			blockUntilCancelled(&started),
+		)
 	}()
-	err := waitForRunAll(t, ctx,
-		blockUntilCancelled(&started),
-		blockUntilCancelled(&started),
-		blockUntilCancelled(&started),
-	)
+
+	// Act — wait on the test's own goroutine (t.Fatal is unsafe from a
+	// spawned one) for all three components to have actually started before
+	// cancelling, rather than sleeping a fixed guess at how long that takes.
+	waitForStartedCount(t, &started, 3, 2*time.Second)
+	cancel()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(runAllTimeout):
+		t.Fatal("runAll did not return; the agent would hang instead of shutting down")
+	}
 
 	// Assert — context.Canceled is how a clean shutdown reaches these
 	// components. Surfacing it would make every SIGTERM exit non-zero and
@@ -164,14 +192,15 @@ func TestRunAllReportsFailureFromAnyPosition(t *testing.T) {
 func TestRunAllPrefersRealFailureOverCancellation(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — the failing component is last, so the cancellation errors from
-	// its siblings are drained first.
+	// Arrange — the failing component is last. Ordering here does not depend
+	// on wall-clock timing: runAll sends a component's error to the shared
+	// errs channel before its own deferred cancel() runs, and the other two
+	// components are blocked on <-ctx.Done() until some component calls
+	// cancel(). So slowFail's error is always queued before the siblings'
+	// cancellation errors can be, regardless of how quickly it returns.
 	wantErr := errors.New("the real cause")
 	var started atomic.Int32
-	slowFail := func(ctx context.Context) error {
-		time.Sleep(50 * time.Millisecond)
-		return wantErr
-	}
+	slowFail := func(context.Context) error { return wantErr }
 
 	// Act
 	err := waitForRunAll(t, context.Background(),

--- a/internal/httpapi/logs_test.go
+++ b/internal/httpapi/logs_test.go
@@ -689,6 +689,11 @@ func TestStreamKeepaliveIsRaceFree(t *testing.T) {
 				// Bounded, short sleep — not a wall-clock wait on the phase's
 				// real timings — giving the 2ms keepalive ticker room to race
 				// with this write on the shared underlying ResponseWriter.
+				// This is not a synchronization wait (issue #54): there is no
+				// observable signal to poll for here, since the goroutine
+				// under test writes into the same handler call this loop is
+				// blocking, and the assertion is race-freedom under `-race`,
+				// not any state this sleep could instead wait on.
 				time.Sleep(time.Millisecond)
 			}
 			return nil
@@ -729,7 +734,11 @@ func TestStreamKeepaliveGoroutineJoinedBeforeReturn(t *testing.T) {
 	fd := &fakeDocker{
 		streamContainerLogsFn: func(context.Context, string, dockerx.LogOptions, func(dockerx.LogLine) error) error {
 			// Return promptly while the 1ms keepalive ticker is still firing,
-			// so cancel() races the next tick.
+			// so cancel() races the next tick. Also not a synchronization
+			// wait (issue #54): the fake has no handle on the ticker or the
+			// ResponseWriter to poll, and the point of this sleep is to
+			// consume real wall-clock time so the ticker fires while the
+			// fake is still running.
 			time.Sleep(5 * time.Millisecond)
 			return nil
 		},
@@ -743,11 +752,19 @@ func TestStreamKeepaliveGoroutineJoinedBeforeReturn(t *testing.T) {
 	s.routes().ServeHTTP(rec, req)
 	lenAtReturn := rec.Body.Len()
 
-	// Assert — give any unjoined goroutine several tick intervals to write
-	// more before checking that nothing changed.
-	time.Sleep(20 * keepaliveInterval)
-	if got := rec.Body.Len(); got != lenAtReturn {
-		t.Errorf("body length grew from %d to %d after ServeHTTP returned; the keepalive goroutine was not joined", lenAtReturn, got)
+	// Assert — watch for several tick intervals rather than sleeping once
+	// and checking after the fact: this fails on the very first observed
+	// growth instead of only after the whole window has elapsed.
+	watchWindow := 20 * keepaliveInterval
+	giveUpAt := time.Now().Add(watchWindow)
+	for {
+		if got := rec.Body.Len(); got != lenAtReturn {
+			t.Fatalf("body length grew from %d to %d after ServeHTTP returned; the keepalive goroutine was not joined", lenAtReturn, got)
+		}
+		if time.Now().After(giveUpAt) {
+			return
+		}
+		time.Sleep(keepaliveInterval)
 	}
 }
 
@@ -778,16 +795,11 @@ func TestStreamGoroutineDoesNotLeak(t *testing.T) {
 	// Assert — a short settle loop rather than a bare sleep: the keepalive
 	// goroutine exits on ctx.Done(), which the scheduler may not have
 	// delivered the instant ServeHTTP returns.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if runtime.NumGoroutine() <= baseline {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("goroutine count = %d, want <= baseline %d", runtime.NumGoroutine(), baseline)
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitForCondition(t, 2*time.Second, 5*time.Millisecond,
+		func() bool { return runtime.NumGoroutine() <= baseline },
+		func() string {
+			return fmt.Sprintf("goroutine count = %d, want <= baseline %d", runtime.NumGoroutine(), baseline)
+		})
 }
 
 // TestLogRoutesRequireDevice asserts both log routes answer 401 with the

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -70,14 +70,17 @@ func runnableServer(t *testing.T, addr string) *Server {
 func TestRunShutsDownCleanly(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — port 0 lets the OS pick, so parallel tests never collide.
-	s := runnableServer(t, "127.0.0.1:0")
+	// Arrange — a known port, reserved and released up front, so parallel
+	// tests never collide and this test can dial it to confirm the listener
+	// has actually bound before cancelling.
+	addr := freeTCPAddr(t)
+	s := runnableServer(t, addr)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 
 	// Act
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(50 * time.Millisecond) // let the listener bind
+	waitForListening(t, addr, 2*time.Second)
 	cancel()
 
 	// Assert
@@ -245,7 +248,9 @@ func TestRunReturnsShutdownError(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(50 * time.Millisecond) // let the listener bind
+	// The listener has to be bound before this test can dial it. Poll for a
+	// successful connect instead of sleeping a fixed 50ms (issue #54).
+	waitForListening(t, addr, 2*time.Second)
 
 	// A raw TLS connection that completes the handshake but never finishes
 	// sending request headers: the server is still waiting to read, so the
@@ -405,7 +410,7 @@ func TestShutdownEndsLiveStreamPromptlyAndReturnsNil(t *testing.T) {
 	runCtx, cancelRun := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- s.Run(runCtx) }()
-	time.Sleep(50 * time.Millisecond) // let the listener bind
+	waitForListening(t, addr, 2*time.Second)
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{

--- a/internal/httpapi/testutil_test.go
+++ b/internal/httpapi/testutil_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// listenerDialTimeout bounds each individual dial attempt in
+// waitForListening, so a single hung attempt cannot stall the whole poll
+// loop until the overall deadline.
+const listenerDialTimeout = 100 * time.Millisecond
+
+// waitForListening dials addr in a short loop until a TCP connection
+// succeeds or deadline elapses, replacing a fixed "let the listener bind"
+// sleep with synchronization on the listener's actual, observable state.
+// A successful dial only proves the OS is accepting connections on addr; it
+// does not perform a TLS handshake.
+func waitForListening(t *testing.T, addr string, deadline time.Duration) {
+	t.Helper()
+
+	giveUpAt := time.Now().Add(deadline)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, listenerDialTimeout)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		if time.Now().After(giveUpAt) {
+			t.Fatalf("listener at %s never accepted a connection within %s: %v", addr, deadline, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// waitForCondition polls cond until it reports true or deadline elapses,
+// failing the test with the result of msg (evaluated only on timeout, so it
+// can report fresh state) on timeout. It replaces ad-hoc "sleep then check"
+// patterns with synchronization on the actual state under test.
+func waitForCondition(t *testing.T, deadline, pollInterval time.Duration, cond func() bool, msg func() string) {
+	t.Helper()
+
+	giveUpAt := time.Now().Add(deadline)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(giveUpAt) {
+			t.Fatal(msg())
+		}
+		time.Sleep(pollInterval)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -26,6 +26,29 @@ func testConfig(t *testing.T, totalMB int) config.Config {
 	}
 }
 
+// waitForGlobMatch polls pattern until it matches at least one file or
+// deadline elapses, so a test can synchronize on a background ticker's
+// observable effect (a rotated file appearing on disk) instead of sleeping
+// a fixed amount of wall-clock time.
+func waitForGlobMatch(t *testing.T, pattern string, deadline time.Duration) []string {
+	t.Helper()
+
+	giveUpAt := time.Now().Add(deadline)
+	for {
+		entries, err := filepath.Glob(pattern)
+		if err != nil {
+			t.Fatalf("glob %q: %v", pattern, err)
+		}
+		if len(entries) > 0 {
+			return entries
+		}
+		if time.Now().After(giveUpAt) {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestSinkPersistsAcrossReopen is the phase's crash-survival signal: lines
 // written by one process must still be readable after it dies and a new one
 // opens the same state mount.
@@ -237,19 +260,12 @@ func TestRotatorRunRotatesOnStartupWhenFileHasContent(t *testing.T) {
 	}()
 
 	// Assert
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		entries, _ := filepath.Glob(filepath.Join(cfg.LogsDir(), "agent-*"))
-		if len(entries) > 0 {
-			cancel()
-			<-done
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	entries := waitForGlobMatch(t, filepath.Join(cfg.LogsDir(), "agent-*"), 2*time.Second)
 	cancel()
 	<-done
-	t.Error("Run() never produced a rotated backup within the test window; the startup pass regressed")
+	if len(entries) == 0 {
+		t.Error("Run() never produced a rotated backup within the test window; the startup pass regressed")
+	}
 }
 
 // TestRotatorRunSkipsStartupRotationOnEmptyOrMissingFile guards against the
@@ -376,15 +392,9 @@ func TestRotatorRotatesOnTick(t *testing.T) {
 	}()
 
 	// Assert
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		entries, _ := filepath.Glob(filepath.Join(cfg.LogsDir(), "agent-*"))
-		if len(entries) > 0 {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	if entries := waitForGlobMatch(t, filepath.Join(cfg.LogsDir(), "agent-*"), 2*time.Second); len(entries) == 0 {
+		t.Error("ticker never produced a rotated file; age-based retention would never apply")
 	}
-	t.Error("ticker never produced a rotated file; age-based retention would never apply")
 }
 
 // TestRotateOnceLogsErrorWhenRotateFails covers rotateOnce's error branch.

--- a/internal/state/errors_test.go
+++ b/internal/state/errors_test.go
@@ -397,7 +397,7 @@ func TestPrunerRunTicksAndPrunes(t *testing.T) {
 
 	// Act
 	go func() { done <- p.Run(runCtx) }()
-	time.Sleep(50 * time.Millisecond) // let at least one tick fire
+	waitForRowCount(t, s, 0, 2*time.Second) // wait for the first tick to prune the stale row
 	cancel()
 
 	// Assert

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -36,6 +36,30 @@ func openStore(t *testing.T, path string) *Store {
 	return s
 }
 
+// waitForRowCount polls the audit table's row count until it equals want or
+// deadline elapses, so a test can synchronize on a background ticker's
+// observable effect (a pruned row) instead of sleeping a fixed multiple of
+// the ticker's interval.
+func waitForRowCount(t *testing.T, s *Store, want int, deadline time.Duration) {
+	t.Helper()
+
+	ctx := context.Background()
+	giveUpAt := time.Now().Add(deadline)
+	for {
+		var got int
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit`).Scan(&got); err != nil {
+			t.Fatalf("count audit rows: %v", err)
+		}
+		if got == want {
+			return
+		}
+		if time.Now().After(giveUpAt) {
+			t.Fatalf("audit row count = %d after %s, want %d", got, deadline, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestOpenFirstRunCreatesSchema(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Replaces wall-clock sleeps in the always-run `-race` suite with synchronization on the condition each test actually waits for. Under `-race` on shared CI runners execution is 5-20x slower, which is exactly where fixed sleeps lose. Nothing was failing because of these; this is preventive. Test-only — no production code changed.

## Changes

- **`internal/httpapi/testutil_test.go`** (new): `waitForListening` (dial-until-connect with a deadline) and `waitForCondition` (poll-until-true with a lazily-built failure message).
- **`internal/httpapi/server_test.go`**: the three `time.Sleep(50ms) // let the listener bind` sites now dial until the listener answers. `TestRunShutsDownCleanly` moved from `":0"` to `freeTCPAddr(t)` so it has an address to dial.
- **`internal/httpapi/logs_test.go`**: `time.Sleep(20 * keepaliveInterval)` became a poll over the same window that fails on the first observed growth rather than only after the window elapses; the existing ad-hoc deadline loop moved onto the shared helper.
- **`internal/state`**: the pruner's "let at least one tick fire" sleep became `waitForRowCount`, polling the audit table until the tick's effect lands.
- **`internal/logging`**: the two glob-poll loops moved onto a shared `waitForGlobMatch` helper (they were already deadline-based; this is DRY, not a behavior change).
- **`cmd/devmon-agent/main_test.go`**: the readiness sleep became a poll on the started counter, with the wait moved onto the test's own goroutine — `t.Fatal` from a spawned goroutine marks the test failed without halting it, so the original shape could not safely host a failing wait. The `slowFail` sleep is deleted: `runAll` sends a component's error to the shared channel *before* its deferred `cancel()` runs, so that ordering never depended on timing.

## Two sleeps deliberately kept

`logs_test.go:692` and `:733` stay, now with comments saying why. Both sit inside a synchronous `ServeHTTP` call — the test's own goroutine is blocked in the handler, so there is no observable state to poll from outside — and their purpose is to consume real wall-clock time so a concurrent keepalive ticker races the write while `-race` watches. They are not synchronization waits, so there is no condition to replace them with, short of adding a production callback seam that would not be worth it.

## Known flake, filed separately

`TestRunReturnsShutdownError` keeps its pre-existing shape apart from the listener wait. It flakes ~10% under `-race`, predates this work, and has a different root cause — the half-open-connection premise looks stale after #41's lifecycle-context cancellation. Full evidence and the open design question are in #72. Reworking it here would have meant deciding what shutdown semantics the test should assert, which is out of scope for a sleep-removal change.

## Test plan

- [x] `gofmt -l` on the touched files — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/... ./cmd/... -race -count=2` — green
- [x] coverage over `./internal/...` — 95.3%, floor is 90%
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gosec ./...` — 0 issues
- [ ] CI `test` job green

Closes #54. Task 2 of Wave 4 in #60 — completes the wave.