### PR TITLE
fix: key the live-stream budget on the calling device

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,8 @@ Failure modes shared by every read route:
 | Unparsable `?since=` timestamp | 400 | `{"error":"invalid since timestamp"}` |
 | No such object | 404 | `{"error":"not found"}` |
 | Engine unreachable, timed out, or otherwise failing | 502 | `{"error":"docker engine unavailable"}` |
-| All live stream slots in use (stream route only) | 503 | `{"error":"too many concurrent log streams"}` |
+| Calling device already holds its own stream cap (stream route only) | 503 | `{"error":"too many concurrent log streams for this device"}` |
+| Every stream slot on the host is in use (stream route only) | 503 | `{"error":"too many concurrent log streams"}` |
 
 The mutating routes add three of their own:
 
@@ -596,12 +597,17 @@ minified bundle — would otherwise be accumulated whole in agent memory before
 any line boundary arrived, which is the agent OOM-killing itself while reading
 logs.
 
-**Eight live streams at once**, after which the route answers 503 with
-`too many concurrent log streams`. Each stream holds a goroutine, an Engine
-connection, and a socket for its entire life, so an unbounded count is
-file-descriptor exhaustion the agent inflicts on the host it exists to protect.
-The limit is a constant rather than a setting, on the same reasoning as the rest
-of the configuration: every additional knob is surface the operator has to
+**Eight live streams per host, three per device**, after which the route answers
+503 — `too many concurrent log streams for this device` when the caller is at its
+own cap, `too many concurrent log streams` when the host's total is gone. Each
+stream holds a goroutine, an Engine connection, and a socket for its entire life,
+so an unbounded count is file-descriptor exhaustion the agent inflicts on the host
+it exists to protect. The per-device cap under that total is what stops one paired
+device — a phone with a stack of tabs, or a client that leaks streams on
+backgrounding — from denying live logs to every other paired device; the host-wide
+refusal is logged with the devices holding the slots, so the operator can tell the
+two apart. Both limits are constants rather than settings, on the same reasoning as
+the rest of the configuration: every additional knob is surface the operator has to
 understand at install time.
 
 If the container turns out not to exist, or the Engine is unreachable, the

--- a/internal/e2e/api/contract_endurance_test.go
+++ b/internal/e2e/api/contract_endurance_test.go
@@ -165,9 +165,10 @@ func TestStreamEnduranceThirtyMinutes(t *testing.T) {
 
 // retentionMaxBackups mirrors internal/logging's unexported maxBackups
 // constant (D4-style duplication, the same reasoning contract_logs_test.go's
-// maxConcurrentStreams applies to a server-side limit): the suite must be
-// able to notice a change to how many rotated files are kept, which it
-// cannot do by importing the value it exists to check.
+// maxConcurrentStreams and maxStreamsPerDevice apply to the stream route's
+// global and per-device limits): the suite must be able to notice a change
+// to how many rotated files are kept, which it cannot do by importing the
+// value it exists to check.
 const retentionMaxBackups = 3
 
 // retentionBudgetMB is DEVMON_LOG_MAX_TOTAL_MB for this test's agent — the

--- a/internal/e2e/api/contract_logs_test.go
+++ b/internal/e2e/api/contract_logs_test.go
@@ -385,28 +385,43 @@ func TestStreamResumeRepeatsAtMostOneLine(t *testing.T) {
 	}
 }
 
-// TestStreamSlotExhaustion asserts the ninth concurrent stream against the
-// same agent answers 503 with the documented body, and that closing one of
-// the eight frees a slot a subsequent stream can use. It does not run
-// t.Parallel(): it deliberately exhausts a resource (maxConcurrentStreams,
-// internal/httpapi/server.go) shared by every stream this agent instance
-// serves, and a sibling test's own stream would make the count
-// non-deterministic — exactly the ordering bug this suite exists to catch,
-// not to introduce (mirrors TestReadsAnswer502WhenEngineIsGone's same
+// TestStreamSlotExhaustion asserts the request that pushes the host past its
+// global ceiling answers 503 with the documented host-wide body, and that
+// closing one of the eight frees a slot a subsequent stream can use. It does
+// not run t.Parallel(): it deliberately exhausts a resource
+// (maxConcurrentStreams, internal/httpapi/server.go) shared by every stream
+// this agent instance serves, and a sibling test's own stream would make the
+// count non-deterministic — exactly the ordering bug this suite exists to
+// catch, not to introduce (mirrors TestReadsAnswer502WhenEngineIsGone's same
 // reasoning for its own single-owner proxy).
+//
+// Reaching the ceiling now takes more than one device (issue #80): a lone
+// device is capped at maxStreamsPerDevice, so a single device could never
+// have reached eight in the first place under the fixed budget. This drives
+// three devices to 3, 3, and 2 streams respectively — summing to the global
+// ceiling while every device stays under its own cap — which is exactly the
+// scenario TestStreamPerDeviceCapDoesNotLockOutOtherDevices below proves does
+// NOT trip the per-device 503 instead.
 func TestStreamSlotExhaustion(t *testing.T) {
 	engine := harness.RequireEngine(t)
-	_, d := readReadyAgent(t, "logs-stream-slots")
+	a, deviceA := readReadyAgent(t, "logs-stream-slots")
 
 	id := harness.StartFixture(t, engine, harness.FixtureOptions{
 		NameSuffix: "slots",
 		Cmd:        logLinesCmd,
 	})
 
-	// maxConcurrentStreams duplicates internal/httpapi/server.go's own
-	// constant (D4): the suite must notice a change to the server's limit,
-	// which it cannot do importing the value it is supposed to be checking.
+	// maxConcurrentStreams and maxStreamsPerDevice duplicate
+	// internal/httpapi/server.go's own constants (D4): the suite must notice
+	// a change to either limit, which it cannot do importing the values it is
+	// supposed to be checking.
 	const maxConcurrentStreams = 8
+	const maxStreamsPerDevice = 3
+
+	deviceB := harness.PairDevice(t, a, "logs-stream-slots-b")
+	deviceC := harness.PairDevice(t, a, "logs-stream-slots-c")
+	devices := []*harness.Device{deviceA, deviceB, deviceC}
+	perDevice := []int{3, 3, 2}
 
 	streams := make([]*harness.Stream, 0, maxConcurrentStreams)
 	defer func() {
@@ -415,17 +430,22 @@ func TestStreamSlotExhaustion(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < maxConcurrentStreams; i++ {
-		s := harness.OpenStream(t, d, "/v1/containers/"+id+"/logs/stream")
-		if s.Status != http.StatusOK {
-			t.Fatalf("stream %d/%d: status = %d, want %d; body = %s", i+1, maxConcurrentStreams, s.Status, http.StatusOK, s.Body)
+	for di, dev := range devices {
+		for i := 0; i < perDevice[di]; i++ {
+			s := harness.OpenStream(t, dev, "/v1/containers/"+id+"/logs/stream")
+			if s.Status != http.StatusOK {
+				t.Fatalf("device %d stream %d/%d: status = %d, want %d; body = %s", di, i+1, perDevice[di], s.Status, http.StatusOK, s.Body)
+			}
+			streams = append(streams, s)
 		}
-		streams = append(streams, s)
 	}
 
-	ninth := harness.OpenStream(t, d, "/v1/containers/"+id+"/logs/stream")
+	// deviceC holds 2 of maxStreamsPerDevice, so its next request clears the
+	// per-device check and is refused for the global ceiling instead —
+	// proving this is the host-wide 503, not the per-device one.
+	ninth := harness.OpenStream(t, deviceC, "/v1/containers/"+id+"/logs/stream")
 	if ninth.Status != http.StatusServiceUnavailable {
-		t.Fatalf("ninth concurrent stream: status = %d, want %d; body = %s", ninth.Status, http.StatusServiceUnavailable, ninth.Body)
+		t.Fatalf("ninth concurrent stream (global ceiling): status = %d, want %d; body = %s", ninth.Status, http.StatusServiceUnavailable, ninth.Body)
 	}
 	var obj map[string]any
 	if err := json.Unmarshal(ninth.Body, &obj); err != nil {
@@ -445,7 +465,7 @@ func TestStreamSlotExhaustion(t *testing.T) {
 	deadline := time.Now().Add(15 * time.Second)
 	var freed *harness.Stream
 	for time.Now().Before(deadline) {
-		freed = harness.OpenStream(t, d, "/v1/containers/"+id+"/logs/stream")
+		freed = harness.OpenStream(t, deviceC, "/v1/containers/"+id+"/logs/stream")
 		if freed.Status == http.StatusOK {
 			break
 		}
@@ -455,6 +475,61 @@ func TestStreamSlotExhaustion(t *testing.T) {
 		t.Fatalf("a new stream still failed within 15s of freeing one of %d slots; want the freed slot reused", maxConcurrentStreams)
 	}
 	streams = append(streams, freed)
+}
+
+// TestStreamPerDeviceCapDoesNotLockOutOtherDevices is issue #80's stated
+// verification: pinning one device at maxStreamsPerDevice must not deny the
+// stream route to a second, otherwise-idle device — the regression the whole
+// per-device budget exists to fix. It does not run t.Parallel(), for the same
+// shared-budget reasoning TestStreamSlotExhaustion gives above.
+func TestStreamPerDeviceCapDoesNotLockOutOtherDevices(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	a, deviceA := readReadyAgent(t, "logs-stream-percap-a")
+	deviceB := harness.PairDevice(t, a, "logs-stream-percap-b")
+
+	id := harness.StartFixture(t, engine, harness.FixtureOptions{
+		NameSuffix: "percap",
+		Cmd:        logLinesCmd,
+	})
+
+	// maxStreamsPerDevice duplicates internal/httpapi/server.go's own
+	// constant, for the same D4 reasoning maxConcurrentStreams carries above.
+	const maxStreamsPerDevice = 3
+
+	streams := make([]*harness.Stream, 0, maxStreamsPerDevice+1)
+	defer func() {
+		for _, s := range streams {
+			s.Close(t)
+		}
+	}()
+
+	for i := 0; i < maxStreamsPerDevice; i++ {
+		s := harness.OpenStream(t, deviceA, "/v1/containers/"+id+"/logs/stream")
+		if s.Status != http.StatusOK {
+			t.Fatalf("device A stream %d/%d: status = %d, want %d; body = %s", i+1, maxStreamsPerDevice, s.Status, http.StatusOK, s.Body)
+		}
+		streams = append(streams, s)
+	}
+
+	blocked := harness.OpenStream(t, deviceA, "/v1/containers/"+id+"/logs/stream")
+	if blocked.Status != http.StatusServiceUnavailable {
+		t.Fatalf("device A's stream beyond its own cap: status = %d, want %d; body = %s", blocked.Status, http.StatusServiceUnavailable, blocked.Body)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(blocked.Body, &obj); err != nil {
+		t.Fatalf("decode device A's rejection body: %v; body = %s", err, blocked.Body)
+	}
+	if obj["error"] != "too many concurrent log streams for this device" {
+		t.Errorf(`device A's rejection error = %v, want "too many concurrent log streams for this device"`, obj["error"])
+	}
+
+	// The regression the issue is about: device A pinned at its own cap must
+	// not deny the route to device B.
+	s := harness.OpenStream(t, deviceB, "/v1/containers/"+id+"/logs/stream")
+	if s.Status != http.StatusOK {
+		t.Fatalf("device B stream while device A is at its own cap: status = %d, want %d; body = %s", s.Status, http.StatusOK, s.Body)
+	}
+	streams = append(streams, s)
 }
 
 // TestStreamAgainstUnknownContainer asserts a stream request against a

--- a/internal/httpapi/logs.go
+++ b/internal/httpapi/logs.go
@@ -38,10 +38,17 @@ const (
 	minTail = 1
 	maxTail = 2000
 
-	// msgTooManyStreams is served when every stream slot is in use. Unlike the
+	// msgTooManyStreams is served when the host's global stream ceiling is
+	// exhausted, regardless of which devices hold the slots. Unlike the
 	// other rejections this one is specific and actionable: the caller is an
 	// authenticated device and the fix is on its side — close a log view.
 	msgTooManyStreams = "too many concurrent log streams"
+
+	// msgTooManyDeviceStreams is served when the caller's own device is at
+	// maxStreamsPerDevice, distinct from msgTooManyStreams so a device that
+	// hit its own cap is told that, rather than being told the host is full
+	// when other devices may have slots to spare (issue #80).
+	msgTooManyDeviceStreams = "too many concurrent log streams for this device"
 
 	// msgInvalidSince is served for an unparsable resume cursor. Unlike tail,
 	// since is not defaulted on a parse failure: it reaches the Engine's
@@ -111,6 +118,11 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, r *http.Request) {
 // every path, including the 400 and 404 ones — a slot leaked on an error path
 // is permanent, and after eight bad requests the route would answer 503
 // forever until a restart.
+//
+// The slot is acquired per device (issue #80): a missing device in the
+// request context is a 500, the same reasoning withDeviceLimit gives — this
+// handler only ever runs behind requireDevice, and falling back to an
+// unkeyed slot would silently restore the bug being fixed.
 func (s *Server) handleStreamContainerLogs(w http.ResponseWriter, r *http.Request) {
 	if !s.requireDocker(w) {
 		return
@@ -122,10 +134,25 @@ func (s *Server) handleStreamContainerLogs(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	select {
-	case s.streams <- struct{}{}:
-		defer func() { <-s.streams }()
-	default:
+	device, ok := DeviceFrom(r.Context())
+	if !ok {
+		s.log.Error("handleStreamContainerLogs ran without a resolved device in the request context")
+		s.writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	release, outcome := s.streams.acquire(device.ID)
+	switch outcome {
+	case streamGranted:
+		defer release()
+	case streamDeviceFull:
+		s.log.Warn("too many concurrent log streams for device",
+			slog.String("device_id", device.ID), slog.Int("limit", maxStreamsPerDevice))
+		s.writeError(w, http.StatusServiceUnavailable, msgTooManyDeviceStreams)
+		return
+	case streamHostFull:
+		s.log.Warn("too many concurrent log streams for host",
+			slog.String("device_id", device.ID), slog.Any("holders", s.streams.holders()))
 		s.writeError(w, http.StatusServiceUnavailable, msgTooManyStreams)
 		return
 	}

--- a/internal/httpapi/logs_test.go
+++ b/internal/httpapi/logs_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -539,9 +540,13 @@ func TestStreamTerminalFrameClientGoneFailureLogsDebug(t *testing.T) {
 }
 
 // TestStreamSlotExhaustion holds maxConcurrentStreams streams open
-// concurrently, asserts the next request is 503 with msgTooManyStreams, then
+// concurrently, spread across enough distinct devices to reach the global
+// ceiling without any one of them hitting maxStreamsPerDevice, asserts the
+// next request (from yet another device) is 503 with msgTooManyStreams, then
 // releases one and asserts the following request succeeds — proving the slot
-// is returned rather than leaked.
+// is returned rather than leaked. One stream per device keeps this a
+// host-wide-exhaustion test distinct from
+// TestStreamPerDeviceCapDoesNotLockOutOtherDevices below.
 func TestStreamSlotExhaustion(t *testing.T) {
 	t.Parallel()
 
@@ -559,10 +564,14 @@ func TestStreamSlotExhaustion(t *testing.T) {
 		},
 	}
 	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
-	serial := pairDeviceForRead(t, st)
+	serials := make([]*big.Int, maxConcurrentStreams)
+	for i := range serials {
+		serials[i] = pairDeviceForRead(t, st)
+	}
 
 	done := make(chan struct{}, maxConcurrentStreams)
-	for i := 0; i < maxConcurrentStreams; i++ {
+	for _, serial := range serials {
+		serial := serial
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -581,8 +590,11 @@ func TestStreamSlotExhaustion(t *testing.T) {
 		}
 	}
 
-	// Act — every slot is held, so the next request must be rejected.
-	probe := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+	// Act — every slot is held across maxConcurrentStreams distinct devices,
+	// so the next request, from yet another device, must be rejected with
+	// the host-wide message rather than the per-device one.
+	probeSerial := pairDeviceForRead(t, st)
+	probe := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, probeSerial)
 	probeRec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
 	s.routes().ServeHTTP(probeRec, probe)
 
@@ -609,7 +621,7 @@ func TestStreamSlotExhaustion(t *testing.T) {
 	fd.streamContainerLogsFn = func(context.Context, string, dockerx.LogOptions, func(dockerx.LogLine) error) error {
 		return nil
 	}
-	nextReq := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial)
+	nextReq := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, probeSerial)
 	nextRec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
 	s.routes().ServeHTTP(nextRec, nextReq)
 
@@ -625,6 +637,124 @@ func TestStreamSlotExhaustion(t *testing.T) {
 	}
 	for i := 0; i < maxConcurrentStreams-1; i++ {
 		<-done
+	}
+}
+
+// TestStreamPerDeviceCapDoesNotLockOutOtherDevices is the issue's stated
+// verification: one device holding maxStreamsPerDevice streams is refused
+// its next one with msgTooManyDeviceStreams, while a second device — with
+// global capacity still free — still gets a stream. Before this change both
+// requests were served (or refused) from a single shared channel with no
+// notion of caller identity, so device A alone could have exhausted the
+// whole host budget.
+func TestStreamPerDeviceCapDoesNotLockOutOtherDevices(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	started := make(chan struct{}, maxStreamsPerDevice)
+	release := make(chan struct{})
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(ctx context.Context, _ string, _ dockerx.LogOptions, _ func(dockerx.LogLine) error) error {
+			started <- struct{}{}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	deviceA := pairDeviceForRead(t, st)
+	deviceB := pairDeviceForRead(t, st)
+
+	done := make(chan struct{}, maxStreamsPerDevice)
+	for i := 0; i < maxStreamsPerDevice; i++ {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, deviceA).WithContext(ctx)
+			rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+			s.routes().ServeHTTP(rec, req)
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < maxStreamsPerDevice; i++ {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of %d device A streams reported started", i, maxStreamsPerDevice)
+		}
+	}
+
+	// Act — device A is at its own cap; its next request must be refused
+	// with the per-device message, not the host-wide one.
+	probeA := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, deviceA)
+	probeARec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+	s.routes().ServeHTTP(probeARec, probeA)
+
+	// Assert
+	if probeARec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("device A status = %d, want 503; body: %s", probeARec.Code, probeARec.Body.String())
+	}
+	var bodyA errorBody
+	if err := json.NewDecoder(probeARec.Body).Decode(&bodyA); err != nil {
+		t.Fatalf("decode device A body: %v", err)
+	}
+	if bodyA.Error != msgTooManyDeviceStreams {
+		t.Errorf("device A error = %q, want %q", bodyA.Error, msgTooManyDeviceStreams)
+	}
+
+	// Act — device B, at zero streams, must still be served: this is the
+	// regression the issue is about.
+	fd.streamContainerLogsFn = func(context.Context, string, dockerx.LogOptions, func(dockerx.LogLine) error) error {
+		return nil
+	}
+	probeB := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, deviceB)
+	probeBRec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+	s.routes().ServeHTTP(probeBRec, probeB)
+
+	// Assert
+	if probeBRec.Code != http.StatusOK {
+		t.Errorf("device B status = %d, want 200; body: %s", probeBRec.Code, probeBRec.Body.String())
+	}
+
+	// Cleanup: release device A's held streams so their goroutines exit
+	// before the test returns.
+	for i := 0; i < maxStreamsPerDevice; i++ {
+		release <- struct{}{}
+	}
+	for i := 0; i < maxStreamsPerDevice; i++ {
+		<-done
+	}
+}
+
+// TestStreamContainerLogsRejectsWithoutDeviceInContext mirrors
+// TestWithDeviceLimitRejectsWithoutDeviceInContext (ratelimit_test.go):
+// handleStreamContainerLogs only ever runs behind requireDevice. Called
+// directly — bypassing routes() and therefore requireDevice — with a
+// request that carries no resolved device, it must answer 500 rather than
+// silently falling back to an unkeyed slot, which would quietly restore the
+// bug this phase fixes.
+func TestStreamContainerLogsRejectsWithoutDeviceInContext(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(context.Context, string, dockerx.LogOptions, func(dockerx.LogLine) error) error {
+			return nil
+		},
+	}
+	s, _ := testServerWithDocker(t, policy.ModeDefault, fd)
+	req := httptest.NewRequest(http.MethodGet, "/v1/containers/c1/logs/stream", nil)
+	rec := httptest.NewRecorder()
+
+	// Act — call the handler directly, skipping requireDevice.
+	s.handleStreamContainerLogs(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -190,6 +191,16 @@ func testServerWithDockerAndLogger(t *testing.T, mode policy.Mode, dc DockerRead
 	return NewServer(cfg, st, nil, dc, nil, log), st
 }
 
+// pairDeviceSerialCounter guarantees every serial pairDeviceForRead mints is
+// distinct across the whole test binary run, even when several calls land
+// in the same time.Now() tick — on Windows the wall clock's granularity is
+// coarse enough (commonly ~15ms) that a tight loop of calls, which the
+// per-device stream budget tests now make routinely, can otherwise produce
+// two identical UnixNano() values and collide on the certificate table's
+// UNIQUE constraint on serial. A package-level monotonic counter sidesteps
+// clock resolution entirely.
+var pairDeviceSerialCounter atomic.Int64
+
 // pairDeviceForRead creates and records an active device in st, returning
 // the serial of the certificate that authenticates it, for driving
 // requireDevice without a real TLS handshake — the same technique
@@ -201,7 +212,7 @@ func pairDeviceForRead(t *testing.T, st *state.Store) *big.Int {
 	if err != nil {
 		t.Fatalf("CreateDevice: %v", err)
 	}
-	serial := big.NewInt(time.Now().UnixNano())
+	serial := big.NewInt(pairDeviceSerialCounter.Add(1))
 	now := time.Now()
 	if err := st.RecordDeviceCert(ctx, device.ID, serial.Text(16), now, now.Add(90*24*time.Hour)); err != nil {
 		t.Fatalf("RecordDeviceCert: %v", err)

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -46,7 +46,19 @@ const (
 	// host it exists to protect. A constant rather than an env var: every extra
 	// startup setting is surface the operator has to understand at install time,
 	// and eight concurrent log views on one phone is already beyond any real use.
+	// This global ceiling is unchanged by the per-device cap below (issue #80);
+	// only how the eight are shared across devices changes.
 	maxConcurrentStreams = 8
+
+	// maxStreamsPerDevice bounds how many of maxConcurrentStreams a single
+	// device may hold at once (issue #80). Without this, one device holding
+	// every stream slot answers 503 for every other paired device — the
+	// budget was global-only and had no notion of who was calling. Three is
+	// generous for a couple of log views open on one phone, while still
+	// keeping the global ceiling reachable in practice: three devices at
+	// their own cap sum past eight, so the host-wide limit stays meaningful
+	// and testable rather than becoming unreachable dead code.
+	maxStreamsPerDevice = 3
 )
 
 // Server owns the HTTPS listener and its routes.
@@ -57,11 +69,12 @@ type Server struct {
 	// dc is the Docker read surface the eight read routes depend on.
 	dc  DockerReader
 	log *slog.Logger
-	// streams bounds concurrent live log streams (D10). Buffered to
-	// maxConcurrentStreams and initialised here rather than lazily in the
-	// handler: a nil channel blocks forever on send and never succeeds on a
-	// non-blocking select, which would answer every stream request with 503.
-	streams chan struct{}
+	// streams bounds concurrent live log streams (D10), with a global
+	// ceiling and a per-device cap under it (issue #80). Built here rather
+	// than lazily in the handler: a nil *streamBudget would panic on first
+	// use, and this way construction failure is impossible by
+	// construction — NewServer always builds one.
+	streams *streamBudget
 
 	// unauthGlobal is the shared, unkeyed backstop bucket every
 	// pre-authentication request checks first (D8).
@@ -118,7 +131,7 @@ type Server struct {
 // likewise be nil in tests that do not exercise the Docker read routes; every
 // read handler tolerates that by serving 502 instead of panicking.
 func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger) *Server {
-	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log, streams: make(chan struct{}, maxConcurrentStreams)}
+	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log, streams: newStreamBudget(maxConcurrentStreams, maxStreamsPerDevice)}
 	s.lifecycleCtx, s.cancelLifecycle = context.WithCancel(context.Background())
 
 	s.unauthGlobal = rate.NewLimiter(rate.Limit(unauthGlobalPerSec), unauthGlobalBurst)

--- a/internal/httpapi/streambudget.go
+++ b/internal/httpapi/streambudget.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import "sync"
+
+// streamOutcome names why an acquire succeeded or failed, so the caller can
+// answer with the right message and log the right thing.
+type streamOutcome int
+
+const (
+	streamGranted streamOutcome = iota
+	streamDeviceFull
+	streamHostFull
+)
+
+// streamBudget bounds concurrent live log streams with a global ceiling and
+// a per-device cap under it, so one device holding streams cannot starve
+// every other paired device (issue #80). It replaces the single buffered
+// channel that previously played this role.
+//
+// Live entries in byDevice are bounded by maxTotal, since every acquire
+// that grows the map also consumes a global slot; deleting an entry once
+// its count reaches zero is therefore the whole eviction story — there is
+// no separate maxKeys cap of the kind internal/ratelimit needs.
+type streamBudget struct {
+	mu           sync.Mutex
+	byDevice     map[string]int
+	total        int
+	maxTotal     int
+	maxPerDevice int
+}
+
+// newStreamBudget builds a streamBudget with a global ceiling of maxTotal
+// slots and a per-device cap of maxPerDevice.
+func newStreamBudget(maxTotal, maxPerDevice int) *streamBudget {
+	return &streamBudget{
+		byDevice:     make(map[string]int),
+		maxTotal:     maxTotal,
+		maxPerDevice: maxPerDevice,
+	}
+}
+
+// acquire takes one slot for deviceID. On streamGranted the returned release
+// must be called exactly once; on any other outcome release is nil.
+//
+// The per-device cap is checked before the global ceiling, so a device
+// already at its own cap is told that rather than being told the host is
+// full — the two refusals are deliberately distinguishable (see the plan's
+// Design section).
+func (b *streamBudget) acquire(deviceID string) (release func(), outcome streamOutcome) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.byDevice[deviceID] >= b.maxPerDevice {
+		return nil, streamDeviceFull
+	}
+	if b.total >= b.maxTotal {
+		return nil, streamHostFull
+	}
+
+	b.byDevice[deviceID]++
+	b.total++
+
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+
+			b.total--
+			b.byDevice[deviceID]--
+			if b.byDevice[deviceID] <= 0 {
+				delete(b.byDevice, deviceID)
+			}
+		})
+	}
+	return release, streamGranted
+}
+
+// holders returns a snapshot of live stream counts by device ID, for
+// logging and tests.
+func (b *streamBudget) holders() map[string]int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	snapshot := make(map[string]int, len(b.byDevice))
+	for id, count := range b.byDevice {
+		snapshot[id] = count
+	}
+	return snapshot
+}

--- a/internal/httpapi/streambudget_test.go
+++ b/internal/httpapi/streambudget_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestStreamBudgetPerDeviceCap proves a device may hold up to maxPerDevice
+// slots, and the next acquire for the same device is refused as
+// streamDeviceFull rather than consuming a global slot.
+func TestStreamBudgetPerDeviceCap(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	const maxPerDevice = 3
+	b := newStreamBudget(8, maxPerDevice)
+
+	// Act — fill the device's own cap
+	for i := 0; i < maxPerDevice; i++ {
+		_, outcome := b.acquire("device-a")
+		if outcome != streamGranted {
+			t.Fatalf("acquire %d: outcome = %v, want streamGranted", i, outcome)
+		}
+	}
+
+	// Assert — the next acquire for the same device is refused
+	release, outcome := b.acquire("device-a")
+	if outcome != streamDeviceFull {
+		t.Fatalf("acquire past per-device cap: outcome = %v, want streamDeviceFull", outcome)
+	}
+	if release != nil {
+		t.Fatal("acquire past per-device cap: release is not nil, want nil")
+	}
+}
+
+// TestStreamBudgetSecondDeviceStillGranted is the regression the issue is
+// about: a second device still gets a slot while the first is pinned at its
+// own per-device cap.
+func TestStreamBudgetSecondDeviceStillGranted(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	const maxPerDevice = 3
+	b := newStreamBudget(8, maxPerDevice)
+	for i := 0; i < maxPerDevice; i++ {
+		if _, outcome := b.acquire("device-a"); outcome != streamGranted {
+			t.Fatalf("seed acquire %d: outcome = %v, want streamGranted", i, outcome)
+		}
+	}
+
+	// Act
+	release, outcome := b.acquire("device-b")
+
+	// Assert
+	if outcome != streamGranted {
+		t.Fatalf("acquire for device-b: outcome = %v, want streamGranted", outcome)
+	}
+	if release == nil {
+		t.Fatal("acquire for device-b: release is nil, want non-nil")
+	}
+}
+
+// TestStreamBudgetGlobalCeiling proves enough devices at their own caps
+// exhaust the global ceiling, and the refusal is streamHostFull — not
+// streamDeviceFull — for the device that triggers it.
+func TestStreamBudgetGlobalCeiling(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — global ceiling of 8, per-device cap of 3: three devices at
+	// their own cap sum to 9, past the global ceiling, so the third device's
+	// last acquire must find the host full rather than its own cap hit.
+	const maxTotal = 8
+	const maxPerDevice = 3
+	b := newStreamBudget(maxTotal, maxPerDevice)
+
+	devices := []string{"device-a", "device-b", "device-c"}
+	granted := 0
+	for _, id := range devices {
+		for i := 0; i < maxPerDevice; i++ {
+			_, outcome := b.acquire(id)
+			if outcome == streamGranted {
+				granted++
+				continue
+			}
+			// Assert — the refusal must be streamHostFull, since this
+			// device has not yet reached its own cap of 3.
+			if outcome != streamHostFull {
+				t.Fatalf("acquire for %s (granted so far: %d): outcome = %v, want streamHostFull", id, granted, outcome)
+			}
+			if granted != maxTotal {
+				t.Fatalf("streamHostFull reached after %d grants, want %d", granted, maxTotal)
+			}
+			return
+		}
+	}
+	t.Fatalf("never hit streamHostFull after granting %d slots across %d devices", granted, len(devices))
+}
+
+// TestStreamBudgetReleaseReturnsSlot proves releasing a slot returns it to
+// both the device's own count and the global total, so a later acquire can
+// reuse it.
+func TestStreamBudgetReleaseReturnsSlot(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	b := newStreamBudget(1, 1)
+	release, outcome := b.acquire("device-a")
+	if outcome != streamGranted {
+		t.Fatalf("seed acquire: outcome = %v, want streamGranted", outcome)
+	}
+	if _, outcome := b.acquire("device-b"); outcome != streamHostFull {
+		t.Fatalf("acquire while budget is full: outcome = %v, want streamHostFull", outcome)
+	}
+
+	// Act
+	release()
+
+	// Assert — the freed slot is usable by another device
+	if _, outcome := b.acquire("device-b"); outcome != streamGranted {
+		t.Fatalf("acquire after release: outcome = %v, want streamGranted", outcome)
+	}
+}
+
+// TestStreamBudgetDeviceEntryDeletedAtZero proves the map entry for a
+// device disappears once its last stream is released — the whole eviction
+// story per the plan's Design section.
+func TestStreamBudgetDeviceEntryDeletedAtZero(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	b := newStreamBudget(8, 3)
+	release, outcome := b.acquire("device-a")
+	if outcome != streamGranted {
+		t.Fatalf("acquire: outcome = %v, want streamGranted", outcome)
+	}
+	if got := b.holders(); len(got) != 1 || got["device-a"] != 1 {
+		t.Fatalf("holders before release = %v, want {device-a: 1}", got)
+	}
+
+	// Act
+	release()
+
+	// Assert
+	if got := b.holders(); len(got) != 0 {
+		t.Fatalf("holders after release = %v, want empty", got)
+	}
+}
+
+// TestStreamBudgetDoubleReleaseDoesNotCorruptCounts proves a double
+// release() is a no-op rather than driving a count negative.
+func TestStreamBudgetDoubleReleaseDoesNotCorruptCounts(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	b := newStreamBudget(8, 3)
+	release, outcome := b.acquire("device-a")
+	if outcome != streamGranted {
+		t.Fatalf("acquire: outcome = %v, want streamGranted", outcome)
+	}
+
+	// Act — release twice
+	release()
+	release()
+
+	// Assert — the budget is back to fully empty, not negative
+	if got := b.holders(); len(got) != 0 {
+		t.Fatalf("holders after double release = %v, want empty", got)
+	}
+	release2, outcome := b.acquire("device-a")
+	if outcome != streamGranted {
+		t.Fatalf("acquire after double release: outcome = %v, want streamGranted", outcome)
+	}
+	if got := b.holders(); got["device-a"] != 1 {
+		t.Fatalf("holders after re-acquire = %v, want {device-a: 1}", got)
+	}
+	release2()
+}
+
+// TestStreamBudgetConcurrentAcquireRelease drives many goroutines through
+// acquire/release at once and proves neither the per-device cap nor the
+// global ceiling is ever exceeded. Run with -race.
+func TestStreamBudgetConcurrentAcquireRelease(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	const maxTotal = 8
+	const maxPerDevice = 3
+	const devices = 6
+	const attemptsPerDevice = 50
+
+	b := newStreamBudget(maxTotal, maxPerDevice)
+
+	var wg sync.WaitGroup
+	var violations int32
+	var mu sync.Mutex
+
+	for d := 0; d < devices; d++ {
+		deviceID := fmt.Sprintf("device-%d", d)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < attemptsPerDevice; i++ {
+				release, outcome := b.acquire(deviceID)
+				if outcome != streamGranted {
+					continue
+				}
+
+				// Assert — neither cap is ever exceeded while this slot is
+				// held. Reading holders() takes the same mutex acquire and
+				// release use, so this is a consistent snapshot, not a race.
+				holders := b.holders()
+				total := 0
+				for _, count := range holders {
+					total += count
+					if count > maxPerDevice {
+						mu.Lock()
+						violations++
+						mu.Unlock()
+					}
+				}
+				if total > maxTotal {
+					mu.Lock()
+					violations++
+					mu.Unlock()
+				}
+
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if violations != 0 {
+		t.Fatalf("observed %d cap violations during concurrent acquire/release", violations)
+	}
+}


### PR DESCRIPTION
The live-stream budget was a single server-wide buffered channel of 8, handed out
first-come, first-served with no notion of who was calling. One paired device holding eight
streams made `/v1/containers/{id}/logs/stream` answer 503 for every other paired device —
the one control in the guarded chain that did not key on device identity, while
`withDeviceLimit` sits immediately inside `requireDevice` on every other guarded route for
exactly the reason that identity is the stronger key.

## What changed

- **`streamBudget`** (`internal/httpapi/streambudget.go`) — a mutex-guarded map of live
  stream counts by device ID under a running total. `acquire` checks the per-device cap
  first, so a device at its own cap is told that rather than being told the host is full;
  `release` is `sync.Once`-guarded so a double release cannot drive a count negative, and
  the map entry is deleted at zero. Live entries are bounded by the global ceiling, which is
  why this needs no eviction hook on unpair or revoke and no `maxKeys` cap of the kind
  `internal/ratelimit` needs — an unpaired device still releases its slot when its stream
  ends, and the entry goes with it.
- **Global ceiling unchanged at 8**, per-device cap **3**. The file-descriptor argument at
  `server.go:43-49` was already correct and is not relaxed; only how the 8 are shared
  changes. Three keeps the ceiling genuinely reachable — it takes more than one device to
  get there now.
- **`handleStreamContainerLogs`** resolves the caller with `DeviceFrom` and acquires per
  device. A request that reaches the handler without a resolved device is a 500, on
  `withDeviceLimit`'s own reasoning: this handler only ever runs behind `requireDevice`, and
  falling back to an unkeyed slot would silently restore the bug being fixed. The existing
  ordering is kept — `requireDocker` and `sinceParam` still run before a slot is taken.
- **The 503 is diagnosable** (option 3 of the issue, worth doing regardless): a device at
  its own cap gets `too many concurrent log streams for this device`, a genuinely full host
  gets the unchanged `too many concurrent log streams` plus a Warn log naming the devices
  holding the slots. Device IDs are server-generated and the map is bounded by the ceiling,
  so this is bounded operator information — unlike client IPs, which `ratelimit.go`
  deliberately keeps out of the log.
- **`pairDeviceForRead`** now mints certificate serials from a counter instead of
  `time.Now().UnixNano()`. The new tests pair several devices per clock tick, which Windows'
  coarse wall clock made collide on the certificate table's UNIQUE constraint — a latent
  test-helper bug the new tests exposed rather than caused.

Not in scope, deliberately: no `DEVMON_*` knob for either limit, no queueing or fair-share
waiting, no forced teardown of a device's live streams on unpair or revoke.

## Tests

- `streambudget_test.go` — per-device cap, second device still granted while the first is
  capped, global ceiling returning `streamHostFull` rather than `streamDeviceFull`, release
  returning the slot to both counts, map entry deleted at zero, double-release safety, and a
  concurrent goroutine stress case under `-race`.
- `logs_test.go` — `TestStreamSlotExhaustion` reworked to reach the ceiling across distinct
  devices; `TestStreamPerDeviceCapDoesNotLockOutOtherDevices` is the issue's stated
  verification; `TestStreamContainerLogsRejectsWithoutDeviceInContext` pins the 500.
- `internal/e2e/api/contract_logs_test.go` — the contract suite drives three paired devices
  to 3/3/2 streams for the host-wide refusal and adds the per-device lockout case. The
  duplicated constants stay duplicated (D4) and now cover both limits.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/... -race` — green
- [x] Coverage 95.6% total, `internal/httpapi` 97.3% (floor 90%)
- [x] `golangci-lint run ./...` — 0 issues; `gosec ./...` — clean
- [x] e2e suite compiled and vetted under `-tags e2e`
- [ ] **e2e not executed** — no reachable Docker Engine in this environment. The two stream
      budget contract tests above have not been run against a live agent.

Closes #80

Refs #92
