### PR TITLE
fix: refuse commits on dev in the git-commit skill

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -36,13 +36,18 @@ git branch --show-current
 
 ### 2. Branch check
 
-If the current branch is `main`, **stop and create a feature branch first**:
+If the current branch is `main` **or `dev`**, **stop and create a feature branch
+first**, cut from `dev`:
 
 ```bash
+git checkout dev && git pull
 git checkout -b <type>/<short-kebab-description>
 ```
 
-Never commit directly to `main`.
+Never commit directly to `main` or `dev`. Both are protected: `main` is
+production/release and `dev` is the integration branch, and every change reaches
+either one through a PR. See `CLAUDE.md` and
+`.claude/rules/ecc/common/git-workflow.md` for the full branching model.
 
 ### 3. Quality gates (Go project)
 


### PR DESCRIPTION
## Summary

`.claude/skills/git-commit/SKILL.md`'s branch check only refused `main`, so the skill would have committed directly onto `dev` — the exact thing the repo forbids in three places (`CLAUDE.md`, `CONTRIBUTING.md`, `.claude/rules/ecc/common/git-workflow.md`).

## Changes

- The guard now stops on `main` **or** `dev`.
- The remediation snippet cuts the feature branch from an up-to-date `dev` (`git checkout dev && git pull` first) rather than from wherever HEAD happens to be — branching off a stale or unrelated HEAD was the other way this step could go wrong.
- Added a line saying why both branches are protected, with a pointer to the full branching model.

Documentation-only; no gates apply. `main` appears nowhere else in the skill, so there is no second copy of the rule to keep in sync.

Closes #57. Wave 5 of #60.