### PR TITLE
docs: reference sibling code by name, not line number, in comments

### DIFF
--- a/internal/dockerx/lifecycle_test.go
+++ b/internal/dockerx/lifecycle_test.go
@@ -266,8 +266,8 @@ func TestRemoveRunningConflict(t *testing.T) {
 // a running container, HTTP 304) is treated as success (D9), never as an
 // error the caller has to special-case.
 //
-// The moby v0.5.1 client's checkResponseErr classifies every 2xx/3xx
-// response as success before the body is even inspected (request.go:225),
+// The moby client's checkResponseErr (request.go in the SDK) classifies
+// every 2xx/3xx response as success before the body is even inspected,
 // so ContainerStart returns a nil error for 304 exactly as it does for 204.
 // classify's ErrNotModified branch (errors.go) exists for callers that
 // receive an actual non-2xx error carrying that condition elsewhere in the

--- a/internal/e2e/api/contract_audit_test.go
+++ b/internal/e2e/api/contract_audit_test.go
@@ -31,7 +31,8 @@ import (
 //
 // Audit ROW RETENTION (internal/state/pruner.go) is out of scope for a live
 // round trip in this suite: Pruner.Run ticks on a fixed, uncomfigurable
-// six-hour interval (pruner.go:12) with no test seam to shorten it, and D19
+// six-hour interval (defaultPruneInterval in pruner.go) with no test seam to
+// shorten it, and D19
 // forbids adding one just to make this task's assertions pass sooner. The
 // retention bound itself — DEVMON_AUDIT_MAX_ROWS enforced by PruneAudit — is
 // already exercised at the unit level (internal/state/audit_test.go's

--- a/internal/e2e/api/contract_ratelimit_test.go
+++ b/internal/e2e/api/contract_ratelimit_test.go
@@ -23,9 +23,9 @@ import (
 // variables are startup configuration, so sharing an agent across cases
 // would make one test's limit leak into another's assertion.
 //
-// maxRateLimitIterations bounds every polling loop in this file. Agent.
-// waitReady already spends tokens from the status tier's bucket before a
-// test body runs (harness/agent.go:328-353), so no case here may assert an
+// maxRateLimitIterations bounds every polling loop in this file. The
+// harness Agent's waitReady (harness/agent.go) already spends tokens from
+// the status tier's bucket before a test body runs, so no case here may assert an
 // exact request count before the first 429 — only that one arrives within
 // this bound. None of these cases sets the status tier to 1: doing so risks
 // waitReady itself failing before the agent is ever considered started.

--- a/internal/e2e/incontainer/contract_selfid_test.go
+++ b/internal/e2e/incontainer/contract_selfid_test.go
@@ -176,8 +176,8 @@ func TestExplicitSelfIDOverrideIsHonoured(t *testing.T) {
 // is answered, and the answer is that the documented 503 contract is NOT
 // what the agent implements.
 //
-// internal/selfid/selfid.go:53-59 makes the override merely the FIRST entry
-// in a candidate list, and internal/dockerx/self.go's confirmSelf walks that
+// internal/selfid's Detect makes the override merely the FIRST entry in a
+// candidate list, and internal/dockerx/self.go's confirmSelf walks that
 // list until the Engine confirms one — an override the Engine does not
 // recognise is skipped exactly like a stale mountinfo line. In a normal
 // container the mountinfo candidate then resolves, so the agent

--- a/internal/httpapi/audit.go
+++ b/internal/httpapi/audit.go
@@ -13,7 +13,7 @@ import (
 
 // auditCtxKey is the context key under which withAudit stores the in-flight
 // entry. An empty struct type, not a string, for the same reason
-// deviceCtxKey is (middleware.go:20).
+// deviceCtxKey (middleware.go) is.
 type auditCtxKey struct{}
 
 // Identity operation names for the audit `operation` column. These are not

--- a/internal/state/audit_test.go
+++ b/internal/state/audit_test.go
@@ -157,8 +157,8 @@ func TestListAuditOrdersMostRecentFirstByID(t *testing.T) {
 	t.Parallel()
 
 	// Arrange — insert three entries whose id order and occurred_at order
-	// agree, then verify ordering is by id, not occurred_at (store.go:272-276
-	// treats id as the ordering that matters for the same reason).
+	// agree, then verify ordering is by id, not occurred_at (PruneAudit's
+	// retention queries in store.go order by id for the same reason).
 	s := openStore(t, tempDBPath(t))
 	ctx := context.Background()
 	for i, target := range []string{"first", "second", "third"} {


### PR DESCRIPTION
## Summary

Code comments that cite another location by line number (`store.go:272-276`, `middleware.go:20`) rot silently: any edit to the cited file shifts the lines, nobody updates the comment, and the pointer misleads the next reader. This PR rewrites the six existing line-numbered references to name the function or file instead, which stays true without maintenance.

One of them had already rotted: `audit_test.go` cited `store.go:272-276` for id-based ordering, but those lines now sit in the middle of `PruneAudit`'s doc comment rather than the queries the comment meant.

| File | Before | After |
|---|---|---|
| `internal/state/audit_test.go` | `store.go:272-276` | `PruneAudit`'s retention queries in `store.go` |
| `internal/httpapi/audit.go` | `middleware.go:20` | `deviceCtxKey` (`middleware.go`) |
| `internal/dockerx/lifecycle_test.go` | `request.go:225` | `checkResponseErr` (`request.go` in the SDK) |
| `internal/e2e/incontainer/contract_selfid_test.go` | `selfid.go:53-59` | `internal/selfid`'s `Detect` |
| `internal/e2e/api/contract_audit_test.go` | `pruner.go:12` | `defaultPruneInterval` in `pruner.go` |
| `internal/e2e/api/contract_ratelimit_test.go` | `harness/agent.go:328-353` | the harness `Agent`'s `waitReady` |

Comment-only change; no behavior affected.

## Test plan

- [x] `gofmt -l` clean on all six files
- [x] `go build ./...`, `go vet ./...`, `go vet -tags e2e ./...` clean
- [x] `go test ./internal/state/ ./internal/httpapi/ ./internal/dockerx/ -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)