### PR TITLE
fix: report the public-address fault regardless of parse order

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,6 +235,7 @@ func (l *loader) publicAddrs() []string {
 	}
 
 	addrs := make([]string, 0, strings.Count(raw, ",")+1)
+	hadInvalidEntry := false
 	for _, part := range strings.Split(raw, ",") {
 		e := strings.TrimSpace(part)
 		if e == "" {
@@ -242,11 +243,17 @@ func (l *loader) publicAddrs() []string {
 		}
 		if !isValidSAN(e) {
 			l.fail(envPublicAddr, "%q is not a valid DNS name or IP address", e)
+			hadInvalidEntry = true
 			continue
 		}
 		addrs = append(addrs, e)
 	}
-	if len(addrs) == 0 && len(l.problems) == 0 {
+	// Only report the missing-address problem when nothing in raw was even
+	// attempted (e.g. it was all commas and blanks) — an invalid entry already
+	// reports its own problem above, and reporting is a per-field decision, so
+	// it must never key off the loader's overall problem count from unrelated
+	// fields such as DEVMON_STATE_DIR.
+	if len(addrs) == 0 && !hadInvalidEntry {
 		l.fail(envPublicAddr, "must list at least one address")
 	}
 	return addrs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -385,6 +385,36 @@ func TestLoadAggregatesEveryProblem(t *testing.T) {
 	}
 }
 
+func TestLoadReportsPublicAddrProblemEvenAfterAnEarlierFault(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a relative DEVMON_STATE_DIR fails first, and DEVMON_PUBLIC_ADDR
+	// is present but empty after trimming its comma-only entries. Both faults
+	// must surface in the same pass: an operator fixing DEVMON_STATE_DIR must
+	// not restart only to discover DEVMON_PUBLIC_ADDR was broken all along.
+	env := map[string]string{
+		envStateDir:   "relative",
+		envPublicAddr: ",",
+	}
+
+	// Act
+	_, err := Load(fakeEnv(env))
+
+	// Assert
+	var vErr *ValidationError
+	if !errors.As(err, &vErr) {
+		t.Fatalf("Load() error = %v, want *ValidationError", err)
+	}
+	if len(vErr.Problems) != 2 {
+		t.Fatalf("Problems = %#v, want 2 (state dir and public addr)", vErr.Problems)
+	}
+	for _, key := range []string{envStateDir, envPublicAddr} {
+		if !strings.Contains(vErr.Error(), key) {
+			t.Errorf("aggregated error does not name %s:\n%s", key, vErr.Error())
+		}
+	}
+}
+
 func TestLoadAggregatesRateLimitProblems(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Item 1 of #46.

## Problem

`publicAddrs()` suppressed its own "must list at least one address" problem whenever the loader had already recorded a problem for *any* earlier field:

```go
if len(addrs) == 0 && len(l.problems) == 0 {
```

With `DEVMON_STATE_DIR=relative` and `DEVMON_PUBLIC_ADDR=","` the operator was told about the state directory, fixed it, restarted, and only then learned the public address was broken too — the one-fault-per-restart experience `ValidationError`'s own doc comment says it exists to prevent.

## Fix

The guard now keys off this field's own parse rather than the loader's global count: a local `hadInvalidEntry` flag, set when an entry fails `isValidSAN` and therefore already reports itself. An unrelated field can no longer silence this one, and an all-commas value still produces exactly one problem instead of two.

## Test plan

- [x] New `TestLoadReportsPublicAddrProblemEvenAfterAnEarlierFault` — verified RED before the fix (`Problems = [DEVMON_STATE_DIR: "relative" is not an absolute path], want 2`) and GREEN after, on this branch, not just as reported.
- [x] `go vet ./...`, `go build ./...`, `gofmt -l internal/config/` clean
- [x] `go test ./internal/... -race` — all pass; total coverage **95.4%** (floor 90%)
- [x] `golangci-lint run` and `gosec` on the touched package — 0 issues
- [x] `TestLoadRejections`, `TestLoadEmptyEnvironmentNamesPublicAddr`, `TestLoadAggregatesEveryProblem` unchanged and passing — the unset-entirely and invalid-SAN paths keep their existing messages

## Provenance

This patch came out of the A/B run comparing `ecc:tdd-guide` against the repo's own `go-implementer` agent on the same finding. Both produced functionally identical fixes; this is `go-implementer`'s. I re-verified the red-then-green transition and every gate on this branch rather than trusting the agent's report — worth noting because both agents ran in worktrees cut from `main`, not `dev`, so their reported coverage figure (85.0%) was measured against an older tree.