### PR TITLE
ci: fail the OpenAPI gate on warnings, not just errors

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -4,8 +4,14 @@
 # says so on every run. Naming it here makes the bar explicit and pins it to the
 # document rather than to whatever a given CLI build defaults to, so a local run
 # and the CI job fail on exactly the same rules.
+#
+# `recommended-strict`, not `recommended`: the two carry the same rules, but
+# the plain set leaves many of them at warning severity, and redocly exits 0 on
+# warnings. A gate that reports a fault and still goes green is not a gate — a
+# missing operationId, say, would have printed and passed. Strict promotes the
+# warnings to errors so the exit code matches what the run actually found.
 extends:
-  - recommended
+  - recommended-strict
 
 apis:
   devmon-agent:


### PR DESCRIPTION
## Why

Follow-up to #82. redocly exits 0 on warnings, and the `recommended` set leaves a large share of its rules at warning severity — so the gate would print a fault and still go green. Measured on a copy of the document:

| Fault injected | `recommended` | `recommended-strict` |
|---|---|---|
| `$ref` pointing at a non-existent schema | error, exit 1 | error, exit 1 |
| broken YAML indentation | parse failure, exit 1 | parse failure, exit 1 |
| `operationId` deleted | warning, **exit 0** | error, **exit 1** |

The third row is the hole: a reported fault that passes CI is not a gate.

## What

One line in `redocly.yaml`: `recommended` → `recommended-strict`. Same rules, warnings promoted to errors, so the exit code matches what the run actually found. The comment above it records why.

Nothing else changes — `make openapi-lint` and the `openapi` CI job both read this file, so both tighten together and stay in step.

## Test plan

- [x] `docs/openapi.yaml` passes `recommended-strict` as it stands, zero findings, exit 0
- [x] deleting an `operationId` now exits 1 (it exited 0 under `recommended`)
- [ ] CI green on this PR (`test`); the `openapi` job itself first runs on the `dev` → `main` release PR

Refs #59 — the issue is already closed by #82; this only tightens the gate it added. The spec-vs-routes drift gap named there is still open by design and still review's job.