### PR TITLE
fix: rotate at startup only when the log's first line is already stale

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -68,8 +68,14 @@ func NewSink(cfg config.Config) (*Sink, error) {
 	logger := slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: cfg.LogLevel}))
 
 	return &Sink{
-		Logger:  logger,
-		rotator: NewRotator(lj, defaultRotateInterval, logger),
+		Logger: logger,
+		// cfg.LogMaxAge is the same budget lj.MaxAge above was derived from,
+		// so the startup pass judges staleness against exactly the operator's
+		// configured DEVMON_LOG_MAX_AGE_DAYS. config.Load floors it at 1 day
+		// (internal/config/config.go, minDays), so in production this is
+		// never zero; NewRotator treats zero as "startup pass disabled" only
+		// as a defensive default for callers that build a Rotator directly.
+		rotator: NewRotator(lj, defaultRotateInterval, cfg.LogMaxAge, logger),
 		lj:      lj,
 	}, nil
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -227,17 +227,169 @@ func TestRotatorRunStopsOnContextCancel(t *testing.T) {
 	}
 }
 
-// TestRotatorRunRotatesOnStartupWhenFileHasContent is the regression test for
-// issue #42: a Rotator that has just started must not wait a full interval
-// (24h in production) before its first pass, or DEVMON_LOG_MAX_AGE_DAYS is
-// never enforced on a host that restarts more often than that.
-func TestRotatorRunRotatesOnStartupWhenFileHasContent(t *testing.T) {
+// writeLogLineWithTime appends one line to path using slog's own TextHandler
+// encoding, so a crafted timestamp lands in exactly the format startupRotate
+// must parse. Building the fixture through the real encoder — rather than
+// hand-writing a "time=..." string — keeps these tests from silently drifting
+// out of sync with NewSink's actual output shape.
+func writeLogLineWithTime(t *testing.T, path string, ts time.Time, msg string) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := slog.NewTextHandler(f, nil)
+	rec := slog.NewRecord(ts, slog.LevelInfo, msg, 0)
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("write log line: %v", err)
+	}
+}
+
+// TestStartupRotate exercises startupRotate directly across every content
+// shape it must decide on, isolated from the ticker and from Run's
+// context-cancellation handling.
+func TestStartupRotate(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — a real log line means the current file is non-empty, the
-	// shape a freshly booted agent's log is in by the time Run starts (see
-	// serve() in cmd/devmon-agent: several lines are logged before runAll
-	// starts the rotator).
+	const maxAge = 24 * time.Hour
+
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, path string) // no-op leaves the file missing
+		wantRotated bool
+	}{
+		{
+			name: "fresh first line is not rotated",
+			setup: func(t *testing.T, path string) {
+				writeLogLineWithTime(t, path, time.Now(), "line written just now")
+			},
+			wantRotated: false,
+		},
+		{
+			name: "stale first line is rotated",
+			setup: func(t *testing.T, path string) {
+				writeLogLineWithTime(t, path, time.Now().Add(-(maxAge + time.Hour)), "line from a previous boot")
+			},
+			wantRotated: true,
+		},
+		{
+			name: "empty file is untouched",
+			setup: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatalf("write empty file: %v", err)
+				}
+			},
+			wantRotated: false,
+		},
+		{
+			name:        "missing file is untouched",
+			setup:       func(t *testing.T, path string) {},
+			wantRotated: false,
+		},
+		{
+			name: "unparsable first line is rotated",
+			setup: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte("not a slog line at all\n"), 0o600); err != nil {
+					t.Fatalf("write corrupt file: %v", err)
+				}
+			},
+			wantRotated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			dir := t.TempDir()
+			path := filepath.Join(dir, "agent.log")
+			var before []byte
+			tt.setup(t, path)
+			if data, err := os.ReadFile(path); err == nil {
+				before = data
+			}
+
+			lj := &lumberjack.Logger{Filename: path}
+			// Rotate's openNew keeps the freshly created current file open in
+			// lj for future writes; on Windows an unclosed handle blocks
+			// t.TempDir's cleanup.
+			t.Cleanup(func() { _ = lj.Close() })
+			log, _ := newCapturingLoggerForTest()
+			r := NewRotator(lj, time.Hour, maxAge, log)
+
+			// Act
+			r.startupRotate()
+
+			// Assert
+			entries, err := filepath.Glob(filepath.Join(dir, "agent-*"))
+			if err != nil {
+				t.Fatalf("glob: %v", err)
+			}
+			if gotRotated := len(entries) > 0; gotRotated != tt.wantRotated {
+				t.Errorf("rotated = %v, want %v (backups: %v)", gotRotated, tt.wantRotated, entries)
+			}
+			if !tt.wantRotated && before != nil {
+				after, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s after startupRotate: %v", path, err)
+				}
+				if string(after) != string(before) {
+					t.Errorf("content changed for a file that should not have been rotated: before %q, after %q", before, after)
+				}
+			}
+		})
+	}
+}
+
+// TestStartupRotateNeverRotatesWhenMaxAgeIsZero covers the defensive
+// zero-disables-the-pass path documented on NewRotator. Production config
+// (internal/config/config.go, minDays) floors DEVMON_LOG_MAX_AGE_DAYS at 1
+// day, so this is not reachable through NewSink; it guards a Rotator built
+// directly, and the behaviour it locks in — zero means "never startup-rotate"
+// — is the one NewSink relies on being safe to fall back to.
+func TestStartupRotateNeverRotatesWhenMaxAgeIsZero(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a file stale enough that a positive maxAge would certainly
+	// rotate it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.log")
+	writeLogLineWithTime(t, path, time.Now().Add(-30*24*time.Hour), "ancient line")
+
+	lj := &lumberjack.Logger{Filename: path}
+	log, _ := newCapturingLoggerForTest()
+	r := NewRotator(lj, time.Hour, 0, log)
+
+	// Act
+	r.startupRotate()
+
+	// Assert
+	entries, err := filepath.Glob(filepath.Join(dir, "agent-*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("logs dir contains %v, want no rotation when maxAge is 0 (disabled)", entries)
+	}
+}
+
+// TestRotatorRunSkipsStartupRotationWhenFileIsFresh is the regression test
+// for issue #99: a Rotator started right after the sink begins writing must
+// not rotate away this boot's own opening lines. Before #99 the startup pass
+// rotated on content alone (any non-empty file), so the sink's earliest
+// lines — self-identification, "agent listening" — were always moved into a
+// backup by the time anything could read them from agent.log.
+func TestRotatorRunSkipsStartupRotationWhenFileIsFresh(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a real log line timestamped now, the shape a freshly booted
+	// agent's log is in by the time Run starts (see serve() in
+	// cmd/devmon-agent: several lines are logged before runAll starts the
+	// rotator).
 	cfg := testConfig(t, 8)
 	s, err := NewSink(cfg)
 	if err != nil {
@@ -245,11 +397,62 @@ func TestRotatorRunRotatesOnStartupWhenFileHasContent(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = s.Close() })
 	s.lj.Compress = false
-	s.Logger.Info("line written before Run starts")
+	s.Logger.Info("agent listening", slog.String("marker", "startup-line"))
+
+	r := NewRotator(s.lj, time.Hour, cfg.LogMaxAge, s.Logger)
+	runCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	done := make(chan struct{})
+
+	// Act
+	go func() {
+		defer close(done)
+		_ = r.Run(runCtx)
+	}()
+	<-runCtx.Done()
+	cancel()
+	<-done
+
+	// Assert — no rotated backup, and the startup line is still there.
+	entries, err := filepath.Glob(filepath.Join(cfg.LogsDir(), "agent-*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("logs dir contains rotated backups %v, want none: a fresh startup line must not be rotated away", entries)
+	}
+
+	data, err := os.ReadFile(cfg.AgentLogPath())
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(data), "startup-line") {
+		t.Error("agent.log no longer contains the startup line; it was rotated away")
+	}
+}
+
+// TestRotatorRunRotatesOnStartupWhenFileIsStale is the regression test for
+// issue #42, narrowed by #99: a Rotator that has just started must not wait a
+// full interval (24h in production) before enforcing DEVMON_LOG_MAX_AGE_DAYS
+// on an agent restarted more often than that — but only once the existing
+// content is actually older than the configured max age, not merely because
+// the file is non-empty.
+func TestRotatorRunRotatesOnStartupWhenFileIsStale(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a log line timestamped well before cfg.LogMaxAge, standing in
+	// for agent.log carried over from a much earlier boot.
+	cfg := testConfig(t, 8)
+	s, err := NewSink(cfg)
+	if err != nil {
+		t.Fatalf("NewSink() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	s.lj.Compress = false
+	writeLogLineWithTime(t, s.lj.Filename, time.Now().Add(-(cfg.LogMaxAge + time.Hour)), "line from a previous boot")
 
 	// Arrange — interval far longer than the test timeout proves any rotated
 	// backup found below cannot be explained by a tick firing.
-	r := NewRotator(s.lj, time.Hour, s.Logger)
+	r := NewRotator(s.lj, time.Hour, cfg.LogMaxAge, s.Logger)
 	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	done := make(chan struct{})
 
@@ -264,7 +467,7 @@ func TestRotatorRunRotatesOnStartupWhenFileHasContent(t *testing.T) {
 	cancel()
 	<-done
 	if len(entries) == 0 {
-		t.Error("Run() never produced a rotated backup within the test window; the startup pass regressed")
+		t.Error("Run() never produced a rotated backup for a stale file within the test window; the startup pass regressed")
 	}
 }
 
@@ -293,7 +496,7 @@ func TestRotatorRunSkipsStartupRotationOnEmptyOrMissingFile(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 	s.lj.Compress = false
 
-	r := NewRotator(s.lj, time.Hour, s.Logger)
+	r := NewRotator(s.lj, time.Hour, cfg.LogMaxAge, s.Logger)
 	runCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	done := make(chan struct{})
 
@@ -332,7 +535,7 @@ func TestRotatorRunDoesNothingWhenContextAlreadyCancelled(t *testing.T) {
 	s.lj.Compress = false
 	s.Logger.Info("line written before Run is ever called")
 
-	r := NewRotator(s.lj, time.Hour, s.Logger)
+	r := NewRotator(s.lj, time.Hour, cfg.LogMaxAge, s.Logger)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -370,9 +573,12 @@ func TestRotatorRotatesOnTick(t *testing.T) {
 	// behaviour under test here (the ticker driving rotation is), so turn it
 	// off.
 	s.lj.Compress = false
+	// Timestamped now, so the startup pass (a fresh file) does not itself
+	// account for the rotated file this test looks for below; only the
+	// ticker should be able to produce one.
 	s.Logger.Info("seed line so there is something to rotate")
 
-	r := NewRotator(s.lj, 10*time.Millisecond, s.Logger)
+	r := NewRotator(s.lj, 10*time.Millisecond, cfg.LogMaxAge, s.Logger)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	// The test returns as soon as it sees one rotated file, but the ticker
 	// keeps firing until it is told to stop. Cancelling is not enough: a tick
@@ -416,7 +622,7 @@ func TestRotateOnceLogsErrorWhenRotateFails(t *testing.T) {
 	}
 	lj := &lumberjack.Logger{Filename: filepath.Join(blocker, "sub", "agent.log")}
 	log, buf := newCapturingLoggerForTest()
-	r := NewRotator(lj, defaultRotateInterval, log)
+	r := NewRotator(lj, defaultRotateInterval, defaultRotateInterval, log)
 
 	// Act — must not panic.
 	r.rotateOnce()

--- a/internal/logging/rotator.go
+++ b/internal/logging/rotator.go
@@ -3,9 +3,14 @@
 package logging
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -14,6 +19,14 @@ import (
 // defaultRotateInterval is one day, matching the granularity of
 // DEVMON_LOG_MAX_AGE_DAYS.
 const defaultRotateInterval = 24 * time.Hour
+
+// slogTimeKeyPrefix is how slog's built-in TextHandler renders the record
+// timestamp as the first key=value pair on every line, given the
+// HandlerOptions this package actually constructs in NewSink (no
+// ReplaceAttr, no JSON handler). The value that follows is RFC3339Nano and so
+// never contains a space, which is what lets startupRotate isolate it with a
+// plain substring split instead of a full key=value parser.
+const slogTimeKeyPrefix = "time="
 
 // Rotator forces a log rotation on a fixed interval.
 //
@@ -26,12 +39,18 @@ const defaultRotateInterval = 24 * time.Hour
 type Rotator struct {
 	lj       *lumberjack.Logger
 	interval time.Duration
+	maxAge   time.Duration
 	log      *slog.Logger
 }
 
-// NewRotator returns a Rotator that rotates lj every interval.
-func NewRotator(lj *lumberjack.Logger, interval time.Duration, log *slog.Logger) *Rotator {
-	return &Rotator{lj: lj, interval: interval, log: log}
+// NewRotator returns a Rotator that rotates lj every interval, and that also
+// rotates a stale current file once at startup (see Run and startupRotate).
+// maxAge should be the same age budget lj.MaxAge was derived from
+// (config.Config.LogMaxAge in production); a value of zero or less disables
+// the startup pass entirely, which callers that construct a Rotator directly
+// (rather than through NewSink) may rely on to skip it.
+func NewRotator(lj *lumberjack.Logger, interval, maxAge time.Duration, log *slog.Logger) *Rotator {
+	return &Rotator{lj: lj, interval: interval, maxAge: maxAge, log: log}
 }
 
 // Run rotates once immediately and then on each tick until ctx is cancelled,
@@ -48,15 +67,16 @@ func NewRotator(lj *lumberjack.Logger, interval time.Duration, log *slog.Logger)
 // never blocks, the agent coming up. If ctx is already cancelled on entry,
 // Run returns immediately without touching the log file.
 //
-// The startup pass calls startupRotate, not rotateOnce directly, to avoid
-// spraying empty rotated backups on a crash-looping agent: verified against
-// lumberjack v2.2.1's Logger.openNew, Rotate renames the current file aside
-// whenever os.Stat on it succeeds, with no check on size — a zero-byte
-// current file would still be renamed into a useless backup on every boot.
-// A missing current file is harmless on its own (openNew just creates it,
-// no rename), but skipping both missing and empty files here keeps a
-// crash-looping agent's logs directory from accumulating backups no tick
-// would ever have produced.
+// The startup pass calls startupRotate, not rotateOnce directly, both to
+// avoid spraying empty rotated backups on a crash-looping agent (see
+// startupRotate's own doc comment for the missing/empty-file skip) and,
+// since issue #99, to avoid rotating away the very lines the sink is
+// currently writing: NewSink opens the file and the caller starts logging
+// (self-identification, "agent listening") before this goroutine ever runs,
+// so an unconditional startup rotation would move this boot's own opening
+// lines into a backup before anything could ever read them from agent.log.
+// startupRotate only rotates when the file's existing content is actually
+// older than the configured max age.
 //
 // A failed rotation is logged and the loop continues: losing retention is bad,
 // but taking the agent down over it is worse.
@@ -81,13 +101,73 @@ func (r *Rotator) Run(ctx context.Context) error {
 
 // startupRotate performs the startup rotation pass, skipping it when the
 // current log file is missing or empty — see the rationale in Run's doc
-// comment.
+// comment — or when r.maxAge is zero or less, which disables the pass
+// entirely.
+//
+// Otherwise it rotates only when the file's OLDEST content — the timestamp on
+// its first line — is already older than r.maxAge. Deliberately not file
+// mtime: a crash-looping agent rewrites (or appends to) the file on every
+// boot, so mtime is always "just now", and an mtime-based check would never
+// fire in exactly the scenario this pass exists for — an agent restarted more
+// often than the r.interval ticker. The first line's own timestamp is the
+// only signal that reflects how long the content has actually been
+// accumulating, so a freshly booted agent's own opening lines are left alone
+// and only genuinely stale carry-over content gets rotated aside.
+//
+// A first line that cannot be read or parsed as a timestamp is treated as
+// stale content too: it means the file holds something other than
+// recognisable slog output — corrupted mid-write by a prior crash, or written
+// by something else entirely — and rotating it aside into a backup preserves
+// it while letting agent.log start clean, rather than leaving unreadable
+// bytes as the "current" log indefinitely.
 func (r *Rotator) startupRotate() {
+	if r.maxAge <= 0 {
+		return
+	}
+
 	info, err := os.Stat(r.lj.Filename)
 	if err != nil || info.Size() == 0 {
 		return
 	}
-	r.rotateOnce()
+
+	ts, err := firstLineTimestamp(r.lj.Filename)
+	if err != nil || time.Since(ts) > r.maxAge {
+		r.rotateOnce()
+	}
+}
+
+// firstLineTimestamp reads the first line of path and parses the value that
+// follows slogTimeKeyPrefix as an RFC3339Nano timestamp.
+func firstLineTimestamp(path string) (time.Time, error) {
+	// #nosec G304 -- path is always r.lj.Filename, set once at startup from
+	// config.Config.AgentLogPath() (NewSink) or, in tests, a fixed
+	// t.TempDir() path. Never a request, a device, or any other untrusted
+	// source.
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	line, err := bufio.NewReader(f).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return time.Time{}, fmt.Errorf("read first line of %s: %w", path, err)
+	}
+	line = strings.TrimRight(line, "\r\n")
+
+	if !strings.HasPrefix(line, slogTimeKeyPrefix) {
+		return time.Time{}, fmt.Errorf("first line of %s does not start with %q", path, slogTimeKeyPrefix)
+	}
+	value := line[len(slogTimeKeyPrefix):]
+	if end := strings.IndexByte(value, ' '); end >= 0 {
+		value = value[:end]
+	}
+
+	ts, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse time from first line of %s: %w", path, err)
+	}
+	return ts, nil
 }
 
 func (r *Rotator) rotateOnce() {


### PR DESCRIPTION
Fixes the three remaining `e2e` failures on release PR #98 (`TestSelfIDResolvesWithOverriddenHostname`, `TestUnresolvableSelfIDFallsBackToDetection`, `TestStateSurvivesCrashRestart`, all in `internal/e2e/incontainer`).

## Cause

The startup rotation pass from #67 rotated any non-empty `agent.log`. But `NewSink` opens the file and the caller starts logging before the rotator goroutine ever runs, so the pass fired against the current boot's own opening lines — self-identification, "agent listening" — moving them into a dated backup before anything could read them, and rotating pre-crash content aside on every restart. That broke both guarantees `internal/logging` documents: startup lines readable in `agent.log`, and post-restart content carrying pre-crash content as a prefix.

## Fix

`startupRotate` now rotates only when the file's **oldest** content — the timestamp on its first line — is older than the configured max age (`cfg.LogMaxAge`, the same budget lumberjack's `MaxAge` is derived from; config floors it at 1 day, and ≤0 disables the pass for direct constructions).

Two deliberate choices, both documented in the code:

- **Not mtime.** A crash-looping agent writes on every boot, so mtime is always fresh — an mtime check would never fire in exactly the scenario the startup pass exists for (an agent restarted more often than the 24h tick).
- **Unparsable first line → rotate.** The content is suspect (corrupted by a prior crash, or foreign); rotating preserves it in a backup and starts clean.

The missing/empty-file skips and the unconditional 24h tick are unchanged.

## Why this fixes the three tests

Each asserts on `agent.log` shortly after a boot or restart, where the first line is seconds old — far under the 1-day floor — so the startup pass now leaves the file alone: startup lines stay, and a restart appends below the pre-kill content, restoring the prefix invariant. The direct local regression test is `TestRotatorRunSkipsStartupRotationWhenFileIsFresh`; the stale path keeps its own coverage (`TestRotatorRunRotatesOnStartupWhenFileIsStale`, plus a table over fresh/stale/empty/missing/unparsable/disabled).

Test fixtures build crafted first lines through a real `slog.TextHandler`, so they match the actual on-disk encoding rather than a hand-rolled string.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags e2e ./...` — clean
- [x] `go test ./internal/... -race` — all ok; `internal/logging` new tests pass under `-count=2`; coverage 95.5% (floor 90%)
- [x] `gofmt -l` clean, `golangci-lint run ./...` 0 issues, `gosec` clean (one documented `#nosec G304` on the fixed config path)
- [ ] The three in-container e2e tests can only run in CI's `e2e` job (host-resolvable bind mounts) — verified on #98's bar after merge

Closes #99

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)