### PR TITLE
fix: container and compose hardening (#56 items 2-8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM golang:1.26-alpine AS build
+# Base images are digest-pinned rather than tag-pinned. A floating tag means two
+# builds of the same commit are not the same build; the digest makes them
+# identical. Dependabot's docker ecosystem watches a pinned digest and opens a PR
+# when the tag moves, so the pin does not rot silently. The tag is kept next to
+# the digest for readability only — Docker resolves the digest and ignores it.
+FROM golang:1.26-alpine@sha256:28d89ee9cc0ff9fec75c82ca201e6bf7fdf9a679d4b7b24dfa04f2bb766bb468 AS build
+
+# GOTOOLCHAIN=local, not the default `auto`. go.mod requires go 1.26.5, bumped
+# specifically for GO-2026-5856. Under `auto`, a base image that has drifted
+# below that requirement does not fail the build — Go quietly downloads the
+# newer toolchain mid-build, turning a hermetic build into one with a network
+# dependency and an unpinned compiler. `local` turns exactly that situation into
+# a loud error naming both versions, which is the signal we want.
+ENV GOTOOLCHAIN=local
 
 WORKDIR /src
 
@@ -24,11 +37,23 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
       -X github.com/scnplt/devmon-agent/internal/version.BuildTime=${BUILD_TIME}" \
     -o /out/devmon-agent ./cmd/devmon-agent
 
+# The default DEVMON_STATE_DIR (internal/config/config.go), staged here so the
+# final stage can COPY it in with the right owner. distroless has no shell, so
+# `RUN mkdir` is not available there and this is the only way to put a directory
+# into the final image. 0700 because that directory holds the CA private key.
+RUN mkdir -m 0700 -p /out/state
+
 # No ca-certificates layer: the agent makes no outbound TLS connections, and
 # distroless/static already carries a bundle if a later phase needs one.
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:1b7b9f0f0e0a1d2155f531db587cc48ec26aaf97ab64364225f5bf18a054e66a
 
 COPY --from=build /out/devmon-agent /usr/local/bin/devmon-agent
+
+# Pre-created and owned by the nonroot UID. UID 65532 cannot MkdirAll under a
+# root-owned /var, so without this a bare `docker run` with no bind mount dies
+# at startup with a permission-denied that reads as an agent fault. A bind mount
+# over this path — what both compose files do — simply takes precedence.
+COPY --from=build --chown=65532:65532 /out/state /var/lib/devmon
 
 USER nonroot:nonroot
 EXPOSE 8443

--- a/README.md
+++ b/README.md
@@ -68,9 +68,26 @@ docker run -d --name devmon-agent \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add "$(stat -c '%g' /var/run/docker.sock)" \
   -p 8443:8443 \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  --read-only --tmpfs /tmp \
+  --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
   ghcr.io/scnplt/devmon-agent:0.2.0
 ```
+
+The four hardening flags are not needed to run the agent and none of them
+changes how it behaves — they narrow what a foothold inside a container that
+holds the Docker socket is worth. `no-new-privileges` is the one to keep if you
+keep only one. `--read-only` covers the image's own filesystem; the state bind
+mount stays writable, and `/tmp` is a tmpfs because SQLite falls back to it for
+spill files.
+
+A published port is reachable from anywhere the host is, and a host firewall
+alone does not change that: Docker installs DNAT rules that are evaluated before
+the chains UFW and firewalld manage, so a `ufw deny 8443` is never consulted.
+Restrict it where Docker honours it — publish to one interface
+(`-p 127.0.0.1:8443:8443`, behind a VPN), or write the rule into `DOCKER-USER`.
 
 See `compose.example.yaml` for the equivalent Compose file. It carries the knobs
 worth setting by hand, not all of them — the full list is the environment table

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -18,8 +18,22 @@
 #
 #        stat -c '%g' /var/run/docker.sock
 #
-#      999 is right on Debian and Ubuntu and wrong elsewhere. install.sh
-#      resolves it with `stat` rather than assuming it.
+#      It is left as the placeholder REPLACE_WITH_DOCKER_SOCKET_GID below on
+#      purpose. 999 is the number most guides print; it is right on Debian and
+#      Ubuntu and wrong elsewhere, and when it is wrong the only symptom is a
+#      permission denial that reads as an agent fault. Docker refuses to start
+#      a container whose group_add it cannot resolve, so the placeholder fails
+#      immediately and says what is wrong. install.sh resolves the real GID
+#      with `stat` rather than assuming it.
+#
+# One thing about the published port below that regularly surprises people:
+# Docker installs its own DNAT rules, and those are evaluated before the chains
+# UFW and firewalld manage. A published port is therefore reachable from
+# anywhere the host is, even with `ufw deny 8443` in place — the deny rule is
+# never consulted. Restrict it where Docker will honour it instead: bind the
+# published port to one interface ("127.0.0.1:8443:8443" behind a VPN), or
+# write the rule into the DOCKER-USER chain. docs/THREAT-MODEL.md has the
+# wider picture.
 
 services:
   devmon-agent:
@@ -30,6 +44,35 @@ services:
     # which changes if this file moves.
     container_name: devmon-agent
     restart: unless-stopped
+
+    # Hardening. This container holds the Docker socket, which makes it the most
+    # valuable thing on the host to compromise; each line below narrows what a
+    # foothold inside it is worth. None of them changes how the agent behaves.
+    #
+    # no-new-privileges is the one to keep if you keep only one: it stops any
+    # setuid binary in the container from ever raising privileges, which is the
+    # usual first step out of an unprivileged process.
+    security_opt:
+      - no-new-privileges:true
+
+    # The agent needs no capabilities at all. It binds 8443, which is above
+    # 1024, so not even NET_BIND_SERVICE is required.
+    cap_drop:
+      - ALL
+
+    # The image's own filesystem is never written to — every write goes to the
+    # state bind mount below, which stays writable under read_only. /tmp is
+    # given as a tmpfs because SQLite falls back to it for spill files.
+    read_only: true
+    tmpfs:
+      - /tmp
+
+    # A ceiling on threads, not processes: the container runs one Go binary that
+    # spawns no children, and Linux counts threads against this limit. It sits
+    # around a dozen at idle, bounded above by GOMAXPROCS plus whatever blocking
+    # syscalls are in flight, so 256 is far out of normal reach while still
+    # capping a runaway.
+    pids_limit: 256
 
     ports:
       - "8443:8443"
@@ -46,8 +89,10 @@ services:
       # itself being replaced, and it states intent.
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
+    # Replace this with the output of `stat -c '%g' /var/run/docker.sock` on
+    # this host. Left unreplaced, Docker refuses to start the container.
     group_add:
-      - "999"
+      - "REPLACE_WITH_DOCKER_SOCKET_GID"
 
     environment:
       # Required. The server certificate's SANs; comma-separated for several.
@@ -68,6 +113,16 @@ services:
 
       DEVMON_LOG_MAX_AGE_DAYS: "1"
       DEVMON_LOG_MAX_TOTAL_MB: "64"
+
+      # Audit retention, shown at its defaults. The audit trail is the security
+      # record, and is deliberately kept far longer than the operational log.
+      #
+      # DEVMON_AUDIT_MAX_AGE_DAYS must be >= DEVMON_LOG_MAX_AGE_DAYS. The agent
+      # checks this at startup and exits 2 if it is violated, on the grounds
+      # that a security record outlived by debug output is worse than useless.
+      # Raising DEVMON_LOG_MAX_AGE_DAYS therefore means raising this as well.
+      DEVMON_AUDIT_MAX_AGE_DAYS: "365"
+      DEVMON_AUDIT_MAX_ROWS: "100000"
 
       # Rate limits, shown at their defaults. The two pre-authentication tiers
       # are per client IP and are counted per minute; the authenticated tier is

--- a/install.sh
+++ b/install.sh
@@ -479,6 +479,30 @@ services:
     container_name: $SERVICE_NAME
     restart: unless-stopped
 
+    # Hardening. This container holds the Docker socket, which makes it the
+    # most valuable thing on the host to compromise; each line below narrows
+    # what a foothold inside it is worth, and none changes how the agent
+    # behaves. no-new-privileges is the most important of them: it stops any
+    # setuid binary in the container from ever raising privileges.
+    security_opt:
+      - no-new-privileges:true
+
+    # The agent needs no capabilities at all — 8443 is above 1024, so not even
+    # NET_BIND_SERVICE is required.
+    cap_drop:
+      - ALL
+
+    # Every write goes to the state bind mount below, which stays writable
+    # under read_only. /tmp is a tmpfs because SQLite falls back to it for
+    # spill files.
+    read_only: true
+    tmpfs:
+      - /tmp
+
+    # A ceiling on threads, not processes: one Go binary, no children, and
+    # Linux counts threads here. Idle sits around a dozen.
+    pids_limit: 256
+
     ports:
       - "$PORT:8443"
 
@@ -666,7 +690,12 @@ EOF
        fingerprint shown before it. The code is single-use and expires.
     2. Do not expose this port to the open internet without a VPN or a
        firewall in front of it. docs/THREAT-MODEL.md says what the agent does
-       and does not defend against.
+       and does not defend against. Note that a host firewall alone may not
+       be doing what you think: Docker's published ports install DNAT rules
+       that are evaluated before the chains UFW and firewalld manage, so port
+       $PORT stays reachable even with a \`ufw deny $PORT\` rule in place.
+       Restrict it where Docker honours it — bind the published port to one
+       interface in $COMPOSE_PATH, or write the rule into DOCKER-USER.
     3. Back up $STATE_DIR. It is the agent's identity, and the backup is
        itself a credential. See docs/BACKUP.md.
 


### PR DESCRIPTION
Items 2 through 8 of #56. Item 1 — the `health` subcommand and the `HEALTHCHECK`
that depends on it — is deliberately **not** here: it adds a CLI surface, and the
tracking issue (#60) asks for it as its own PR. It follows once this merges.

Refs #56

## What changed

### Dockerfile

- **Digest-pinned both base images.** `golang:1.26-alpine` and
  `gcr.io/distroless/static-debian12:nonroot` were mutable tags, so two builds of
  one commit were not the same build. Dependabot's docker ecosystem tracks a
  pinned digest and opens a PR when the tag moves.
- **`GOTOOLCHAIN=local`.** `go.mod` requires `go 1.26.5`, bumped for
  GO-2026-5856. Under the default `auto`, a base image that drifts below that
  requirement does not fail the build — Go downloads the newer toolchain
  mid-build, adding a network dependency and an unpinned compiler to what should
  be a hermetic build. `local` makes that a loud error. The pinned image is
  go1.26.7, so nothing changes today.
- **`/var/lib/devmon` now exists in the image**, owned by 65532. It is the config
  default for `DEVMON_STATE_DIR`, and UID 65532 cannot `MkdirAll` under a
  root-owned `/var` — so a bare `docker run` with no bind mount died at startup
  with exactly the permission denial the compose comments warn reads as an agent
  fault. distroless has no shell, so the directory is staged in the build stage
  and copied in with `--chown`. A bind mount over the path takes precedence as
  before.

### Both compose files, and the README quickstart

- **Four hardening settings**: `security_opt: [no-new-privileges:true]`,
  `cap_drop: [ALL]`, `read_only: true` with a tmpfs `/tmp`, and
  `pids_limit: 256`. The agent needs no capabilities (8443 is above 1024) and
  writes only to the state bind mount, which stays writable under `read_only`.
  `/tmp` is a tmpfs because SQLite falls back to it for spill files.
  `pids_limit` bounds threads, not processes — measured at 11 at idle, so 256 is
  far out of normal reach while still capping a runaway.
- **`group_add: "999"` → `REPLACE_WITH_DOCKER_SOCKET_GID`** in
  `compose.example.yaml`. 999 is right on Debian and Ubuntu and wrong elsewhere,
  and when it is wrong the only symptom is a mysterious permission denial.
  Docker refuses to start a container whose `group_add` it cannot resolve, so
  the placeholder fails at create time and names itself.
- **Audit retention added to `compose.example.yaml`**, closing the drift with
  install.sh: `DEVMON_AUDIT_MAX_AGE_DAYS`, `DEVMON_AUDIT_MAX_ROWS`, and the
  audit-must-outlive-logs constraint the agent enforces with exit 2 — which a
  hand-assembling operator previously had no way to learn.
- **The DNAT caveat**, next to the existing exposure warning in install.sh and
  in both docs: published ports install rules evaluated before the chains UFW
  and firewalld manage, so `ufw deny 8443` is never consulted.

No Go code changed.

## Test plan

All run locally; the `docker build` and `shellcheck` CI jobs are on the release
bar and do not fire for a PR into `dev`, so they were reproduced by hand.

- [x] `docker build` succeeds with both digests and `GOTOOLCHAIN=local`
      (pinned base is go1.26.7 ≥ go.mod's 1.26.5).
- [x] Bare `docker run`, no bind mount: now reaches the Docker-socket ping,
      having created the state dir, DB, CA and server cert. Previously died at
      `MkdirAll`.
- [x] Full hardening set (`--read-only --tmpfs /tmp --cap-drop ALL
      --security-opt no-new-privileges:true --pids-limit 256`) with a writable
      state mount and the socket attached: agent listens and serves
      `/v1/status`. `docker stats` reports 11 PIDs at idle.
- [x] `docker compose config` accepts `compose.example.yaml`.
- [x] `--group-add REPLACE_WITH_DOCKER_SOCKET_GID` fails at create with
      `unable to find group REPLACE_WITH_DOCKER_SOCKET_GID`.
- [x] `install.sh --dry-run --yes` on Linux: generated compose validates under
      `docker compose config`; the reworded closing note renders with correct
      backticks and variable expansion.
- [x] `shellcheck -s sh install.sh` clean (run in `koalaman/shellcheck:stable`).
- [x] `gofmt -l .` silent, `go vet ./...` clean,
      `scripts/check-doc-citations.sh` reports all citations resolve — all on
      Linux, matching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)