### PR TITLE
fix: keep audit list at six columns when identity rows have no target

### DIFF
--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -266,7 +266,7 @@ func runAuditList(ctx context.Context, st *state.Store, w io.Writer, limit int) 
 	}
 	for _, e := range entries {
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			e.OccurredAt.Format(deviceTimeFormat), auditDeviceColumn(devices, e.DeviceID), e.Operation, e.Target, e.Outcome, e.Detail); err != nil {
+			e.OccurredAt.Format(deviceTimeFormat), auditDeviceColumn(devices, e.DeviceID), e.Operation, orDash(e.Target), e.Outcome, orDash(e.Detail)); err != nil {
 			return fmt.Errorf("write audit list row: %w", err)
 		}
 	}
@@ -286,4 +286,23 @@ func auditDeviceColumn(devices []state.Device, id string) string {
 		return id
 	}
 	return fmt.Sprintf("%s (%s)", id, name)
+}
+
+// auditEmptyColumn is printed in place of an empty TARGET or DETAIL cell.
+// Identity audit rows (pair, renew, unpair_self — internal/httpapi/audit.go)
+// leave one or both of those fields empty by design: pairing and renewal
+// have no container target, and a pair row has no detail to report. An empty
+// tabwriter cell between tab stops collapses visually and defeats column
+// counting, so every row always carries six visually distinct columns.
+const auditEmptyColumn = "-"
+
+// orDash returns auditEmptyColumn for an empty string and s unchanged
+// otherwise, keeping every `audit list` row at a fixed column count for both
+// human readers and the tabwriter-column parser in
+// internal/e2e/harness/cli.go.
+func orDash(s string) string {
+	if s == "" {
+		return auditEmptyColumn
+	}
+	return s
 }

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -385,6 +385,87 @@ func TestRunAuditListRespectsLimit(t *testing.T) {
 	}
 }
 
+func TestRunAuditListPrintsDashForEmptyTargetAndDetail(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — mirrors the identity operations (pair, renew, unpair_self;
+	// internal/httpapi/audit.go) that leave Target and/or Detail empty by
+	// design: pairing and renewal have no container target, and a pair row
+	// has no detail. An empty tabwriter cell between tab stops collapses
+	// visually and defeats the e2e harness's column-count parser
+	// (internal/e2e/harness/cli.go's parseTable), so every row must always
+	// print a visually distinct placeholder instead.
+	st := openTestStore(t)
+	ctx := context.Background()
+	device, err := st.CreateDevice(ctx, "Pixel 9")
+	if err != nil {
+		t.Fatalf("CreateDevice() unexpected error: %v", err)
+	}
+	entry := state.AuditEntry{
+		DeviceID:  device.ID,
+		Operation: "pair",
+		Target:    "",
+		Outcome:   state.OutcomeSuccess,
+		Detail:    "",
+	}
+	if err := st.AppendAudit(ctx, entry); err != nil {
+		t.Fatalf("AppendAudit() unexpected error: %v", err)
+	}
+	var buf bytes.Buffer
+
+	// Act
+	if err := runAuditList(ctx, st, &buf, defaultAuditLimit); err != nil {
+		t.Fatalf("runAuditList() unexpected error: %v", err)
+	}
+
+	// Assert — the row is header + one line; every field, including the two
+	// placeholders, must land in its own tab-separated cell.
+	got := buf.String()
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("runAuditList() printed %d lines, want 2 (header + 1 row): %q", len(lines), got)
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) < 5 {
+		t.Fatalf("runAuditList() row %q, want at least 5 whitespace-separated fields", lines[1])
+	}
+	dashCount := 0
+	for _, f := range fields {
+		if f == auditEmptyColumn {
+			dashCount++
+		}
+	}
+	if dashCount != 2 {
+		t.Errorf("runAuditList() row = %q, want exactly 2 fields equal to %q (TARGET and DETAIL), got %d", lines[1], auditEmptyColumn, dashCount)
+	}
+}
+
+func TestOrDash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty string becomes the placeholder", "", auditEmptyColumn},
+		{"non-empty string is unchanged", "web", "web"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := orDash(tt.in)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("orDash(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunAuditListCommandParsesLimitFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/e2e/api/contract_audit_test.go
+++ b/internal/e2e/api/contract_audit_test.go
@@ -45,6 +45,34 @@ import (
 // searching a long list for its own rows.
 const auditListLimit = 50
 
+// identityAuditOperations names the operation column values withPairAudit
+// and withIdentityAudit write (internal/httpapi/audit.go's opPair, opRenew,
+// opUnpairSelf). Since #69, harness.PairDevice's own pairing request writes
+// one of these (a "pair" row) before a test's scripted sequence ever runs,
+// so a test that asserts an exact row count for its own scripted calls must
+// exclude identity rows to stay meaningful regardless of how many pairing or
+// renewal events its setup happens to produce.
+var identityAuditOperations = map[string]bool{
+	"pair":        true,
+	"renew":       true,
+	"unpair_self": true,
+}
+
+// nonIdentityAuditRows filters rows down to the ones NOT written by identity
+// bootstrapping (see identityAuditOperations), preserving order. Used by
+// every test in this file that asserts an exact count of rows its own
+// scripted container-lifecycle calls produced, so the assertion does not
+// silently over-count the pairing row PairDevice always writes.
+func nonIdentityAuditRows(rows []harness.AuditRow) []harness.AuditRow {
+	result := make([]harness.AuditRow, 0, len(rows))
+	for _, row := range rows {
+		if !identityAuditOperations[row.Operation] {
+			result = append(result, row)
+		}
+	}
+	return result
+}
+
 // TestAuditRowPerMutatingRequest replays a small scripted sequence — a
 // restart that succeeds, a kill refused by default policy, and a delete of a
 // container that does not exist — against one agent with no other audit
@@ -85,9 +113,12 @@ func TestAuditRowPerMutatingRequest(t *testing.T) {
 		t.Fatalf("step 3, restart of an unknown container: status = %d, want %d; body = %s", status, http.StatusNotFound, raw)
 	}
 
-	rows := harness.ListAudit(t, a, auditListLimit)
+	// Excludes the pair row d's own PairDevice call writes (identityAuditOperations
+	// doc comment: since #69, pairing itself is audited), so this count stays
+	// exactly the three scripted lifecycle calls below.
+	rows := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(rows) != 3 {
-		t.Fatalf("audit list holds %d rows, want exactly 3: %+v", len(rows), rows)
+		t.Fatalf("audit list holds %d non-identity rows, want exactly 3: %+v", len(rows), rows)
 	}
 
 	// Newest first: the unknown-container restart lands last and is listed first.
@@ -144,9 +175,12 @@ func TestAuditRecordsRefusals(t *testing.T) {
 		t.Fatalf("POST .../kill under default policy: status = %d, want %d; body = %s", status, http.StatusForbidden, raw)
 	}
 
-	rows := harness.ListAudit(t, a, auditListLimit)
+	// Excludes the pair row PairDevice's own call writes (identityAuditOperations
+	// doc comment: since #69, pairing itself is audited), so this count stays
+	// exactly the one refused request under test.
+	rows := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(rows) != 1 {
-		t.Fatalf("audit list holds %d rows after one refused request, want exactly 1: %+v", len(rows), rows)
+		t.Fatalf("audit list holds %d non-identity rows after one refused request, want exactly 1: %+v", len(rows), rows)
 	}
 	if rows[0].Outcome != "denied_policy" {
 		t.Errorf("refused request's row outcome = %q, want %q", rows[0].Outcome, "denied_policy")
@@ -192,9 +226,13 @@ func TestReadsWriteNoAuditRows(t *testing.T) {
 		}
 	}
 
-	rows := harness.ListAudit(t, a, auditListLimit)
+	// PairDevice's own call writes one identity "pair" row (identityAuditOperations
+	// doc comment: since #69, pairing itself is audited); that row is expected
+	// and excluded here, so what remains must genuinely be zero — the read and
+	// log routes under test.
+	rows := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(rows) != 0 {
-		t.Errorf("audit list holds %d rows after only read and log requests, want 0: %+v", len(rows), rows)
+		t.Errorf("audit list holds %d non-identity rows after only read and log requests, want 0: %+v", len(rows), rows)
 	}
 }
 
@@ -219,9 +257,12 @@ func TestRevokedDeviceWritesNoAuditRow(t *testing.T) {
 	if status != http.StatusNoContent {
 		t.Fatalf("sanity restart before revocation: status = %d, want %d; body = %s", status, http.StatusNoContent, raw)
 	}
-	before := harness.ListAudit(t, a, auditListLimit)
+	// Excludes the pair row PairDevice's own call wrote before the sanity
+	// restart (identityAuditOperations doc comment: since #69, pairing itself
+	// is audited), so "before" is exactly the one legitimate mutating request.
+	before := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(before) != 1 {
-		t.Fatalf("audit list before revocation holds %d rows, want exactly 1: %+v", len(before), before)
+		t.Fatalf("audit list before revocation holds %d non-identity rows, want exactly 1: %+v", len(before), before)
 	}
 
 	harness.RevokeDevice(t, a, d.ID)
@@ -231,9 +272,9 @@ func TestRevokedDeviceWritesNoAuditRow(t *testing.T) {
 		t.Fatalf("revoked device POST .../stop: status = %d, want %d; body = %s", status, http.StatusUnauthorized, raw)
 	}
 
-	after := harness.ListAudit(t, a, auditListLimit)
+	after := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(after) != len(before) {
-		t.Errorf("audit list after a revoked device's retry holds %d rows, want unchanged from %d: %+v", len(after), len(before), after)
+		t.Errorf("audit list after a revoked device's retry holds %d non-identity rows, want unchanged from %d: %+v", len(after), len(before), after)
 	}
 }
 
@@ -277,9 +318,12 @@ func TestAuditRecordsEngineUnavailable(t *testing.T) {
 		t.Fatalf("POST .../restart with the Engine severed: status = %d, want %d; body = %s", status, http.StatusBadGateway, raw)
 	}
 
-	rows := harness.ListAudit(t, a, auditListLimit)
+	// Excludes the pair row d's own PairDevice call writes (identityAuditOperations
+	// doc comment: since #69, pairing itself is audited), so this count stays
+	// exactly the one Engine-unavailable attempt under test.
+	rows := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(rows) != 1 {
-		t.Fatalf("audit list after one Engine-unavailable attempt holds %d rows, want exactly 1: %+v", len(rows), rows)
+		t.Fatalf("audit list after one Engine-unavailable attempt holds %d non-identity rows, want exactly 1: %+v", len(rows), rows)
 	}
 	if rows[0].Outcome != "engine_error" {
 		t.Errorf("row outcome with the Engine severed = %q, want %q", rows[0].Outcome, "engine_error")
@@ -339,9 +383,12 @@ func TestAuditDetailCarriesNoEngineText(t *testing.T) {
 	}
 	proxy.Restore(t)
 
-	rows := harness.ListAudit(t, a, auditListLimit)
+	// Excludes the pair row d's own PairDevice call writes (identityAuditOperations
+	// doc comment: since #69, pairing itself is audited), so this count stays
+	// exactly the four scripted outcomes below.
+	rows := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
 	if len(rows) != 4 {
-		t.Fatalf("audit list holds %d rows after the four scripted outcomes, want exactly 4: %+v", len(rows), rows)
+		t.Fatalf("audit list holds %d non-identity rows after the four scripted outcomes, want exactly 4: %+v", len(rows), rows)
 	}
 
 	forbidden := []string{
@@ -377,17 +424,20 @@ func TestAuditSurvivesAgentRestart(t *testing.T) {
 		t.Fatalf("restart before agent restart: status = %d, want %d; body = %s", status, http.StatusNoContent, raw)
 	}
 
-	before := harness.ListAudit(t, a1, auditListLimit)
+	// Excludes the pair row d1's own PairDevice call wrote (identityAuditOperations
+	// doc comment: since #69, pairing itself is audited), so "before" is
+	// exactly the one restart under test.
+	before := nonIdentityAuditRows(harness.ListAudit(t, a1, auditListLimit))
 	if len(before) != 1 {
-		t.Fatalf("audit list before the agent restart holds %d rows, want exactly 1: %+v", len(before), before)
+		t.Fatalf("audit list before the agent restart holds %d non-identity rows, want exactly 1: %+v", len(before), before)
 	}
 
 	a1.Stop(t)
 	a2 := harness.StartAgent(t, harness.AgentOptions{StateDir: stateDir})
 
-	after := harness.ListAudit(t, a2, auditListLimit)
+	after := nonIdentityAuditRows(harness.ListAudit(t, a2, auditListLimit))
 	if len(after) != len(before) {
-		t.Fatalf("audit list after the agent restart holds %d rows, want unchanged from %d: %+v", len(after), len(before), after)
+		t.Fatalf("audit list after the agent restart holds %d non-identity rows, want unchanged from %d: %+v", len(after), len(before), after)
 	}
 	if after[0] != before[0] {
 		t.Errorf("audit row after restart = %+v, want unchanged from %+v", after[0], before[0])

--- a/internal/e2e/api/contract_logs_test.go
+++ b/internal/e2e/api/contract_logs_test.go
@@ -421,7 +421,7 @@ func TestStreamSlotExhaustion(t *testing.T) {
 	deviceB := harness.PairDevice(t, a, "logs-stream-slots-b")
 	deviceC := harness.PairDevice(t, a, "logs-stream-slots-c")
 	devices := []*harness.Device{deviceA, deviceB, deviceC}
-	perDevice := []int{3, 3, 2}
+	perDevice := []int{maxStreamsPerDevice, maxStreamsPerDevice, 2}
 
 	streams := make([]*harness.Stream, 0, maxConcurrentStreams)
 	defer func() {

--- a/internal/e2e/harness/cli.go
+++ b/internal/e2e/harness/cli.go
@@ -112,6 +112,17 @@ func parseDeviceRows(t *testing.T, out string) []DeviceRow {
 	return result
 }
 
+// auditEmptyColumn is cmd/devmon-agent/cli.go's orDash placeholder: an
+// identity audit row (pair, renew, unpair_self) leaves TARGET and/or DETAIL
+// empty, and the CLI prints "-" there instead so every row keeps six
+// visually distinct columns for both a human reader and this parser. "-" is
+// never a valid container reference or a real detail value in this system
+// (references are hex device/container IDs or Docker names; details are
+// either empty or a short server-generated tag), so mapping it back to ""
+// here is unambiguous and lets existing assertions keep comparing against
+// real refs or genuine empties.
+const auditEmptyColumn = "-"
+
 // parseAuditRows parses `audit list`'s tabwriter table into AuditRow values.
 // Shared by the host-side (ListAudit) and in-container (ListAuditInContainer)
 // call sites so their assertions never drift apart.
@@ -125,12 +136,21 @@ func parseAuditRows(t *testing.T, out string) []AuditRow {
 			OccurredAt: f[0],
 			Device:     f[1],
 			Operation:  f[2],
-			Target:     f[3],
+			Target:     undash(f[3]),
 			Outcome:    f[4],
-			Detail:     f[5],
+			Detail:     undash(f[5]),
 		})
 	}
 	return result
+}
+
+// undash maps the CLI's "-" placeholder back to the empty string it stands
+// in for, leaving every other value unchanged.
+func undash(s string) string {
+	if s == auditEmptyColumn {
+		return ""
+	}
+	return s
 }
 
 // parseTable splits a tabwriter table's stdout into rows of exactly


### PR DESCRIPTION
Two of the `e2e` failures on release PR #98 (`TestAuditRecordsEngineUnavailable`, `TestAuditDetailCarriesNoEngineText`) trace to one CLI defect and one masked test defect, both from #69 and both invisible until the release bar ran — `e2e` runs only on PRs into `main`.

## CLI defect

Identity audit rows (`pair`, `renew`, `unpair_self`) carry an empty target — pair rows an empty detail too — and `audit list` printed the fields raw. Tabwriter collapses an empty cell between tab stops, so any table holding an identity row lost a column, positionally unreadable for humans and fatal for the harness parser. `audit list` now prints `-` for an empty target/detail, and the harness maps `-` back to `""` — `-` is never a valid container reference or detail value, so the round trip is unambiguous.

## Masked test defect

With rows parsing again, the audit contract tests over-counted: they assert exact row counts and predate #69, so the pair row each test's own `PairDevice` call writes made every count one high. The tests now filter identity operations out via `nonIdentityAuditRows` and keep asserting the **exact** count their scripted calls produce — the two "write NO rows" tests stay `== 0` over the filtered slice, not weakened to `>=`. The rate-limit and self-exclusion audit assertions were audited too: relative comparisons, unaffected.

## Rider: e2e lint

A separate commit fixes the one `golangci-lint --build-tags e2e` finding: #93 declared `maxStreamsPerDevice` so the suite would notice a limit change, then hardcoded `3` anyway. The e2e job runs `make e2e-lint` only after `make e2e` passes, so this was unreachable on #98 until the audit fixes landed — it would have been the next red. Values unchanged.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags e2e ./...` — clean
- [x] `go test ./internal/... ./cmd/... -race` — all ok; coverage 95.6% (floor 90%)
- [x] `golangci-lint run ./...` and `--build-tags e2e ./internal/e2e/...` — 0 issues
- [x] New unit tests: `TestRunAuditListPrintsDashForEmptyTargetAndDetail`, `TestOrDash`
- [x] e2e verified in a Linux golang container against the local Docker engine: all seven audit contract tests pass, including the two that fail on #98. (`TestAuditIsNotReachableOverTheAPI` times out on SIGTERM in that nested environment on the **pristine** branch too — environment artifact, passes in CI.)
- [ ] CI green; `e2e` on #98 after merge

Closes #100

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)