### PR TITLE
docs: re-anchor drifted citations and fix the audit CLI name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Build
         run: go build ./...
 
+      # docs/THREAT-MODEL.md promises every claim traces back to a line of
+      # code, and docs/BACKUP.md quotes README.md and install.sh the same way.
+      # Those citations silently rot whenever a prose file grows (#48), so they
+      # are checked on every PR rather than only on the release bar.
+      - name: Check doc citations
+        run: sh scripts/check-doc-citations.sh
+
       # -race is implemented in cgo, so it needs CGO_ENABLED=1 even though the
       # shipped binary is built with CGO_ENABLED=0. gcc ships on ubuntu-latest.
       #

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ E2E_PKGS := ./internal/e2e/...
 # failures.
 E2E_TESTFLAGS := -race -count=1 -v
 
-.PHONY: all build test test-race cover lint sec vuln shellcheck openapi-lint image fmt clean e2e e2e-container e2e-endurance e2e-lint e2e-clean
+.PHONY: all build test test-race cover lint sec vuln shellcheck doc-citations openapi-lint image fmt clean e2e e2e-container e2e-endurance e2e-lint e2e-clean
 
 all: build
 
@@ -102,7 +102,12 @@ vuln:
 # operator's host with sudo. -s sh, not the default, because the script is
 # POSIX sh: shellcheck would otherwise let a bashism through that dash rejects.
 shellcheck:
-	shellcheck -s sh install.sh
+	shellcheck -s sh install.sh scripts/check-doc-citations.sh
+
+# The prose docs cite README.md, install.sh and internal/**.go by anchor and by
+# line; this proves every one of them still resolves.
+doc-citations:
+	sh scripts/check-doc-citations.sh
 
 # docs/openapi.yaml is hand-maintained and no Go gate reads it, so this is the
 # only automated check that the contract file is well-formed and internally

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -25,7 +25,7 @@ $DEVMON_STATE_DIR/                 bind mount — not a named volume        0700
     └── agent-….log.gz             rotated and compressed                 0600
 ```
 
-— [`README.md:310-329`](../README.md) (`## State directory`).
+— [`README.md`, `## State directory`](../README.md#state-directory).
 
 `logs/` is operational output, not identity, and does not need to survive a
 restore for the agent to run — but back it up anyway if you are diagnosing
@@ -54,7 +54,7 @@ In the README's own words, which this document does not restate differently:
 > the host and restart. The agent then creates a new CA, every paired device
 > is unpaired, and the fingerprint changes.
 >
-> — [`README.md:331-340`](../README.md)
+> — [`README.md`, `## State directory`](../README.md#state-directory)
 
 Concretely, that means:
 
@@ -88,9 +88,9 @@ sudo tar czf devmon-backup.tgz -C / var/lib/devmon
 docker start devmon-agent
 ```
 
-— [`README.md:346-355`](../README.md). This checkpoints the write-ahead log
-before the copy runs, so the archive holds a single consistent state rather
-than a snapshot mid-write.
+— [`README.md`, `### Backup`](../README.md#backup). This checkpoints the
+write-ahead log before the copy runs, so the archive holds a single consistent
+state rather than a snapshot mid-write.
 
 If your `$DEVMON_STATE_DIR` is not `/var/lib/devmon`, substitute it — but keep
 `-C /` and the mount's absolute path, so the archive extracts back to an
@@ -104,7 +104,7 @@ it prepares a fresh state directory:
 
 ```bash
 # NONROOT_UID='65532', NONROOT_GID='65532'
-# — install.sh:30-31
+# — install.sh, NONROOT_UID / NONROOT_GID
 ```
 
 Extract to the target path, then set ownership and mode exactly as a fresh
@@ -125,17 +125,17 @@ The directory and file modes mirror the layout table above and
 `install.sh`'s own `prepare_state_dir` step: "the image runs as UID
 `$NONROOT_UID`, so the directory must be owned by it," followed by `chown` and
 `chmod 700` on the state directory
-([`install.sh:438-444`](../install.sh)). A wrong owner fails startup at
-`MkdirAll` with "permission denied," which reads as an agent bug rather than a
-restore step that was skipped — get ownership right before starting the
-container, not after.
+([`install.sh`, `prepare_state_dir`](../install.sh)). A wrong owner fails
+startup at `MkdirAll` with "permission denied," which reads as an agent bug
+rather than a restore step that was skipped — get ownership right before
+starting the container, not after.
 
 Once ownership and modes are correct, start the agent normally. It validates
 the restored database is a readable, uncorrupted SQLite file at open —
 "Restore by extracting to the same path with the same ownership. The agent
 detects a truncated or corrupt `devmon.db` at startup and refuses to run
 rather than failing obscurely at the first query."
-([`README.md:357-359`](../README.md)).
+([`README.md`, `### Backup`](../README.md#backup)).
 
 ## If `certs/` is lost
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -75,7 +75,7 @@ made it.
   logs, and the five mutating routes:
   [`internal/httpapi/server.go:149-208`](../internal/httpapi/server.go)
   (`routes`). It is read only through the host-side CLI
-  (`device audit list`), which is host access, not API access.
+  (`audit list`), which is host access, not API access.
 - Retention is enforced on a fixed interval, independent of request traffic:
   [`internal/state/pruner.go:11-14`](../internal/state/pruner.go) and
   [`internal/state/pruner.go:44-56`](../internal/state/pruner.go).
@@ -88,13 +88,12 @@ documented deployment.
 - `install.sh` mounts it `:ro`: "`:ro` does not prevent writes through the
   Docker API — the API is request/response over the socket — but it does
   prevent the socket file itself being replaced, and it states intent."
-  ([`install.sh:465-468`](../install.sh)).
+  ([`install.sh`, `compose_file_contents`](../install.sh)).
 - The agent talks to it through `github.com/moby/moby/client`, constructed
   once at startup from `DEVMON_DOCKER_HOST`:
   [`internal/dockerx/client.go:42-46`](../internal/dockerx/client.go).
 - The socket's GID is resolved from the host, not assumed, because it varies
-  per distribution: [`install.sh:371-390`](../install.sh)
-  (`resolve_socket_gid`).
+  per distribution: [`install.sh`, `resolve_socket_gid`](../install.sh).
 
 ---
 
@@ -252,7 +251,7 @@ substance, because the two documents describe the same boundary:
 - **An operator who exposes the port to the internet with no VPN or firewall
   in front of it.** `install.sh`'s own closing message says so directly: "Do
   not expose this port to the open internet without a VPN or a firewall in
-  front of it." ([`install.sh:622-623`](../install.sh)).
+  front of it." ([`install.sh`, `print_next_steps`](../install.sh)).
 - **A deployment that terminates TLS in front of the agent.** The agent
   authenticates from the connection it terminates itself; an HTTPS reverse
   proxy or tunnel ingress is not a supported configuration and is outside this
@@ -280,7 +279,7 @@ substance, because the two documents describe the same boundary:
 > by nothing else. It is therefore present, in the clear, in every host backup
 > and every VPS snapshot of this directory.
 >
-> — [`README.md:331-340`](../README.md)
+> — [`README.md`, `## State directory`](../README.md#state-directory)
 
 This is an accepted risk rather than a defect. A CA private key readable in
 host backups and VPS snapshots is judged medium likelihood and mitigated by
@@ -294,8 +293,8 @@ only `s.cfg.PolicyMode`, the same value for every device
 The README states the same property from the operator's side: "The mode is
 fixed at startup and read once. No client can widen it... Changing the mode
 means changing `DEVMON_POLICY_MODE` on the host and restarting the agent."
-([`README.md:203-206`](../README.md)). A general operator-defined per-device
-permission set is out of scope for this release.
+([`README.md`, `### Policy modes`](../README.md#policy-modes)). A general
+operator-defined per-device permission set is out of scope for this release.
 
 **Root-equivalent blast radius if the agent is compromised.** From
 `SECURITY.md`: "Anything that can drive its API can start, stop, and delete

--- a/scripts/check-doc-citations.sh
+++ b/scripts/check-doc-citations.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Verifies that every citation in docs/*.md still resolves.
+#
+# Three citation forms are checked:
+#   [`path/to/file.go:12-34`](../path/to/file.go)   the line range exists
+#   [`README.md`, `## Heading`](../README.md#anchor) the heading exists
+#   [`install.sh`, `symbol`](../install.sh)          the symbol exists
+#
+# THREAT-MODEL.md promises every claim traces back to a line of code; this is
+# the gate that keeps that promise true as the sources move.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+# Each loop below runs in a pipeline subshell, so failures are recorded in a
+# file rather than in a variable.
+failures=$(mktemp)
+trap 'rm -f "$failures"' EXIT
+
+fail() {
+	printf 'broken citation: %s: %s\n' "$1" "$2" >&2
+	printf 'x' >> "$failures"
+}
+
+# Form 1: `file.ext:N` or `file.ext:N-M`
+# shellcheck disable=SC2016  # the backticks are markdown, not command substitution
+grep -Eon '`[A-Za-z0-9_./-]+\.(go|sh|yaml|yml):[0-9]+(-[0-9]+)?`' docs/*.md |
+	while IFS= read -r hit; do
+		doc=${hit%%:*}
+		rest=${hit#*:}
+		lineno=${rest%%:*}
+		ref=$(printf '%s' "${rest#*:}" | tr -d '`')
+		file=${ref%%:*}
+		range=${ref#*:}
+		start=${range%%-*}
+		end=${range#*-}
+		if [ ! -f "$file" ]; then
+			fail "$doc:$lineno" "no such file: $file"
+			continue
+		fi
+		total=$(wc -l < "$file")
+		if [ "$start" -lt 1 ] || [ "$end" -gt "$total" ]; then
+			fail "$doc:$lineno" "$file has $total lines, citation points at $range"
+		fi
+	done
+
+# Form 2: heading anchors into README.md
+grep -on '(\.\./README\.md#[a-z0-9-]*)' docs/*.md |
+	while IFS= read -r hit; do
+		doc=${hit%%:*}
+		rest=${hit#*:}
+		lineno=${rest%%:*}
+		anchor=${rest#*#}
+		anchor=${anchor%)}
+		found=$(grep -E '^#{1,6} ' README.md |
+			sed -E 's/^#+ //; s/[^A-Za-z0-9 -]//g' |
+			tr '[:upper:] ' '[:lower:]-' |
+			grep -cx -- "$anchor" || true)
+		if [ "$found" -eq 0 ]; then
+			fail "$doc:$lineno" "README.md has no heading '#$anchor'"
+		fi
+	done
+
+# Form 3: named symbols in install.sh
+# shellcheck disable=SC2016  # the backticks are markdown, not command substitution
+grep -on '`install\.sh`, `[A-Za-z0-9_ /]*`' docs/*.md |
+	while IFS= read -r hit; do
+		doc=${hit%%:*}
+		rest=${hit#*:}
+		lineno=${rest%%:*}
+		syms=$(printf '%s' "${rest#*, }" | tr -d '`')
+		for sym in $(printf '%s' "$syms" | tr '/' ' '); do
+			grep -q -- "$sym" install.sh ||
+				fail "$doc:$lineno" "install.sh has no '$sym'"
+		done
+	done
+
+if [ -s "$failures" ]; then
+	exit 1
+fi
+printf 'all doc citations resolve\n'


### PR DESCRIPTION
## Problem

`docs/THREAT-MODEL.md` promises that every claim traces back to a line of code, but its `README.md` citations were off by ~54 lines and its `install.sh` citations by 25-45 lines (`docs/BACKUP.md` had the same drift). It also named a CLI command, `device audit list`, that does not exist.

Closes #48

## Changes

- **Re-anchored the prose citations.** `README.md` is now cited by heading anchor (`../README.md#state-directory`, `#backup`, `#policy-modes`) and `install.sh` by shell function (`prepare_state_dir`, `compose_file_contents`, `resolve_socket_gid`, `print_next_steps`). Line numbers in prose files drift on every edit; headings and function names do not. The ~30 `internal/**.go` line citations still resolve and are left as they are.
- **Fixed the command name.** `device audit list` → `audit list`, matching `cmd/devmon-agent/cli.go:217` and `README.md`.
- **Added `scripts/check-doc-citations.sh`.** Validates all three citation forms — code line ranges, README heading anchors, and `install.sh` symbols — and fails with the offending doc line. Wired into the `test` job so it runs on every PR (docs drift lands through `dev`), exposed as `make doc-citations`, and added to the `shellcheck` target.

## Test plan

- [x] `sh scripts/check-doc-citations.sh` passes on the current tree
- [x] Negative test: injecting a bad line range, a bad heading anchor, and a bad `install.sh` symbol each produces a distinct error and exit 1
- [x] Verified on Linux under `dash` (debian:stable-slim), not just Git Bash
- [x] `shellcheck -s sh install.sh scripts/check-doc-citations.sh` clean (koalaman/shellcheck:stable)
- [x] Every rewritten citation checked by hand against the current `README.md` / `install.sh`

Docs and CI only — no Go code touched.