### PR TITLE
docs: rewrap the maxConcurrentStreams comment

### DIFF
--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -44,9 +44,8 @@ const (
 	// goroutine, an Engine connection, and a socket for its entire life, so an
 	// unbounded count is a file-descriptor exhaustion the agent inflicts on the
 	// host it exists to protect. A constant rather than an env var: every extra
-	// startup setting is surface the operator has to understand at install
-	// time, and eight concurrent log views on one phone is
-	// already beyond any real use.
+	// startup setting is surface the operator has to understand at install time,
+	// and eight concurrent log views on one phone is already beyond any real use.
 	maxConcurrentStreams = 8
 )
 


### PR DESCRIPTION
Follow-up to #76. That PR's comment edit left the `maxConcurrentStreams` block one line longer than needed, moving the constant from `internal/httpapi/server.go:49` to `:50` — the anchor #46 cites for the global stream-semaphore finding. Rewrapping restores it.

Comment only, no behaviour change. `go build ./...` and `go vet` pass.