### PR TITLE
ci: automate the documented OpenAPI lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 # Two bars, scaled to the target branch:
 #   PR -> dev     : `test` only, for fast feedback on the integration branch.
-#   PR -> main    : `test` plus `lint`, `image`, `shellcheck`, `gosec`, `govulncheck`
-#                   and `e2e` — the release bar.
+#   PR -> main    : `test` plus `lint`, `image`, `shellcheck`, `gosec`, `govulncheck`,
+#                   `openapi` and `e2e` — the release bar.
 #   push -> main  : the same release bar, so main's HEAD carries its own result.
 # The main-only jobs are gated on `github.base_ref == 'main'` (populated on
 # pull_request only) or `github.ref == 'refs/heads/main'` (the push of the merge
 # commit), so they never queue on a dev PR but always run on what main actually
 # holds. Branch protection is per branch, so `dev` requires `test` and `main`
-# requires all seven.
+# requires all eight.
 
 on:
   pull_request:
@@ -34,6 +34,7 @@ env:
   GOLANGCI_LINT_VERSION: v2.12.2
   GOSEC_VERSION: v2.28.0
   GOVULNCHECK_VERSION: v1.6.0
+  REDOCLY_VERSION: 2.46.2
   COVERAGE_FLOOR: 90
 
 jobs:
@@ -168,6 +169,29 @@ jobs:
 
       - name: gosec
         run: gosec ./...
+
+  # docs/openapi.yaml is the contract the client is generated from, and it is
+  # hand-maintained: no Go gate reads it, so nothing else in this workflow would
+  # notice it going malformed. This job is the floor — it proves the document
+  # still parses as OpenAPI 3.1 and passes redocly's recommended rules. It
+  # cannot check the document against the registered routes; that is still
+  # review's job, and CONTRIBUTING.md says so.
+  #
+  # Release bar rather than every dev PR: a spec fault cannot break a running
+  # agent, only a client generated from a release.
+  openapi:
+    name: openapi
+    # Release bar. `base_ref` covers the PR into main; `ref` covers the push of
+    # the merge commit onto main, where `base_ref` is empty.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pinned to the same version the Makefile names, so a local
+      # `make openapi-lint` and this job cannot disagree.
+      - name: redocly lint
+        run: npx --yes @redocly/cli@${REDOCLY_VERSION} lint docs/openapi.yaml
 
   # gosec and govulncheck answer different questions and neither substitutes for
   # the other: gosec looks for faults in the code written here, govulncheck for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ go test ./internal/... -race -coverprofile=coverage.out
 go tool cover -func=coverage.out | tail -1   # floor is 90%
 
 shellcheck -s sh install.sh
+make openapi-lint                            # docs/openapi.yaml must lint clean
 ```
 
 The end-to-end suite runs against a real Docker Engine and is not part of the
@@ -116,8 +117,9 @@ Code written from memory will use the pre-v29 forms and will not compile.
 types and nothing checks it against them, so a change to a route, a status
 code, or a projection field is only half done until the spec carries it too.
 The `*FieldCount` tests will tell you a projection gained a field; they will
-not tell you this file was forgotten. Validate with
-`npx @redocly/cli lint docs/openapi.yaml`.
+not tell you this file was forgotten. `make openapi-lint` validates the
+document itself — it catches a malformed spec, not a spec that drifted from the
+routes. Only review catches the second.
 
 **3. Build with `CGO_ENABLED=0`.** `modernc.org/sqlite` is pure Go, which is
 what keeps the binary static so it runs on `distroless/static`. Its

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 # local `make vuln` and the CI gate run the same scanner.
 GOVULNCHECK_VERSION ?= v1.6.0
 
+# Same contract for the OpenAPI linter: pinned here and in ci.yml so `make
+# openapi-lint` and the CI gate run the same rules against the same document.
+REDOCLY_VERSION ?= 2.46.2
+
 # Stamped into internal/version at link time. Defined once here so it is never retyped.
 LDFLAGS := -s -w \
 	-X $(MODULE)/internal/version.Version=$(VERSION) \
@@ -44,7 +48,7 @@ E2E_PKGS := ./internal/e2e/...
 # failures.
 E2E_TESTFLAGS := -race -count=1 -v
 
-.PHONY: all build test test-race cover lint sec vuln shellcheck image fmt clean e2e e2e-container e2e-endurance e2e-lint e2e-clean
+.PHONY: all build test test-race cover lint sec vuln shellcheck openapi-lint image fmt clean e2e e2e-container e2e-endurance e2e-lint e2e-clean
 
 all: build
 
@@ -99,6 +103,17 @@ vuln:
 # POSIX sh: shellcheck would otherwise let a bashism through that dash rejects.
 shellcheck:
 	shellcheck -s sh install.sh
+
+# docs/openapi.yaml is hand-maintained and no Go gate reads it, so this is the
+# only automated check that the contract file is well-formed and internally
+# consistent. It does not — and cannot — verify the document against the
+# registered routes; that gap is still closed by review.
+#
+# Run through npx rather than a checked-in node_modules: this repository has no
+# other JavaScript, and a dependency tree for one linter is not worth carrying.
+# The rules come from redocly.yaml at the repository root.
+openapi-lint:
+	npx --yes @redocly/cli@$(REDOCLY_VERSION) lint docs/openapi.yaml
 
 # -race instruments the test binary only; the agent binary it builds and runs as
 # a child process is still built with CGO_ENABLED=0, matching the shipped

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,12 @@
+# The ruleset behind `make openapi-lint` and the `openapi` CI job.
+#
+# Without this file redocly falls back to its built-in `recommended` set and
+# says so on every run. Naming it here makes the bar explicit and pins it to the
+# document rather than to whatever a given CLI build defaults to, so a local run
+# and the CI job fail on exactly the same rules.
+extends:
+  - recommended
+
+apis:
+  devmon-agent:
+    root: docs/openapi.yaml


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` named `npx @redocly/cli lint docs/openapi.yaml` as a gate, but the command appeared in no Makefile target and no CI job. It was the one documented gate with zero automation behind it — gofmt, vet, golangci-lint, gosec, govulncheck, shellcheck and the coverage floor all run on their own.

## What

- `redocly.yaml` at the repository root — states the ruleset (`recommended`) explicitly instead of relying on the CLI's built-in default, so the bar is pinned to the document rather than to a given CLI build.
- `make openapi-lint` — runs redocly through `npx`, pinned via `REDOCLY_VERSION`. No `node_modules` is checked in: this repository has no other JavaScript, and a dependency tree for one linter is not worth carrying.
- `openapi` CI job on the release bar, pinned to the same version, so a local run and CI cannot disagree. Release bar rather than every dev PR: a spec fault cannot break a running agent, only a client generated from a release.
- `CONTRIBUTING.md` now points at `make openapi-lint` and says plainly what it does *not* cover — drift between the spec and the registered routes is still caught by review only.

Branch protection on `main` now needs `openapi` added to its required checks (the workflow comment count went from seven to eight).

## Test plan

- [x] `make openapi-lint` passes against `docs/openapi.yaml` as it stands
- [x] `ci.yml` and `redocly.yaml` parse as valid YAML; job list is the eight expected
- [ ] CI green on this PR (`test`), and the `openapi` job green on the next PR into `main`

Closes #59