### PR TITLE
fix: require Go 1.26.7, clearing five reachable stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scnplt/devmon-agent
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/containerd/errdefs v1.0.0


### PR DESCRIPTION
The `govulncheck` job on release PR #98 fails with five standard-library vulnerabilities, all `Found in: go1.26.5`, all `Fixed in: go1.26.6`. The one that matters most for this agent is GO-2026-5972 — unbounded recursion in `encoding/asn1`, reached from `CA.IssueDeviceCert` → `x509.ParseCertificateRequest`: the pre-authentication pairing path parsing an attacker-supplied CSR.

## Change

One line: `go.mod` `go 1.26.5` → `go 1.26.7`.

1.26.7 rather than 1.26.6 to match the digest-pinned builder image exactly — verified `docker run` against the pinned digest reports `go1.26.7`, so `GOTOOLCHAIN=local` in the Dockerfile keeps holding. CI installs from `go-version-file: go.mod`, so every job follows automatically. Same precedent as #88, which made this exact bump for GO-2026-5856.

## Test plan

- [x] `go build ./...`, `go vet ./...` on go1.26.7
- [x] `go test ./internal/... -race` — all packages ok
- [x] `govulncheck v1.6.0` (CI's pinned version) locally: **No vulnerabilities found**
- [ ] CI green

Closes #101

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)