### PR TITLE
feat: add a health subcommand and the image HEALTHCHECK it enables (#56 item 1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,14 @@ COPY --from=build --chown=65532:65532 /out/state /var/lib/devmon
 USER nonroot:nonroot
 EXPOSE 8443
 
+# The exec form with an absolute path is mandatory: distroless/static has no
+# shell, so the shell form of CMD/HEALTHCHECK never runs there. `health`
+# (cmd/devmon-agent/health.go) exists specifically to give this instruction
+# something it can invoke without a shell or curl. --timeout=5s comfortably
+# exceeds the subcommand's own 3-second client timeout, so a slow-but-alive
+# listener is reported by the subcommand's own readable message rather than
+# by Docker's generic timeout kill.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["/usr/local/bin/devmon-agent", "health"]
+
 ENTRYPOINT ["/usr/local/bin/devmon-agent"]

--- a/README.md
+++ b/README.md
@@ -756,6 +756,44 @@ trade.
 Reading this list while the agent runs is safe and expected — that is what WAL
 mode and the busy timeout were configured for.
 
+### Health
+
+The image carries a `HEALTHCHECK`, so `docker ps` reports a health state
+alongside the running state:
+
+```bash
+$ docker ps --filter name=devmon-agent --format '{{.Names}} {{.Status}}'
+devmon-agent    Up 4 hours (healthy)
+```
+
+It runs `devmon-agent health`, a third subcommand on the same binary — for the
+same reason as the two above, there is no shell and no curl in the image to
+run a probe with. The subcommand makes one HTTPS `GET /v1/status` against the
+agent's own listener on loopback and exits 0 or 1. `restart: unless-stopped`
+alone only reacts to the process exiting; this also catches a listener that is
+up but no longer answering.
+
+```bash
+$ docker exec devmon-agent /usr/local/bin/devmon-agent health
+healthy: GET /v1/status returned 200
+
+$ docker inspect -f '{{.State.Health.Status}}' devmon-agent
+healthy
+```
+
+A rate-limited answer (429) counts as healthy: it proves the listener is
+accepting connections and running the middleware chain, which is all this probe
+claims to measure. Lowering `DEVMON_RATE_STATUS_PER_MIN` therefore cannot make
+a working container report unhealthy. TLS verification is skipped, deliberately
+— the server certificate is issued for `DEVMON_PUBLIC_ADDR`'s SANs, which do
+not include loopback, and a process probing the listener from inside the
+container that owns it is not the place to re-establish who that listener is.
+It never reads `certs/`, for the same reason `device` and `audit` do not.
+
+One consequence worth knowing: the probe is a real request, so it writes a
+request log line every 30 seconds — about 2900 a day. Raise
+`DEVMON_LOG_MAX_TOTAL_MB` if that crowds out what you are actually reading.
+
 ### The audit log
 
 Every mutating request writes exactly **one** row — successes, refusals by

--- a/cmd/devmon-agent/health.go
+++ b/cmd/devmon-agent/health.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// `health` is the process that runs inside the distroless/static image's
+// HEALTHCHECK, 2880 times a day. The image has no shell and no curl, so a
+// HEALTHCHECK is only implementable if the agent's own binary can probe
+// itself — this subcommand exists for exactly that reason and no other.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+)
+
+// healthClientTimeout bounds the whole probe request. It must sit comfortably
+// under the Dockerfile's HEALTHCHECK --timeout=5s so a slow-but-alive listener
+// is reported unhealthy by this client, with a readable reason, rather than by
+// Docker killing the process with no explanation at all.
+const healthClientTimeout = 3 * time.Second
+
+// healthStatusPath is the one route this probes, chosen because it is the only
+// unauthenticated GET the agent serves. The listener's ClientAuth is
+// VerifyClientCertIfGiven (internal/tlsconf), so a client presenting no
+// certificate completes the handshake and gets a 200 — which is what makes
+// this route reachable from a process that must never touch certs/.
+const healthStatusPath = "/v1/status"
+
+// loopbackHost is dialed whenever the configured listener is bound to every
+// interface. Docker's HEALTHCHECK runs inside the same network namespace as
+// the agent, so loopback is always a valid path to a listener bound to
+// 0.0.0.0 or [::].
+const loopbackHost = "127.0.0.1"
+
+// runHealthCommand implements `devmon-agent health`. It performs one HTTPS GET
+// against the agent's own listener and returns nil for healthy or an error for
+// unhealthy — main() maps a non-nil error to exit code 1, which is what
+// Docker's HEALTHCHECK reads as "unhealthy".
+//
+// It takes no subcommand and no flags, matching how `device revoke` rejects
+// the wrong argument count: a HEALTHCHECK line is fixed at image build time
+// and a stray argument here would otherwise fail silently 2880 times a day
+// instead of being caught once, at review time.
+//
+// Like `device` and `audit` (see cli.go), this MUST NOT build a log sink,
+// prepare the state directory, or load certificates: it runs on a 30-second
+// interval forever, so any cost paid here is paid 2880 times a day, and a
+// second process touching certs/ could race the running agent's own startup
+// exactly as cli.go's comment on runDeviceCommand explains.
+func runHealthCommand(ctx context.Context, cfg config.Config, args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("health: unexpected argument %q (health takes no arguments)", args[0])
+	}
+
+	addr, err := healthTargetAddr(cfg.ListenAddr)
+	if err != nil {
+		return fmt.Errorf("health: %w", err)
+	}
+
+	return probeStatus(ctx, addr)
+}
+
+// healthTargetAddr derives the address to dial from the agent's own
+// DEVMON_LISTEN_ADDR. An empty host, "0.0.0.0", or "::" means the listener is
+// bound to every interface, and loopback is the correct way in from inside
+// the container that owns it. Any other host means an operator bound the
+// listener to one specific address on purpose, and that address is dialed
+// as configured rather than second-guessed.
+func healthTargetAddr(listenAddr string) (string, error) {
+	host, port, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		return "", fmt.Errorf("parse listen address %q: %w", listenAddr, err)
+	}
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = loopbackHost
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+// probeStatus performs the single HTTPS GET and maps its outcome to healthy
+// (nil) or unhealthy (error), printing a one-line reason so `docker inspect`'s
+// health log stays readable.
+func probeStatus(ctx context.Context, addr string) error {
+	client := &http.Client{
+		Timeout: healthClientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				// #nosec G402 -- The server certificate is issued by the
+				// agent's own CA for DEVMON_PUBLIC_ADDR's SANs, which do not
+				// include the loopback address this probe dials. This check
+				// measures liveness of the listener from inside the container
+				// that owns it, not the identity of the peer — verifying the
+				// chain here would require a second process reading certs/,
+				// which the CLI deliberately never does (see cli.go's comment
+				// on runDeviceCommand racing the agent's own startup).
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS13,
+			},
+			// A fresh, single-use transport: the process exits after one
+			// request, so a connection pool buys nothing, and leaving the
+			// connection open would hold an idle server-side connection slot
+			// 2880 times a day for no benefit.
+			DisableKeepAlives: true,
+		},
+	}
+
+	url := "https://" + addr + healthStatusPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build health request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", addr, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		fmt.Println("healthy: GET /v1/status returned 200")
+		return nil
+	case http.StatusTooManyRequests:
+		// A 429 proves the listener is accepting connections, running the
+		// full middleware chain, and answering — exactly and only what this
+		// probe measures. An operator who lowers DEVMON_RATE_STATUS_PER_MIN
+		// far enough must not thereby make their container permanently
+		// unhealthy, so a rate-limited response counts as healthy too.
+		fmt.Println("healthy: GET /v1/status returned 429 (rate-limited, listener is answering)")
+		return nil
+	default:
+		return fmt.Errorf("unhealthy: GET /v1/status returned %d", resp.StatusCode)
+	}
+}

--- a/cmd/devmon-agent/health_test.go
+++ b/cmd/devmon-agent/health_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+)
+
+func TestHealthTargetAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		listenAddr string
+		want       string
+	}{
+		{name: "no host binds every interface, dial loopback", listenAddr: ":8443", want: "127.0.0.1:8443"},
+		{name: "explicit 0.0.0.0 binds every interface, dial loopback", listenAddr: "0.0.0.0:8443", want: "127.0.0.1:8443"},
+		{name: "explicit :: binds every interface, dial loopback", listenAddr: "[::]:8443", want: "127.0.0.1:8443"},
+		{name: "specific address is dialed as configured", listenAddr: "192.0.2.10:9999", want: "192.0.2.10:9999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := healthTargetAddr(tt.listenAddr)
+			if err != nil {
+				t.Fatalf("healthTargetAddr(%q) unexpected error: %v", tt.listenAddr, err)
+			}
+			if got != tt.want {
+				t.Errorf("healthTargetAddr(%q) = %q, want %q", tt.listenAddr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHealthTargetAddrRejectsMalformedListenAddr(t *testing.T) {
+	t.Parallel()
+
+	if _, err := healthTargetAddr("not-a-host-port"); err == nil {
+		t.Fatal("healthTargetAddr() = nil error, want one for a malformed listen address")
+	}
+}
+
+// tlsAddr strips the "https://" scheme httptest.NewTLSServer's URL carries,
+// since probeStatus builds its own URL from a bare host:port.
+func tlsAddr(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	const schemePrefix = "https://"
+	return srv.URL[len(schemePrefix):]
+}
+
+func TestProbeStatusHealthyOn200(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := probeStatus(context.Background(), tlsAddr(t, srv)); err != nil {
+		t.Errorf("probeStatus() = %v, want nil on 200", err)
+	}
+}
+
+// TestProbeStatusHealthyOn429 is the non-obvious case: a rate-limited response
+// still proves the listener accepted the connection, ran the middleware chain,
+// and answered — which is exactly what this probe measures. An operator who
+// lowers DEVMON_RATE_STATUS_PER_MIN must not thereby make their container
+// permanently unhealthy.
+func TestProbeStatusHealthyOn429(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	if err := probeStatus(context.Background(), tlsAddr(t, srv)); err != nil {
+		t.Errorf("probeStatus() = %v, want nil on 429 (rate-limited but alive)", err)
+	}
+}
+
+func TestProbeStatusUnhealthyOnServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	err := probeStatus(context.Background(), tlsAddr(t, srv))
+	if err == nil {
+		t.Fatal("probeStatus() = nil error, want one on 500")
+	}
+	if got := err.Error(); !strings.Contains(got, "500") {
+		t.Errorf("probeStatus() error = %q, want it to name the status code 500", got)
+	}
+}
+
+func TestProbeStatusUnhealthyWhenNothingListens(t *testing.T) {
+	t.Parallel()
+
+	// No server bound here — 127.0.0.1:0 with a resolved-but-unused address
+	// stands in for a wedged/absent listener.
+	if err := probeStatus(context.Background(), "127.0.0.1:1"); err == nil {
+		t.Fatal("probeStatus() = nil error, want one when nothing is listening")
+	}
+}
+
+func TestRunHealthCommandRejectsTrailingArgument(t *testing.T) {
+	t.Parallel()
+
+	err := runHealthCommand(context.Background(), config.Config{ListenAddr: ":8443"}, []string{"extra"})
+	if err == nil {
+		t.Fatal("runHealthCommand() = nil error, want one for an unexpected trailing argument")
+	}
+}

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -86,6 +86,15 @@ func run() error {
 		return runAuditCommand(context.Background(), cfg, flag.Args()[1:])
 	}
 
+	// `health` (issue #56) backs the Dockerfile's HEALTHCHECK. It is
+	// dispatched here for the same reason as `device` and `audit`: it must
+	// never trigger state-dir prep, log-sink construction, or certificate
+	// loading meant only for the long-running agent — and doubly so here,
+	// since Docker invokes it every 30 seconds for the life of the container.
+	if flag.Arg(0) == "health" {
+		return runHealthCommand(context.Background(), cfg, flag.Args()[1:])
+	}
+
 	if err := prepareStateDir(cfg); err != nil {
 		return err
 	}

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -45,6 +45,11 @@ services:
     container_name: devmon-agent
     restart: unless-stopped
 
+    # The image carries its own HEALTHCHECK (it runs `devmon-agent health`, a
+    # subcommand on the same binary — distroless has no shell or curl to probe
+    # with), so `docker ps` reports a health state here without any compose
+    # configuration. Override it below only if you want a different interval.
+
     # Hardening. This container holds the Docker socket, which makes it the most
     # valuable thing on the host to compromise; each line below narrows what a
     # foothold inside it is worth. None of them changes how the agent behaves.

--- a/install.sh
+++ b/install.sh
@@ -479,6 +479,11 @@ services:
     container_name: $SERVICE_NAME
     restart: unless-stopped
 
+    # The image carries its own HEALTHCHECK — it runs \`devmon-agent health\`,
+    # a subcommand on the same binary, because distroless has no shell or curl
+    # to probe with. \`docker ps\` therefore reports a health state with no
+    # configuration here.
+
     # Hardening. This container holds the Docker socket, which makes it the
     # most valuable thing on the host to compromise; each line below narrows
     # what a foothold inside it is worth, and none changes how the agent


### PR DESCRIPTION
Item 1 of #56, and the last part of it. Items 2–8 landed in #88; this is the
separate PR the tracking issue (#60) asked for, because it adds a CLI surface.

Closes #56

## The problem

The image is `distroless/static:nonroot` — no shell, no curl — and the binary
exposed only `device` and `audit`. A `HEALTHCHECK` was therefore not merely
missing but *unimplementable*: nothing in the image could make an HTTPS request.

The consequence is real rather than cosmetic. `restart: unless-stopped` reacts
to the process exiting; it does not react to a listener that is up but no longer
answering, and `docker ps` showed no health state at all — mildly ironic for an
agent that surfaces `health` for every other container on the host
(`docs/openapi.yaml`).

## What changed

`devmon-agent health` makes one HTTPS `GET /v1/status` against the agent's own
listener on loopback and exits 0 (healthy) or 1 (unhealthy), printing a one-line
reason so `docker inspect`'s health log is readable. The Dockerfile invokes it:

```
HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
  CMD ["/usr/local/bin/devmon-agent", "health"]
```

Exec form with an absolute path, necessarily — the shell form never runs on
distroless.

### Decisions worth reviewing

Each is carried as a comment at the point it matters.

- **Dispatched alongside `device` and `audit`**, before state-dir prep, log-sink
  construction and certificate loading, for the same reasons those two are — and
  doubly so here, since Docker invokes it every 30 seconds for the life of the
  container.
- **429 counts as healthy.** A rate-limited answer proves the listener is
  accepting connections and running the middleware chain, which is exactly and
  only what this probe measures. An operator who lowers
  `DEVMON_RATE_STATUS_PER_MIN` far enough must not thereby make a working
  container permanently unhealthy. Anything else — including 500 — is unhealthy.
- **TLS verification is skipped**, with `#nosec G402` and the rationale inline.
  The server certificate is issued for `DEVMON_PUBLIC_ADDR`'s SANs, which do not
  include the loopback address this dials; and a process probing the listener
  from inside the container that owns it is not the place to re-establish who
  that listener is. Verifying the chain would mean a second process reading
  `certs/`, which the CLI deliberately never does (racing the agent's own
  startup). `MinVersion` stays TLS 1.3, matching `internal/tlsconf`.
- **Target address** is derived from `DEVMON_LISTEN_ADDR`: an empty host,
  `0.0.0.0` or `::` means bound to every interface, so loopback is dialed;
  any other host was chosen deliberately and is dialed as configured.
- **3s client timeout**, under the HEALTHCHECK's 5s, so a slow-but-alive listener
  is reported by this command's own readable message rather than killed by
  Docker's generic timeout. Keep-alives disabled — the process exits after one
  request, so a pool buys nothing and an idle server-side connection slot would
  be held 2880 times a day for no benefit.

### One cost, stated plainly

The probe is a real request, so it writes a request log line every 30 seconds —
about 2900 a day. That is documented in the README next to the feature rather
than left for someone to discover. Suppressing it would mean special-casing
loopback in the middleware, which is more surface than the noise is worth.

## Test plan

- [x] `gofmt -l ./cmd ./internal` silent; `go vet ./...` clean; `go build ./...`
      clean.
- [x] `CGO_ENABLED=1 go test ./cmd/... -race` passes, including the new tests:
      address derivation (`:8443`, `0.0.0.0:8443`, `[::]:8443`,
      `192.0.2.10:9999`, malformed), and `probeStatus` against
      `httptest.NewTLSServer` answering 200, 429 and 500, plus nothing-listening
      and trailing-argument cases.
- [x] `CGO_ENABLED=1 go test ./internal/... -race` passes; coverage 95.2%, above
      the 90% floor and unchanged (no `internal/` code touched). Run on Linux as
      a non-root user, matching CI — as root, two filesystem-permission tests
      fail spuriously.
- [x] `golangci-lint run ./...` — 0 issues. `gosec ./...` — 0 issues, 2 nosec
      (one pre-existing, one added here).
- [x] `scripts/check-doc-citations.sh` — all citations resolve.
- [x] `shellcheck -s sh install.sh` clean; `docker compose config` accepts
      `compose.example.yaml`.
- [x] End to end on the built image, under the full hardening set from #88
      (`--read-only --tmpfs /tmp --cap-drop ALL --security-opt
      no-new-privileges:true --pids-limit 256`): reports healthy within the start
      period, `docker ps` shows `Up 8 seconds (healthy)`, health log records
      `"healthy: GET /v1/status returned 200"` with exit code 0.
- [x] Unhealthy path: pointed at a port with no listener, exits 1 with
      `dial 127.0.0.1:9999: … connection refused`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)