### PR TITLE
chore: stop tracking planning documents and drop their references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
 
       # DEVMON_E2E_REQUIRE turns "no Engine answered, skipping" from a silent
       # green into a hard failure. A suite that quietly does nothing is worse
-      # than no suite, because a green run is what flips a PRD row.
+      # than no suite, because a green run is what marks the phase done.
       - name: make e2e
         env:
           DEVMON_E2E_REQUIRE: 1

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@
 coverage.out
 .env
 
-# Review write-ups are ephemeral working notes. Reviews are delivered in the
-# session or as PR comments, never committed.
-.claude/PRPs/reviews/
+# Planning artifacts (PRDs, phase plans, reports) and review write-ups are local
+# working notes. Reviews are delivered in the session or as PR comments.
+.claude/PRPs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,14 +113,17 @@ Never add a client-facing way to change policy mode or retention.
 delivered where it is read: in the session for local work, or as a comment on the PR it
 covers. It does not become a file in the repository.
 
-- Do not create `.claude/PRPs/reviews/` or any other committed review write-up. The path is
-  gitignored; if a scratch copy helps, write it to the session scratchpad instead.
+- Do not create `.claude/PRPs/reviews/` or any other committed review write-up. If a scratch
+  copy helps, write it to the session scratchpad instead.
 - A plan task that calls for a review means "perform it and report the verdict", never
   "produce a review document to commit".
-- Reports (`.claude/PRPs/reports/*.md`) still land in the repo — they record what a phase
-  shipped, not what a reviewer said.
+- Reports (`.claude/PRPs/reports/*.md`) are still written — they record what a phase shipped,
+  not what a reviewer said — but like the rest of `.claude/PRPs/` they stay local.
 
 ## Planning docs
+
+All of `.claude/PRPs/` is gitignored — these are local working documents, not repository
+content. They exist in the working tree but are never committed.
 
 - PRD: `.claude/PRPs/prds/devmon-agent.prd.md` — scope, decisions log, phase table
 - Plans: `.claude/PRPs/plans/*.plan.md` — one per phase; the plan is the implementation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,9 @@ suggests. Most of what follows is about making that bar cheap to clear.
 **Security issues do not go here.** See [SECURITY.md](SECURITY.md) and report
 privately.
 
-For anything else, open an issue first if the change is more than a fix. The
-project follows a written PRD and phase plans (`.claude/PRPs/`), and a feature
-that is deliberately out of scope is usually recorded there with the reasoning
-— it saves you writing something that will be declined on principle.
+For anything else, open an issue first if the change is more than a fix. Some
+features are deliberately out of scope, and asking first saves you writing
+something that will be declined on principle.
 
 ## Language
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -9,10 +9,9 @@ cannot be traced to a line of code, it does not appear — see
 [`CONTRIBUTING.md`](../CONTRIBUTING.md) if you find one that no longer
 resolves.
 
-This document does not contradict [`README.md`](../README.md) or the
-[PRD](../.claude/PRPs/prds/devmon-agent.prd.md). Where the README already
-states a security property, this document repeats its wording rather than
-rephrasing it.
+This document does not contradict [`README.md`](../README.md). Where the
+README already states a security property, this document repeats its wording
+rather than rephrasing it.
 
 ---
 
@@ -283,11 +282,10 @@ substance, because the two documents describe the same boundary:
 >
 > — [`README.md:331-340`](../README.md)
 
-The PRD records this as an accepted risk rather than a defect: "CA private key
-readable in host backups and VPS snapshots" is Likelihood M, mitigated by
-"restrictive file permissions" with encryption revisited "only if a credible
-unlocking mechanism exists"
-([`.claude/PRPs/prds/devmon-agent.prd.md:184`](../.claude/PRPs/prds/devmon-agent.prd.md)).
+This is an accepted risk rather than a defect. A CA private key readable in
+host backups and VPS snapshots is judged medium likelihood and mitigated by
+restrictive file permissions; encryption at rest will be revisited only if a
+credible unlocking mechanism exists.
 
 **No RBAC — every paired device has the same powers.** Policy is a single
 mode fixed for the whole install, not a per-device grant: `requireOp` checks
@@ -297,20 +295,18 @@ The README states the same property from the operator's side: "The mode is
 fixed at startup and read once. No client can widen it... Changing the mode
 means changing `DEVMON_POLICY_MODE` on the host and restarting the agent."
 ([`README.md:203-206`](../README.md)). A general operator-defined per-device
-permission set is out of scope for this release
-([`.claude/PRPs/prds/devmon-agent.prd.md:164`](../.claude/PRPs/prds/devmon-agent.prd.md)).
+permission set is out of scope for this release.
 
 **Root-equivalent blast radius if the agent is compromised.** From
 `SECURITY.md`: "Anything that can drive its API can start, stop, and delete
 containers on the host, and — through Docker — reach root-equivalent power
 over that host. A vulnerability here is not a 'container management bug'; it
 is a host compromise."
-([`SECURITY.md:5-8`](../SECURITY.md)). The PRD's Technical Risks table records
-the same as the first row: "Agent compromise equals host root compromise
-(Docker socket access is root-equivalent)," mitigated by "narrow enumerated
-API surface rather than a socket proxy; mTLS with per-device credentials;
-audit logging; treat security review as a release gate"
-([`.claude/PRPs/prds/devmon-agent.prd.md:178`](../.claude/PRPs/prds/devmon-agent.prd.md)).
+([`SECURITY.md:5-8`](../SECURITY.md)). This is the project's first-ranked
+technical risk — agent compromise equals host root compromise, because Docker
+socket access is root-equivalent — and it is mitigated by a narrow enumerated
+API surface rather than a socket proxy, mTLS with per-device credentials,
+audit logging, and treating security review as a release gate.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func (c Config) AgentLogPath() string { return filepath.Join(c.LogsDir(), "agent
 //
 // It aggregates rather than failing on the first fault: an operator correcting a
 // `docker run` line one variable at a time, one restart at a time, is a bad first
-// experience and the exact thing the PRD asks this package to avoid.
+// experience and the exact thing this package exists to avoid.
 type ValidationError struct{ Problems []string }
 
 func (e *ValidationError) Error() string {
@@ -335,7 +335,7 @@ func (l *loader) boundedInt(key string, def, min int) int {
 	return n
 }
 
-// checkRetentionOrder enforces the PRD's separate-retention-budgets rule: the
+// checkRetentionOrder enforces the separate-retention-budgets rule: the
 // security record must outlive debug output. One shared short budget would
 // quietly destroy the audit trail to make room for operational logs.
 func (l *loader) checkRetentionOrder(cfg Config) {

--- a/internal/dockerx/logs.go
+++ b/internal/dockerx/logs.go
@@ -165,8 +165,8 @@ func (c *Client) StreamContainerLogs(ctx context.Context, ref string, opts LogOp
 	// No callTimeout here, deliberately: it bounds the pre-stream inspect
 	// above and the historical fetch in ContainerLogs only. A 15s timeout on
 	// this call would kill every stream at 15 seconds — the stream's lifetime
-	// is bounded by ctx and nothing else, and the PRD's success signal is a
-	// 30-minute stream.
+	// is bounded by ctx and nothing else, and the success signal for this
+	// route is a 30-minute stream.
 	res, err := c.api.ContainerLogs(ctx, ref, engineOpts)
 	if err != nil {
 		return classify("stream container logs", err)

--- a/internal/e2e/api/contract_audit_test.go
+++ b/internal/e2e/api/contract_audit_test.go
@@ -19,9 +19,8 @@ import (
 // log is deliberately unreachable over the HTTPS API, so this file drives
 // every assertion through harness.ListAudit, never SQLite and never a route
 // this agent does not register).
-// lifecycle-policy-and-audit.plan.md:1086-1126, specifically the "audit list
-// shows one row per attempt..." and "revoke the device... audit list gains
-// no row" checklist items.
+// It covers specifically the "audit list shows one row per attempt..." and
+// "revoke the device... audit list gains no row" checklist items.
 //
 // What this file deliberately does NOT cover: the exact HTTP status per
 // operation is contract_lifecycle_test.go and contract_policy_test.go's job;
@@ -125,8 +124,8 @@ func TestAuditRowPerMutatingRequest(t *testing.T) {
 	}
 }
 
-// TestAuditRecordsRefusals is the PRD's explicit requirement stated on its
-// own: a call the host's policy refuses still leaves a row, with outcome
+// TestAuditRecordsRefusals states one explicit requirement on its own: a
+// call the host's policy refuses still leaves a row, with outcome
 // denied_policy, not silence. TestAuditRowPerMutatingRequest already proves
 // this as one cell of a sequence; this test isolates it so a reader searching
 // for "does a refusal get logged" finds a single, minimal answer.
@@ -159,8 +158,8 @@ func TestAuditRecordsRefusals(t *testing.T) {
 
 // TestReadsWriteNoAuditRows drives all eight read routes and both log routes
 // against a freshly started agent, then asserts the audit table is still
-// empty: only mutating routes carry withAudit
-// (lifecycle-policy-and-audit.plan.md D17), and a suite that never checked
+// empty: only mutating routes carry withAudit (D17), and a suite that never
+// checked
 // this would not notice a future route accidentally gaining the middleware.
 func TestReadsWriteNoAuditRows(t *testing.T) {
 	t.Parallel()

--- a/internal/e2e/api/contract_endurance_test.go
+++ b/internal/e2e/api/contract_endurance_test.go
@@ -23,11 +23,11 @@ import (
 // weekly is code that rots. `make e2e-endurance` sets the variable and the
 // longer -timeout (45m) both tests need room inside.
 //
-// TestStreamEnduranceThirtyMinutes closes the PRD's Phase 4 success signal:
-// logs-and-live-streaming-report.md:178-190 records that only a 70-second run
-// was ever performed against a real host, proving the write-deadline fix but
-// not the 30-minute claim itself. TestLogRetentionBoundsDiskUse closes the
-// PRD's Phase 1 retention signal: that the agent's own log volume stays
+// TestStreamEnduranceThirtyMinutes closes Phase 4's success signal: only a
+// 70-second run was ever performed against a real host, proving the
+// write-deadline fix but not the 30-minute claim itself.
+// TestLogRetentionBoundsDiskUse closes Phase 1's retention signal: that the
+// agent's own log volume stays
 // bounded by DEVMON_LOG_MAX_TOTAL_MB rather than growing without limit, and
 // that this bound is enforced with no client-facing way to change it — every
 // knob here is a DEVMON_* startup variable read once by the agent process,
@@ -56,15 +56,15 @@ func requireEndurance(t *testing.T) {
 }
 
 // enduranceLogLinesCmd writes one numbered line per second, forever — the
-// PRD's 30-minute stream needs a fixture that keeps producing for the whole
+// 30-minute stream needs a fixture that keeps producing for the whole
 // window without racing its own startup the way logLinesCmd's 0.2s interval
 // (contract_logs_test.go) would at this scale.
 var enduranceLogLinesCmd = []string{"sh", "-c", `i=0; while true; do echo "line $i"; i=$((i+1)); sleep 1; done`}
 
 // TestStreamEnduranceThirtyMinutes holds a single live log stream open for 30
 // minutes against a fixture writing one line per second, and asserts every
-// line arrived, in order, with no gap and no reconnect — the PRD's Phase 4
-// success signal that logs-and-live-streaming-report.md left unticked.
+// line arrived, in order, with no gap and no reconnect — Phase 4's success
+// signal, which no earlier run ticked.
 //
 // The sequence is tracked by the fixture's own printed counter (decoded out
 // of each frame's data.line field), never by wall-clock arithmetic: a
@@ -180,7 +180,7 @@ const retentionBudgetMB = 8
 // DEVMON_LOG_LEVEL=debug to force the agent's own log file to rotate more
 // than once, then asserts the logs directory stays within a generous
 // headroom of its configured budget and that compressed backups exist —
-// the PRD's Phase 1 retention success signal, and proof that retention is
+// Phase 1's retention success signal, and proof that retention is
 // enforced with no client-facing knob: DEVMON_LOG_MAX_TOTAL_MB is read once
 // at agent startup (internal/config), and nothing this suite's mTLS client
 // can reach changes it afterward.

--- a/internal/e2e/api/contract_identity_test.go
+++ b/internal/e2e/api/contract_identity_test.go
@@ -24,12 +24,11 @@ import (
 // revocation, self-unpair under every policy mode, renewal keeping the old
 // certificate usable, and the two diagnostic signals a client uses to tell
 // "my code was already used" from "the server's identity changed under me".
-// identity-pairing-and-revocation.plan.md:908-922.
 //
 // What this file deliberately does NOT cover: the *timing* of proactive
 // renewal (renewing before expiry with no user interaction) and a genuinely
 // expired client certificate diagnosing itself — both are named client-side
-// in the phase plan's Coverage Map, because producing them needs a real
+// as client-side coverage, because producing them needs a real
 // wall-clock wait or a shortened certificate lifetime, and D19 forbids the
 // latter.
 

--- a/internal/e2e/api/contract_lifecycle_test.go
+++ b/internal/e2e/api/contract_lifecycle_test.go
@@ -19,13 +19,13 @@ import (
 // idempotent start, kill refused, delete refused in default mode; then, in
 // full mode, delete-while-running conflicts, stop, then delete succeeds — plus
 // the invalid/unknown-reference, Engine-unavailable, and wrong-method cells
-// of the same checklist. lifecycle-policy-and-audit.plan.md:1086-1126.
+// of the same checklist.
 //
 // What this file deliberately does NOT cover: the three-mode × operation
 // matrix lives in contract_policy_test.go, one row of which
 // (TestDeleteRunningContainerConflicts here) it deliberately does not repeat;
 // the audit trail these same requests leave behind is contract_audit_test.go
-// (Task 8); and the self-exclusion guarantee — the PRD's headline metric —
+// (Task 8); and the self-exclusion guarantee — the headline metric —
 // needs a containerised agent and lives in internal/e2e/incontainer
 // (Tasks 9-11).
 
@@ -66,7 +66,7 @@ func waitContainerRunning(t *testing.T, engine *client.Client, id string) {
 // TestLifecycleHappyPath reproduces the default-mode half of the curl script
 // verbatim: restart, stop, start, a second (idempotent) start, kill refused,
 // delete refused — against a DEFAULT-mode agent started with
-// DEVMON_POLICY_MODE absent, not set to "default": the PRD metric is about
+// DEVMON_POLICY_MODE absent, not set to "default": the metric is about
 // the operator who configures nothing, and setting the variable would test a
 // different claim (Task 7's gotcha; the explicit value is covered by
 // TestPolicyMatrix's "default" row in contract_policy_test.go).

--- a/internal/e2e/api/contract_logs_test.go
+++ b/internal/e2e/api/contract_logs_test.go
@@ -16,9 +16,8 @@ import (
 	"github.com/scnplt/devmon-agent/internal/e2e/harness"
 )
 
-// This file replays Phase 4's outstanding half — the two items
-// logs-and-live-streaming-report.md:178-190 left unverified against a real
-// host: the 30-minute endurance run (owned by Task 12's
+// This file replays Phase 4's outstanding half — the two items left
+// unverified against a real host: the 30-minute endurance run (owned by Task 12's
 // contract_endurance_test.go, gated by DEVMON_E2E_ENDURANCE per D14 — no
 // long-running test belongs here) and the Wi-Fi <-> mobile-data handover's
 // agent-side half. That half is two properties an app's reconnect logic
@@ -26,14 +25,14 @@ import (
 // cleanly after an RST (D15), and ?since=<last id> resumes with at most one
 // repeated line, never a gap. The client half — actually performing a
 // network handover — is named as belonging to the client app's own suite
-// (the phase plan's Coverage Map).
+// (it belongs to the client app's own suite).
 //
 // It also covers the historical log route's bounds (?tail=, ?since=) and the
 // stream route's keepalive and slot-exhaustion behaviour, none of which had
 // an owner outside this file.
 //
-// What this file deliberately does NOT assert: logs-and-live-streaming-report.md
-// records that an abandoned stream logs at ERROR in agent.log. That is a
+// What this file deliberately does NOT assert: an abandoned stream logs at
+// ERROR in agent.log. That is a
 // known, recorded, unfixed observation (D19 — no production code changes in
 // this phase); asserting its absence would make the eventual fix look like a
 // regression, so it is left alone.
@@ -111,7 +110,7 @@ func collectFrames(t *testing.T, s *harness.Stream, n int, deadline time.Duratio
 // TestHistoricalLogsBounded asserts ?tail=20 against a fixture producing far
 // more than 20 lines returns exactly 20 items, truncated: false, and every
 // item carries the documented ts/stream/line keys (Timestamp extracted into
-// its own field, as the phase plan's Coverage Map requires).
+// its own field, as the documented contract requires).
 func TestHistoricalLogsBounded(t *testing.T) {
 	t.Parallel()
 	engine := harness.RequireEngine(t)

--- a/internal/e2e/api/contract_policy_test.go
+++ b/internal/e2e/api/contract_policy_test.go
@@ -15,8 +15,7 @@ import (
 // three named tiers (read-only, default, full) each answer a fixed status
 // per lifecycle operation, and reads/logs stay at 200 regardless of tier —
 // read-only restricts mutation, never visibility.
-// lifecycle-policy-and-audit.plan.md:1086-1126, and specifically the two
-// checklist rows "Start the agent with DEVMON_POLICY_MODE=read-only; all
+// It covers specifically the two checklist rows "Start the agent with DEVMON_POLICY_MODE=read-only; all
 // five routes answer 403 and reads still answer 200" and "Start with
 // DEVMON_POLICY_MODE unset; restart/stop/start work, kill/delete are
 // refused".
@@ -182,6 +181,6 @@ func TestPolicyMatrix(t *testing.T) {
 // "false", already asserted (both list and inspect projections) by
 // TestContainerReadContractKeys in contract_reads_test.go — repeating an
 // identical assertion in this file would add no falsifiability. The value
-// this field takes for the agent's OWN row ("true", the PRD's headline
+// this field takes for the agent's OWN row ("true", the headline
 // signal) needs a containerised agent to observe at all and is
 // TestAgentRowIsMarkedProtected, internal/e2e/incontainer, Task 10.

--- a/internal/e2e/api/contract_ratelimit_test.go
+++ b/internal/e2e/api/contract_ratelimit_test.go
@@ -18,7 +18,6 @@ import (
 // two pre-authentication tiers (status, pair), the per-device guarded tier
 // (D6), recovery once Retry-After elapses, and the audit-table property D7
 // exists for — a throttled call writes no row.
-// hardening-and-oss-release.plan.md's "Rate-Limiting Contract" section.
 //
 // Every test in this file starts its own agent: the three DEVMON_RATE_*
 // variables are startup configuration, so sharing an agent across cases

--- a/internal/e2e/api/contract_reads_test.go
+++ b/internal/e2e/api/contract_reads_test.go
@@ -26,7 +26,6 @@ import (
 // projections, freshness with no caching layer, invalid and unknown
 // references, the Engine-unavailable 502 path with recovery (D16's proxy),
 // and read-only mode permitting every one of them.
-// read-operations.plan.md:894-907.
 //
 // What this file deliberately does NOT cover: revocation losing read access
 // is TestRevokedDeviceLosesAccessImmediately in contract_identity_test.go —
@@ -50,7 +49,7 @@ const readContractTimeout = 30 * time.Second
 // PERMITTED superset, never promised: a container with no healthcheck omits
 // "health" entirely, one with a healthcheck does not. Writing down which list
 // is which, rather than asserting one blanket set, is itself part of the
-// contract a client needs (Task 5's gotcha in the phase plan).
+// contract a client needs.
 func assertKeySet(t *testing.T, obj map[string]any, required, optional []string) {
 	t.Helper()
 
@@ -439,8 +438,7 @@ func TestReadsAreNotCached(t *testing.T) {
 // Engine) and 404 for a well-formed but nonexistent one.
 //
 // The invalid-ref probes are percent-encoded ("%2e%2e", not a literal ".."),
-// mirroring what Phase 3's manual validation confirmed
-// (read-operations-report.md's End-to-End Validation section): a literal
+// mirroring what Phase 3's manual validation confirmed: a literal
 // ".." in the request path is collapsed by net/http.ServeMux's own path
 // cleaning BEFORE the pattern ever matches, which answers with a redirect,
 // not the documented 400 — a probe that never reaches this agent's own
@@ -599,8 +597,7 @@ func TestReadsAnswer502WhenEngineIsGone(t *testing.T) {
 // r.URL.Path verbatim (method/path/status/duration only), and a read route's
 // path IS the object reference the caller supplied — a GET to
 // /v1/containers/<ref> logs <ref> as part of "path". This was confirmed
-// during Phase 3's manual validation (read-operations-report.md, "Confirmed
-// review finding M4 with evidence") and is a recorded, un-fixed observation,
+// during Phase 3's manual validation and is a recorded, un-fixed observation,
 // not something this task may correct (D19: no production code changes).
 //
 // What the checklist item's underlying security concern actually protects

--- a/internal/e2e/api/contract_startup_test.go
+++ b/internal/e2e/api/contract_startup_test.go
@@ -19,7 +19,6 @@ import (
 // unreachable-Engine startup path, graceful shutdown, the "certs/ deleted
 // under an intact database" identity fault, and the no-credential-material
 // sweep of the whole state directory.
-// secure-foundation-and-persistence.plan.md:1216-1229.
 
 // TestConfigFaultsReportedTogether asserts internal/config's aggregation
 // contract from the outside: an operator who typos three variables at once
@@ -76,9 +75,8 @@ func TestConfigFaultsReportedTogether(t *testing.T) {
 	})
 
 	// A zero DEVMON_RATE_GUARDED_PER_SEC is a configuration fault, not "no
-	// limit": internal/config's minRatePerX floor is 1 (hardening-and-oss-
-	// release.plan.md, Task 2's gotcha) precisely so no value can disable the
-	// limiter, and this proves that floor from the outside.
+	// limit": internal/config's minRatePerX floor is 1, precisely so no value
+	// can disable the limiter, and this proves that floor from the outside.
 	t.Run("zero DEVMON_RATE_GUARDED_PER_SEC is a configuration fault", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/e2e/api/contract_status_test.go
+++ b/internal/e2e/api/contract_status_test.go
@@ -19,7 +19,6 @@ import (
 // exactly the documented allowlist, POST is rejected, and no route leaks
 // anything to a caller with no client certificate" — the one endpoint every
 // scanner on the internet can already reach.
-// secure-foundation-and-persistence.plan.md:1216-1229.
 
 // unauthenticatedClient builds an http.Client that trusts only the CA an
 // already-paired Device was pinned to, but presents no client certificate of

--- a/internal/e2e/api/main_test.go
+++ b/internal/e2e/api/main_test.go
@@ -5,8 +5,8 @@
 // Package api is the host-binary group: it builds and runs the real
 // devmon-agent binary, pairs through the documented host-side command path
 // (device pair-code), and drives every route over mTLS. Every file in this
-// package replays one section of a manual checklist from Phases 1-5 (PRD
-// Phase 6) so it runs unattended against a real Docker Engine instead of a
+// package replays one section of a manual checklist from Phases 1-5, so it
+// runs unattended against a real Docker Engine instead of a
 // human with curl.
 //
 // What this package deliberately does NOT cover: anything that needs a

--- a/internal/e2e/harness/doc.go
+++ b/internal/e2e/harness/doc.go
@@ -4,8 +4,8 @@
 
 // Package harness runs the real devmon-agent against a real Docker Engine.
 //
-// It exists so the outstanding manual checklists from Phases 1-5 (PRD Phase
-// 6) can be replayed unattended: it builds the shipped binary, starts it with
+// It exists so the outstanding manual checklists from Phases 1-5 can be
+// replayed unattended: it builds the shipped binary, starts it with
 // a curated environment, pairs a device through the documented host-side
 // command path, and drives every route over mTLS. Nothing in this package is
 // imported outside internal/e2e (it lives under internal/, which is what
@@ -24,7 +24,7 @@
 //     skip its cleanups; `make e2e-clean` is that operation, and it is
 //     deliberately explicit. No code path in this package removes containers
 //     by label, because such a pass cannot distinguish a dead run's
-//     leftovers from a live run's fixtures (D11 of the phase plan).
+//     leftovers from a live run's fixtures (D11).
 //
 //  2. It never passes the ambient environment to the agent under test. The
 //     child process's environment is built from the test case alone, so a

--- a/internal/e2e/harness/engine.go
+++ b/internal/e2e/harness/engine.go
@@ -18,7 +18,7 @@ import (
 	"github.com/moby/moby/client"
 )
 
-// Environment variables read by the harness itself (D13 of the phase plan).
+// Environment variables read by the harness itself (D13).
 // They share the DEVMON_ prefix for discoverability, but they are NOT part of
 // the agent's own configuration surface: the agent's environment is built
 // explicitly for every subprocess (see buildAgentEnv in agent.go) and never
@@ -76,7 +76,7 @@ func EngineHost() (host, skipReason string) {
 
 // RequireEngine skips the calling test — or fails it, when DEVMON_E2E_REQUIRE=1
 // — when no Docker Engine answers a ping. A suite that quietly does nothing
-// is worse than no suite, because a green run is what flips a PRD row to
+// is worse than no suite, because a green run is what marks a phase
 // complete (D5).
 func RequireEngine(t *testing.T) *client.Client {
 	t.Helper()
@@ -135,7 +135,7 @@ func skipOrFail(t *testing.T, reason string) {
 // Only the actual version comparison — and an unparseable version string —
 // calls t.Skipf DIRECTLY, never skipOrFail: DEVMON_E2E_REQUIRE=1 exists to
 // turn "no Engine answered" into a hard failure so a silently-passing suite
-// cannot flip a PRD row (D5). An Engine that DID answer but predates the API
+// cannot mark a phase complete (D5). An Engine that DID answer but predates the API
 // version carrying the field under test is not a missing Engine — it is a
 // genuine capability gap in the Engine itself, and no amount of
 // DEVMON_E2E_REQUIRE=1 can make an old Engine speak a field it never sends.

--- a/internal/e2e/incontainer/contract_selfexclusion_test.go
+++ b/internal/e2e/incontainer/contract_selfexclusion_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/scnplt/devmon-agent/internal/e2e/harness"
 )
 
-// This file is the PRD's headline metric — "agent surviving a delete attempt
+// This file is the project's headline metric — "agent surviving a delete attempt
 // in the most permissive mode, 100%" — and the reason self-exclusion needs a
 // containerised agent to test at all: the rule (internal/dockerx/lifecycle.go
 // resolveTarget) compares the request's resolved container ID against the ID
@@ -25,7 +25,6 @@ import (
 // (internal/dockerx/self.go), which is only non-empty when the agent
 // genuinely runs as a container. A host-binary agent (internal/e2e/api) has
 // no container of its own to protect, so it can never exercise this path.
-// lifecycle-policy-and-audit.plan.md:1086-1126.
 //
 // What this file deliberately does NOT cover: hostname-override and
 // unresolvable-override self-identification variants — proving the *right*
@@ -127,7 +126,7 @@ func waitFixtureRunning(t *testing.T, e *client.Client, id string) {
 // containers are plain busybox processes, not the agent itself.
 const containerReadinessTimeoutForFixtures = 20 * time.Second
 
-// TestAgentRefusesToActOnItself is the PRD's headline metric: a full-mode
+// TestAgentRefusesToActOnItself is the headline metric: a full-mode
 // agent — the most permissive policy tier there is — refuses all five
 // lifecycle routes against its own container, by every one of the three
 // reference forms a client could plausibly send, and is still running,
@@ -165,7 +164,7 @@ func TestAgentRefusesToActOnItself(t *testing.T) {
 		}
 	}
 
-	// The PRD metric itself: still running, no restart, still answering —
+	// The metric itself: still running, no restart, still answering —
 	// asked of the ENGINE, never the agent (Task 10's GOTCHA). An agent that
 	// answered 403 fifteen times and then died would pass a version of this
 	// assertion that only asked the agent's own HTTP port.

--- a/internal/e2e/incontainer/contract_selfid_test.go
+++ b/internal/e2e/incontainer/contract_selfid_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // This file covers the self-IDENTIFICATION half of Phase 5's outstanding
-// checklist (lifecycle-policy-and-audit.plan.md:1086-1126): proving the
+// checklist: proving the
 // agent finds its own container through /proc/self/mountinfo rather than
 // $HOSTNAME, that an explicit DEVMON_SELF_CONTAINER override is honoured
 // ahead of that auto-detection, and that a well-formed but unresolvable
@@ -188,9 +188,8 @@ func TestExplicitSelfIDOverrideIsHonoured(t *testing.T) {
 //
 // This test now asserts that real behaviour rather than the specification it
 // diverges from, because a permanently red test asserting an unimplemented
-// contract is worth nothing. The divergence itself is recorded as Finding 1
-// in .claude/PRPs/reports/client-independent-e2e-report.md: the security
-// posture is sound (self-exclusion still fires, via a correctly detected
+// contract is worth nothing. The divergence itself is a recorded finding: the
+// security posture is sound (self-exclusion still fires, via a correctly detected
 // ID). What was lost — operator visibility into the discarded override — is
 // now fixed (Phase 7): confirmSelf logs a Warn naming the discarded override
 // the moment the Engine fails to confirm it, so this test now asserts that

--- a/internal/e2e/incontainer/contract_state_test.go
+++ b/internal/e2e/incontainer/contract_state_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 // This file covers the state-survival half of Task 11 (the earlier phases'
-// persistence items, lifecycle-policy-and-audit.plan.md:1086-1126 and
-// secure-foundation-and-persistence.plan.md:1216-1229): pre-kill log lines
+// persistence items): pre-kill log lines
 // readable after a crash restart, both paired devices surviving a genuine
 // image rebuild and container recreation against the same bind mount, and
 // the negative case — a fresh state directory yields a different CA
@@ -94,7 +93,7 @@ func TestStateSurvivesCrashRestart(t *testing.T) {
 	}
 }
 
-// TestPairingsSurviveImageUpgrade is the PRD's "pairings surviving a
+// TestPairingsSurviveImageUpgrade is the "pairings surviving a
 // restart and an image upgrade: 100%" success signal. It rebuilds the image
 // with a different VERSION build arg and RECREATES the container — not a
 // restart, which shares the writable layer and would prove nothing about

--- a/internal/httpapi/audit.go
+++ b/internal/httpapi/audit.go
@@ -87,7 +87,7 @@ func (s *Server) recordAudit(ctx context.Context, entry *auditEntry) {
 // carries a real device — an unauthenticated caller is unattributable, and
 // letting one write rows would hand a scanner a way to flood the operator's
 // security record. It sits OUTSIDE requireOp, so refusals by policy are
-// recorded, which the PRD requires explicitly.
+// recorded, which is an explicit requirement.
 func (s *Server) withAudit(op policy.Operation, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		entry := &auditEntry{

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -43,9 +43,9 @@ const (
 	// maxConcurrentStreams bounds simultaneous live log streams. Each holds a
 	// goroutine, an Engine connection, and a socket for its entire life, so an
 	// unbounded count is a file-descriptor exhaustion the agent inflicts on the
-	// host it exists to protect. A constant rather than an env var: the PRD's
-	// rule is that every extra startup setting is surface the operator has to
-	// understand at install time, and eight concurrent log views on one phone is
+	// host it exists to protect. A constant rather than an env var: every extra
+	// startup setting is surface the operator has to understand at install
+	// time, and eight concurrent log views on one phone is
 	// already beyond any real use.
 	maxConcurrentStreams = 8
 )

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -3,7 +3,7 @@
 // Package logging builds the agent's structured logger over a size- and
 // age-bounded file on the state mount, teed to stderr.
 //
-// Two guarantees this package exists to keep, both PRD requirements:
+// Two guarantees this package exists to keep, both of them requirements:
 //
 //   - Log lines written before a crash are readable after a restart. That is why
 //     the sink is a file on the bind-mounted state directory and not only stderr.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Sentinel errors for the two conditions a caller must branch on. Both are fatal
-// at startup: the PRD asks for a loud, early, specific failure rather than an
-// obscure one at first query.
+// at startup, because a loud, early, specific failure beats an obscure one at
+// first query.
 var (
 	// ErrStateCorrupt means the file exists but is not a usable database — the
 	// realistic outcome of a botched restore or a truncated copy.
@@ -58,7 +58,7 @@ type Store struct {
 
 	// FirstRun is true when the database file did not exist before Open.
 	//
-	// Phase 2 hangs the PRD's "loud on missing identity" check off this: once a
+	// Phase 2 hangs the "loud on missing identity" check off this: once a
 	// CA exists, a first run on a mount that should already hold one means the
 	// operator lost their state directory, and the agent must say so rather than
 	// silently minting a new identity that unpairs every device.
@@ -257,7 +257,7 @@ func (s *Store) SchemaVersion(ctx context.Context) (int, error) {
 //
 // Age and row count are applied together, not as alternatives: whichever bites
 // first is the one that limits growth, which is what "bounded by both age and
-// size" means in the PRD.
+// size" means here.
 func (s *Store) PruneAudit(ctx context.Context, maxAge time.Duration, maxRows int) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
## What

`.claude/PRPs/` (PRD, phase plans, phase reports) is no longer repository content. This branch stops tracking it and removes every reference to those documents from files that stay public.

- **Ignore + untrack.** The existing `.claude/PRPs/reviews/` ignore rule is widened to the whole `.claude/PRPs/` tree and the 15 tracked files are dropped from the index. The files are untouched in the working tree.
- **References removed.** `docs/THREAT-MODEL.md` cited the PRD in four places; those claims are now stated directly instead of linking a file a reader cannot open. `CONTRIBUTING.md` no longer points contributors at the plans. Go doc comments and one CI comment keep their rationale but drop the PRD/plan/report citations.
- **CLAUDE.md** is corrected so it no longer claims phase reports land in the repo.

`.claude/PRPs/` paths remain in `CLAUDE.md` and `.claude/agents/*.md`, which are the operating instructions that read those files — removing them there would break the workflow.

## Notes

History was rewritten separately with `git filter-repo` to purge these paths from all commits and tags, so no past commit contains them either.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags e2e ./internal/e2e/...`
- [x] `go test ./internal/... -race` — all packages pass

Comment-only changes to Go files; no behaviour change.