### PR TITLE
docs: correct minor inaccuracies across README, CLAUDE.md, and reports

### DIFF
--- a/.claude/PRPs/reports/client-independent-e2e-report.md
+++ b/.claude/PRPs/reports/client-independent-e2e-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Client-Independent End-to-End Suite (Phase 6)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 ## Summary
 
 The manual validation checklists of Phases 1-5 are now code. `internal/e2e/` holds a

--- a/.claude/PRPs/reports/hardening-and-oss-release-report.md
+++ b/.claude/PRPs/reports/hardening-and-oss-release-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Hardening & OSS Release (Phase 7)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 **Plan**: [hardening-and-oss-release.plan.md](../plans/completed/hardening-and-oss-release.plan.md)
 **Branch**: `feat/hardening-and-oss-release`
 **Baseline**: `14b1804` (Phase 6 merge) → `854251a`

--- a/.claude/PRPs/reports/identity-pairing-and-revocation-report.md
+++ b/.claude/PRPs/reports/identity-pairing-and-revocation-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Identity, Pairing & Revocation (PRD Phase 2)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 ## Summary
 
 The agent is now its own certificate authority and authenticates every guarded

--- a/.claude/PRPs/reports/lifecycle-policy-and-audit-report.md
+++ b/.claude/PRPs/reports/lifecycle-policy-and-audit-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Lifecycle, Policy & Audit (Phase 5)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 ## Summary
 
 A paired device can now act. Five lifecycle routes — start, restart, stop, kill, delete —

--- a/.claude/PRPs/reports/logs-and-live-streaming-report.md
+++ b/.claude/PRPs/reports/logs-and-live-streaming-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Logs & Live Streaming (Phase 4)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 ## Summary
 
 A paired device can now read a container's output two ways: a bounded historical fetch that

--- a/.claude/PRPs/reports/read-operations-report.md
+++ b/.claude/PRPs/reports/read-operations-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Read Operations (Phase 3)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 ## Summary
 
 Eight mTLS-guarded `GET` routes give a paired device full read visibility into the host's

--- a/.claude/PRPs/reports/secure-foundation-and-persistence-report.md
+++ b/.claude/PRPs/reports/secure-foundation-and-persistence-report.md
@@ -1,5 +1,9 @@
 # Implementation Report: Secure Foundation & Persistence (Phase 1)
 
+> **Historical record.** Figures, thresholds, and release status below describe the
+> repo as it stood when this phase shipped, and are deliberately not updated in
+> place. Most visibly, the coverage floor was 80% at the time and is 90% today.
+
 ## Summary
 
 The DevMon agent now runs as a container. It parses and validates its entire

--- a/.claude/agents/go-implementer.md
+++ b/.claude/agents/go-implementer.md
@@ -10,7 +10,8 @@ planner: the plan is the contract, not a suggestion.
 
 ## Before writing code
 
-1. Read the task in `.claude/PRPs/plans/<phase>.plan.md` **and** the plan's `Patterns to
+1. Read the task in `.claude/PRPs/plans/<phase>.plan.md` (completed phases live under
+   `.claude/PRPs/plans/completed/`) **and** the plan's `Patterns to
    Mirror`, `Files to Change`, and `NOT Building` sections.
 2. Read the existing packages the task touches. Match their naming, error wrapping, logging,
    and test structure — consistency with this repo beats generic Go style.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,8 @@ First public release — the full surface.
 - **Audit.** Every mutating attempt recorded and attributed to the calling
   device, including the ones policy refused. The audit table outlives the
   operational log.
-- **Rate limiting.** Two tiers on the listening port.
+- **Rate limiting.** Two pre-authentication tiers on the listening port, plus a
+  per-device tier behind the handshake and a global backstop.
 - **Installer.** `install.sh` takes a clean host to a printed pairing code:
   resolving the docker socket GID, creating and chowning the state directory,
   writing a `compose.yaml`, and waiting for the agent to answer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,9 @@ covers. It does not become a file in the repository.
 ## Planning docs
 
 - PRD: `.claude/PRPs/prds/devmon-agent.prd.md` — scope, decisions log, phase table
-- Plans: `.claude/PRPs/plans/*.plan.md` — one per phase; the plan is the implementation contract
+- Plans: `.claude/PRPs/plans/*.plan.md` — one per phase; the plan is the implementation
+  contract. Every phase shipped so far has moved to `.claude/PRPs/plans/completed/`, so
+  that is where the current examples live; an in-flight plan sits in `plans/` itself.
 
 Read the current phase's plan before writing code. It carries verified upstream API
 signatures and the gotchas above with full rationale.

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,6 @@ e2e-container:
 e2e-endurance:
 	DEVMON_E2E_ENDURANCE=1 CGO_ENABLED=1 go test -tags e2e ./internal/e2e/api/... $(E2E_TESTFLAGS) -timeout 45m
 
-# `make lint` already covers the e2e files with gofmt, which ignores build tags.
-# go vet and golangci-lint do not, which is the only reason this target exists.
-# Do not fold `--build-tags e2e` into `lint`: it would pull the e2e packages into
-# every ordinary lint run and slow the fast dev-PR path for no benefit.
 # Removes containers a run that crashed hard enough to skip its own t.Cleanup
 # left behind. Deliberately an EXPLICIT operator action and never automatic:
 # the label matches every run's containers, so an implicit version could not
@@ -133,6 +129,10 @@ e2e-clean:
 		echo "no com.devmon.e2e containers to remove"; \
 	fi
 
+# `make lint` already covers the e2e files with gofmt, which ignores build tags.
+# go vet and golangci-lint do not, which is the only reason this target exists.
+# Do not fold `--build-tags e2e` into `lint`: it would pull the e2e packages into
+# every ordinary lint run and slow the fast dev-PR path for no benefit.
 e2e-lint:
 	go vet -tags e2e ./...
 	@if command -v golangci-lint >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ read historical logs and follow a live stream; and start, restart, stop, kill
 and delete containers — as far as the host's startup policy mode permits, and
 never against the agent's own container. Every mutating attempt is recorded in
 an audit table that outlives the operational log. The listening port is rate
-limited in two tiers, and an executable contract suite runs the real binary
-against a real Docker Engine.
+limited in two pre-authentication tiers, plus a per-device tier behind the
+handshake and a global backstop, and an executable contract suite runs the real
+binary against a real Docker Engine.
 
 License: [AGPL-3.0-only](LICENSE). Changes by version: [CHANGELOG.md](CHANGELOG.md).
 
@@ -71,8 +72,9 @@ docker run -d --name devmon-agent \
   ghcr.io/scnplt/devmon-agent:0.2.0
 ```
 
-See `compose.example.yaml` for the equivalent Compose file and a reference for
-every configuration knob.
+See `compose.example.yaml` for the equivalent Compose file. It carries the knobs
+worth setting by hand, not all of them — the full list is the environment table
+below.
 
 Verify it is up:
 
@@ -193,7 +195,7 @@ file, or signal that can widen what was granted here.
 | `DEVMON_PUBLIC_ADDR` | comma list | *(required)* | ≥1 entry; each a DNS name or IP; used as server-certificate SANs |
 | `DEVMON_POLICY_MODE` | enum | `default` | One of `read-only`, `default`, `full` |
 | `DEVMON_DOCKER_HOST` | URL | `unix:///var/run/docker.sock` | Scheme `unix` or `tcp` |
-| `DEVMON_SELF_CONTAINER` | name or ID | *(auto-detected)* | A Docker container name, or a 12/64-character hex ID |
+| `DEVMON_SELF_CONTAINER` | name or ID | *(auto-detected)* | Docker's own name grammar: `[a-zA-Z0-9][a-zA-Z0-9_.-]+` (two characters or more). Hex container IDs satisfy it too |
 | `DEVMON_LOG_LEVEL` | enum | `info` | One of `debug`, `info`, `warn`, `error` |
 | `DEVMON_LOG_MAX_AGE_DAYS` | int | `1` | ≥1 |
 | `DEVMON_LOG_MAX_TOTAL_MB` | int | `64` | ≥8 |
@@ -776,7 +778,7 @@ cover up. Host access is the authority here, exactly as it is for revocation.
 make build          # -> bin/devmon-agent
 make test           # unit tests
 make test-race      # with -race (needs a C toolchain)
-make cover          # coverage; the floor is 90% over ./internal/...
+make cover          # prints total coverage over ./internal/...; CI enforces the 90% floor
 make lint           # gofmt + go vet + golangci-lint when installed
 make sec            # gosec
 make image          # docker build

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,7 +287,7 @@ func (l *loader) selfContainer() string {
 		return ""
 	}
 	if !containerRefPattern.MatchString(ref) {
-		l.fail(envSelfContainer, "%q is not a valid container name or ID (want a container name or a 12/64-character hex ID)", ref)
+		l.fail(envSelfContainer, "%q is not a valid container name or ID (want two or more characters matching [a-zA-Z0-9][a-zA-Z0-9_.-])", ref)
 	}
 	return ref
 }


### PR DESCRIPTION
## Summary

The seven grouped findings from #51. All documentation, plus one error-message reword. No behavior changes.

| # | Finding | Fix |
|---|---|---|
| 1 | README/CHANGELOG: "rate limited in two tiers" contradicts the three-tier table plus the global backstop below it | Both now say two **pre-authentication** tiers and name the per-device tier and backstop |
| 2 | `CLAUDE.md` and `go-implementer.md` point at `plans/*.plan.md`, but every shipped phase is in `plans/completed/` | Both say where completed plans live; an in-flight plan still sits in `plans/` |
| 3 | Phase reports state the 80% floor in present tense; one says v0.1.0 is unpublished | A one-line historical-record banner per report, rather than rewriting the records |
| 4 | `DEVMON_SELF_CONTAINER` documented as "a container name, or a 12/64-character hex ID" | Doc and error string now describe what the pattern checks |
| 5 | README implies `make cover` enforces the floor | Reworded; notes CI is where the gate lives |
| 6 | `compose.example.yaml` called "a reference for every configuration knob" — it has 8 of 14 | Reworded; points at the environment table |
| 7 | The `e2e-lint` rationale comment sits above `e2e-clean` | Moved onto `e2e-lint` |

## On item 4

The issue asked to fix the doc, the regex, or both, after deciding the contract. **The pattern is correct as written and is unchanged.** `^[a-zA-Z0-9][a-zA-Z0-9_.-]+$` is Docker's own container-name grammar, which itself requires two characters or more — so rejecting a 1-character name is not a bug, it matches what the Engine would reject anyway. Hex IDs satisfy it as a byproduct, exactly as the code comment at `config.go:91-95` already says. What was wrong was the documentation and the error message, both of which promised hex/length checks that no code performs.

`internal/config/config.go:290` is the one non-doc line in the diff — an error string. No test asserts on its text.

## Test plan

- [x] `gofmt -l internal/config/config.go` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/... -race` — green, coverage 95.3%
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gosec ./...` — 0 issues
- [ ] CI `test` job green

Closes #51. Wave 5 of #60.