### PR TITLE
feat: add GET /v1/events/stream, a live container health event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ reasoning; the spec keeps the shapes.
 | `GET /v1/volumes/{name}` | client cert | Inspect one volume |
 | `GET /v1/containers/{id}/logs` | client cert | Recent log lines as JSON |
 | `GET /v1/containers/{id}/logs/stream` | client cert | Live log stream (Server-Sent Events) |
+| `GET /v1/events/stream` | client cert | Live container health and lifecycle events (Server-Sent Events) |
 | `POST /v1/containers/{id}/start` | client cert | Start a stopped container — needs `default` |
 | `POST /v1/containers/{id}/restart` | client cert | Restart a container — needs `default` |
 | `POST /v1/containers/{id}/stop` | client cert | Stop a running container — needs `default` |
@@ -546,6 +547,11 @@ args are what identify a misconfigured container, and they are already visible
 in the host's process table and in `docker ps`. This is a bounded, deliberate
 disclosure rather than an oversight.
 
+**Engine event attributes are never forwarded.** The event stream maps no
+attribute of a Docker event, because an event's attributes are the container's
+label set — the same rule that removes env vars, applied to a different field.
+Only the container's name is read out of them, by exact key.
+
 **Lists are capped at 500 items** and carry a `truncated` flag. A host with
 thousands of images would otherwise send a multi-megabyte body to a phone on a
 mobile connection. The cap is server-side and cannot be raised by a client,
@@ -623,6 +629,61 @@ including the secrets the projection rules above work to keep out of
 responses — the difference is only that here the operator asked for them. That
 makes it more important, not less, that they pass through in transit and leave
 nothing behind.
+
+### Container health event stream
+
+`GET /v1/events/stream` tells a client the moment a container's health flips or
+a container dies, starts, stops, or is OOM-killed — without polling. It is SSE
+on the same listener, behind the same certificate, rate-limit, and policy guards
+as every read route, and it is permitted in every policy mode because it
+discloses a strict subset of what `GET /v1/containers` already returns.
+
+**The snapshot replaces replay.** The first frame is always one
+`event: snapshot` carrying `{id, name, state, health}` for every container on
+the host. There is deliberately no `?since=` and no `Last-Event-ID` resume: a
+replay window would mean the agent buffering events per absent device — exactly
+the durable per-client state the log stream refused to add — and would still be
+wrong at its edges. A snapshot is one Engine call and is always true. The
+ordering is guaranteed the strong way round: the agent subscribes to the
+Engine's event feed first and takes the snapshot only once the subscription is
+live, so an event firing in between lands in the stream rather than in a gap.
+
+After the snapshot, one `event: health` frame per forwarded event. Exactly six
+Engine events are forwarded — `health_status: healthy`,
+`health_status: unhealthy`, `die`, `start`, `stop`, `oom` — through a closed
+allowlist. That allowlist is a security control, not a filter: Docker's raw
+health action string can carry the healthcheck's own output, and an event's
+attributes are the container's labels, so neither ever reaches the wire or the
+agent's own log.
+
+**One Engine subscription, fanned out.** However many devices are connected,
+the agent holds exactly one `/events` connection to the Engine, started when
+the first client attaches and closed when the last one leaves. An event stream
+therefore consumes none of the log-stream budget — holding a health view open
+never costs the device a log view.
+
+**Every gap becomes a disconnect.** If the Engine feed dies the agent does not
+silently reconnect — a resumed feed would have a hole in it and no way to say
+what fell in. Every client gets a terminal `event: error` /
+`docker engine unavailable` and reconnects into a fresh snapshot. A client that
+cannot keep up is dropped the same way (`event stream fell behind`) rather than
+having events silently skipped: a dropped client re-snapshots and is correct
+again, a client missing one event is quietly wrong forever.
+
+**One stream per device, newest wins.** A second connection from the same
+device closes the older one with `event stream superseded` — in practice the
+second connection is a client that reconnected before its old socket was
+reaped, and the newer socket is the one the device is actually holding. That is
+the one terminal error a client must not retry; the other two are retryable
+with backoff.
+
+A `: heartbeat` comment is written every 25 seconds, for the same two reasons
+the log stream's keepalive exists. `id` is the join key across routes: `name`
+on this stream strips the leading `/` the Engine puts on list names, because
+the Engine's list and event APIs disagree on the form and one stream must be
+self-consistent. Snapshot `health` needs Engine 29+ (API v1.52) — on an older
+Engine every container snapshots as `none` while the events themselves still
+arrive.
 
 `/v1/status` is the only endpoint served without a client certificate. Its fields
 are a strict allowlist — it may inform, never issue — and it carries no host,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -78,6 +78,8 @@ tags:
     description: Container reads.
   - name: logs
     description: Historical log retrieval and the live stream.
+  - name: events
+    description: The live container health and lifecycle event stream.
   - name: lifecycle
     description: Mutating container operations, bounded by the host's policy mode.
   - name: images
@@ -515,6 +517,112 @@ paths:
               schema: { $ref: "#/components/schemas/Error" }
               example: { error: too many concurrent log streams }
 
+  /v1/events/stream:
+    get:
+      tags: [events]
+      operationId: streamContainerEvents
+      summary: Live container health and lifecycle events (Server-Sent Events)
+      description: |
+        Permitted in every policy mode: the stream discloses a strict subset of
+        what `GET /v1/containers` already returns.
+
+        **The snapshot replaces replay.** The first frame is always one
+        `event: snapshot` carrying the current state of every container, taken
+        only after the Engine-side event subscription is live, so no event can
+        fall between the two. There is no `since` parameter and no
+        `Last-Event-ID` resume: a client reconciles from the snapshot on every
+        connect, which is one mechanism that is always true rather than a replay
+        window that is bounded and stale at its edges.
+
+        After the snapshot, one `event: health` frame per forwarded Engine
+        event. Exactly six container events are forwarded —
+        `health_status: healthy`, `health_status: unhealthy`, `die`, `start`,
+        `stop`, and `oom`. Everything else, including every event attribute the
+        Engine attaches (attributes are the container's label set), is dropped
+        agent-side.
+
+        **One stream per paired device, newest wins.** A second connection from
+        the same device closes the older one with a terminal
+        `event: error` / `event stream superseded` frame — the one terminal
+        error a client must **not** retry, since reconnecting would fight the
+        newer stream. This limit is independent of the log-stream budget: an
+        event stream consumes no log-stream slot, because every event stream
+        shares one Engine subscription per agent process.
+
+        **A gap becomes a disconnect.** If the Engine feed dies, every client
+        receives `event: error` / `docker engine unavailable` and the stream
+        closes; a client that falls too far behind receives
+        `event stream fell behind`. Both are retryable with backoff, and a
+        reconnect serves a fresh snapshot.
+
+        A `: heartbeat` comment frame is written every 25 seconds so NAT and
+        proxies keep the connection open, and so a client can detect a dead
+        stream.
+
+        `id` is the join key across routes. `name` here carries the Engine name
+        with its leading `/` stripped (the Engine's list and event APIs disagree
+        on the form), which differs from `GET /v1/containers`'s `names`.
+
+        Snapshot `health` requires Engine 29+ / API v1.52: on an older Engine
+        every container snapshots as `none` while the events themselves are
+        unaffected.
+
+        Response headers are withheld until the snapshot is ready to send, which
+        keeps `502` available as an ordinary JSON response. Once the stream has
+        started, a later failure can only arrive as a terminal `event: error`
+        frame on a response that already said 200.
+      responses:
+        "200":
+          description: The stream. Ends when the client disconnects, a newer stream from the same device supersedes it, or a terminal error frame is sent.
+          headers:
+            Cache-Control:
+              schema: { type: string, const: no-store }
+            X-Accel-Buffering:
+              schema: { type: string, const: "no" }
+              description: Disables response buffering on nginx-style proxies, which would otherwise hold the stream until it closed.
+          content:
+            text/event-stream:
+              schema:
+                description: |
+                  The HTTP body is SSE text framing, not JSON; this schema names
+                  the frame `data` payloads for generators. `event: snapshot`
+                  carries a bare JSON array of ContainerStateSummary as its
+                  `data`, exactly once, always first. `event: health` carries a
+                  ContainerEvent. `event: error` carries an Error object and
+                  terminates the stream. Comment frames (`: heartbeat`) carry no
+                  event and are ignored by any conforming SSE client. Frame `id`
+                  fields are empty: there is deliberately no resume cursor on
+                  this route.
+                oneOf:
+                  - type: string
+                    description: The body as transmitted — SSE text framing.
+                  - type: array
+                    items: { $ref: "#/components/schemas/ContainerStateSummary" }
+                    description: "The `data` payload of the one `event: snapshot` frame."
+                  - $ref: "#/components/schemas/ContainerEvent"
+                  - $ref: "#/components/schemas/Error"
+              examples:
+                stream:
+                  value: |
+                    event: snapshot
+                    data: [{"id":"a1b2c3","name":"api","state":"running","health":"healthy"},{"id":"d4e5f6","name":"cron","state":"exited","health":"none"}]
+
+                    : heartbeat
+
+                    event: health
+                    data: {"id":"a1b2c3","name":"api","event":"health_status","health":"unhealthy","time":"2026-08-25T09:14:02Z"}
+
+                    event: health
+                    data: {"id":"d4e5f6","name":"cron","event":"die","time":"2026-08-25T09:31:47Z"}
+
+                    event: error
+                    data: {"error":"event stream superseded"}
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/PolicyForbidden" }
+        "429": { $ref: "#/components/responses/RateLimited" }
+        "500": { $ref: "#/components/responses/InternalError" }
+        "502": { $ref: "#/components/responses/EngineUnavailable" }
+
   /v1/images:
     get:
       tags: [images]
@@ -797,6 +905,18 @@ components:
         returned here would already be stale. Re-fetch
         `GET /v1/containers/{id}` instead; it is one cheap request and always
         true.
+
+    PolicyForbidden:
+      description: |
+        The host's policy mode does not permit the operation. Every shipped
+        mode permits reads, so on a read route this answer indicates an agent
+        misconfiguration rather than a tier a client could encounter by design —
+        it is documented because the taxonomy keeps 403 distinct from 401 and
+        502 on every route.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: operation not permitted by host policy }
 
     LifecycleForbidden:
       description: |
@@ -1305,3 +1425,59 @@ components:
             exists because one enormous line — a stack dump, a base64 payload —
             would otherwise be accumulated whole in agent memory before any line
             boundary arrived.
+
+    ContainerStateSummary:
+      type: object
+      description: |
+        One entry of the event stream's opening snapshot: the minimum a client
+        needs to reconcile its own view before live events start arriving. It is
+        deliberately not ContainerSummary — the snapshot is resent on every
+        reconnect, so it carries the four fields the stream can change and
+        nothing else. The snapshot array is capped at 500 entries like every
+        list; a host beyond that is outside this route's design point.
+      required: [id, name, state, health]
+      properties:
+        id:
+          type: string
+          description: The join key across routes.
+        name:
+          type: string
+          description: The Engine name with its leading `/` stripped, matching the form events carry. Join on `id`, not this.
+        state:
+          type: string
+          examples: [running, exited, created, paused, restarting, removing, dead]
+        health:
+          type: string
+          enum: [none, starting, healthy, unhealthy]
+          description: |
+            Never omitted: a client must be able to tell "no healthcheck"
+            (`none`) from "this agent version does not report health". `none` is
+            also what every container reports on an Engine older than API v1.52,
+            where the list response carries no health at all.
+
+    ContainerEvent:
+      type: object
+      description: |
+        One allowlisted Docker container event. `event` is a normalised literal
+        from a fixed six-entry allowlist, never the Engine's raw action string —
+        a raw health action can carry the healthcheck's own output. Engine event
+        attributes are never mapped: they are the container's label set.
+      required: [id, name, event, time]
+      properties:
+        id:
+          type: string
+          description: The join key across routes.
+        name:
+          type: string
+          description: The Engine name with its leading `/` stripped.
+        event:
+          type: string
+          enum: [health_status, die, start, stop, oom]
+        health:
+          type: string
+          enum: [healthy, unhealthy]
+          description: Present only when `event` is `health_status`. The snapshot's other two values cannot arrive here — `starting` and `none` never produce an Engine event this route forwards.
+        time:
+          type: string
+          format: date-time
+          description: RFC 3339 UTC, from the Engine's own event timestamp.

--- a/internal/dockerx/errors.go
+++ b/internal/dockerx/errors.go
@@ -45,6 +45,14 @@ var ErrConflict = errors.New("docker object is in a conflicting state")
 // distinct sentinel so the audit detail can record that nothing changed.
 var ErrNotModified = errors.New("docker object already in the requested state")
 
+// ErrEventFeedClosed is returned when the Engine's event feed ends rather than
+// fails — an io.EOF on the error channel, or a closed channel. It is distinct
+// from a transport failure because the caller's response is the same either way
+// (tear the subscribers down so they reconnect and re-snapshot) while the log
+// level is not: an ended feed is ordinary on a daemon restart, a transport
+// failure is not.
+var ErrEventFeedClosed = errors.New("docker event feed closed")
+
 // classify maps a raw Engine error onto the package's sentinel errors,
 // wrapping the result with op so a caller can name the failing operation
 // without inspecting the underlying error type.

--- a/internal/dockerx/errors_test.go
+++ b/internal/dockerx/errors_test.go
@@ -45,6 +45,40 @@ func TestErrInvalidSinceIsDistinctSentinel(t *testing.T) {
 	}
 }
 
+// TestErrEventFeedClosedIsDistinct guards against ErrEventFeedClosed ever
+// being folded into another sentinel by an accidental reuse — a caller must
+// be able to tell "the feed ended" apart from every other classified error
+// via errors.Is.
+func TestErrEventFeedClosedIsDistinct(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "is itself", err: ErrEventFeedClosed, want: ErrEventFeedClosed},
+		{name: "wrapped still matches", err: fmt.Errorf("stream container events: %w", ErrEventFeedClosed), want: ErrEventFeedClosed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act & Assert
+			if !errors.Is(tt.err, tt.want) {
+				t.Errorf("errors.Is(%v, ErrEventFeedClosed) = false, want true", tt.err)
+			}
+			if errors.Is(tt.err, ErrNotFound) {
+				t.Errorf("errors.Is(%v, ErrNotFound) = true, want false", tt.err)
+			}
+			if errors.Is(tt.err, ErrInvalidSince) {
+				t.Errorf("errors.Is(%v, ErrInvalidSince) = true, want false", tt.err)
+			}
+		})
+	}
+}
+
 func TestClassify(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dockerx/events.go
+++ b/internal/dockerx/events.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dockerx
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+// ContainerStates returns the current state and health of every container on
+// the host, including stopped ones — the payload of the event stream's opening
+// snapshot.
+//
+// One ContainerList call, never a per-container inspect. container.Summary
+// carries Health directly, and N+1 inspects taken at N different instants
+// would produce a "snapshot" that was never simultaneously true.
+//
+// Health arrived on the list response in Docker API v1.52 (Engine 29). On an
+// older Engine Summary.Health is nil for every container and they all report
+// "none"; the events themselves are unaffected.
+func (c *Client) ContainerStates(ctx context.Context) ([]ContainerStateSummary, error) {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	res, err := c.api.ContainerList(ctx, client.ContainerListOptions{All: true})
+	if err != nil {
+		return nil, classify("list container states", err)
+	}
+
+	items := make([]ContainerStateSummary, 0, len(res.Items))
+	for _, s := range res.Items {
+		items = append(items, toContainerStateSummary(s))
+	}
+
+	items, truncated := truncate(items)
+	if truncated {
+		c.log.Warn("container state snapshot truncated", slog.Int("count", len(res.Items)))
+	}
+
+	return items, nil
+}
+
+// toContainerStateSummary projects a container.Summary onto the snapshot DTO.
+// s.Health is a pointer and is nil for a container with no healthcheck and on
+// every Engine older than API v1.52 — both mean "none".
+func toContainerStateSummary(s container.Summary) ContainerStateSummary {
+	var name string
+	if len(s.Names) > 0 {
+		name = trimContainerName(s.Names[0])
+	}
+
+	return ContainerStateSummary{
+		ID:     s.ID,
+		Name:   name,
+		State:  string(s.State),
+		Health: healthOrNone(s.Health),
+	}
+}
+
+// healthOrNone maps a *container.HealthSummary onto the four-value contract
+// vocabulary. A nil summary, an empty status, or a status the Engine invents
+// in a future release all collapse to "none": the field is an enum on the
+// wire, and forwarding an unrecognised value would break that promise.
+func healthOrNone(h *container.HealthSummary) string {
+	if h == nil {
+		return string(container.NoHealthcheck)
+	}
+
+	switch h.Status {
+	case container.NoHealthcheck, container.Starting, container.Healthy, container.Unhealthy:
+		return string(h.Status)
+	default:
+		return string(container.NoHealthcheck)
+	}
+}
+
+// trimContainerName strips the single leading "/" the Engine puts on container
+// names in list responses. The events API's own "name" attribute has no slash,
+// and the snapshot and the events it is reconciled against must agree.
+func trimContainerName(name string) string {
+	return strings.TrimPrefix(name, "/")
+}

--- a/internal/dockerx/events.go
+++ b/internal/dockerx/events.go
@@ -4,10 +4,14 @@ package dockerx
 
 import (
 	"context"
+	"errors"
+	"io"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/client"
 )
 
@@ -83,4 +87,126 @@ func healthOrNone(h *container.HealthSummary) string {
 // and the snapshot and the events it is reconciled against must agree.
 func trimContainerName(name string) string {
 	return strings.TrimPrefix(name, "/")
+}
+
+// eventHealthStatus is the normalised literal both health actions forward as.
+const eventHealthStatus = "health_status"
+
+// eventActions is the closed allowlist of Docker container actions this agent
+// forwards, mapped onto the normalised literal that reaches the wire.
+//
+// Map-driven so an action outside it can never fall through. The health entries
+// match the two EXACT SDK constants and nothing else: events.Action for a health
+// event is a compound string, and the SDK's own doc comment records that a
+// health_status action can be free-form, "followed by the output of the
+// health-check output". Matching a "health_status" PREFIX would therefore
+// publish healthcheck output to a client and, worse, into the agent's log.
+var eventActions = map[events.Action]string{
+	events.ActionHealthStatusHealthy:   eventHealthStatus,
+	events.ActionHealthStatusUnhealthy: eventHealthStatus,
+	events.ActionDie:                   "die",
+	events.ActionStart:                 "start",
+	events.ActionStop:                  "stop",
+	events.ActionOOM:                   "oom",
+}
+
+// eventHealthByAction gives the resulting health value for the two health
+// actions. Absent for every lifecycle action, which is why ContainerEvent.Health
+// is omitempty.
+var eventHealthByAction = map[events.Action]string{
+	events.ActionHealthStatusHealthy:   string(container.Healthy),
+	events.ActionHealthStatusUnhealthy: string(container.Unhealthy),
+}
+
+// toContainerEvent projects an Engine message onto the allowlisted DTO,
+// reporting false for anything outside eventActions.
+//
+// msg.Actor.Attributes is the container's LABEL SET (see events.Actor's own doc
+// comment). It is never forwarded and never logged; exactly one key, "name", is
+// read out of it.
+func toContainerEvent(msg events.Message) (ContainerEvent, bool) {
+	if msg.Type != events.ContainerEventType {
+		return ContainerEvent{}, false
+	}
+
+	action, ok := eventActions[msg.Action]
+	if !ok {
+		return ContainerEvent{}, false
+	}
+
+	return ContainerEvent{
+		ID:     msg.Actor.ID,
+		Name:   trimContainerName(msg.Actor.Attributes["name"]),
+		Event:  action,
+		Health: eventHealthByAction[msg.Action],
+		Time:   eventTime(msg),
+	}, true
+}
+
+// eventTime converts an Engine message's timestamp to RFC3339 UTC, preferring
+// the nanosecond field over the second one when both are set.
+func eventTime(msg events.Message) string {
+	switch {
+	case msg.TimeNano != 0:
+		return time.Unix(0, msg.TimeNano).UTC().Format(time.RFC3339)
+	case msg.Time != 0:
+		return time.Unix(msg.Time, 0).UTC().Format(time.RFC3339)
+	default:
+		return ""
+	}
+}
+
+// StreamContainerEvents follows the Engine's container event feed, calling emit
+// once per allowlisted event until ctx is cancelled, the feed ends, or emit
+// returns an error.
+//
+// onReady is invoked exactly once, after the Engine subscription is established
+// and before the first event can be delivered. Callers depend on this: the event
+// stream's opening snapshot must be taken AFTER the subscription exists, or an
+// event firing in between is in neither the snapshot nor the stream, and this
+// feature has no replay to recover it. client.Client.Events blocks internally
+// until GET /events has been issued and its response received, so the moment it
+// returns is exactly that point.
+//
+// emit MUST NOT BLOCK. The SDK's message channel is unbuffered, so a slow emit
+// stalls the Engine decoder goroutine and backs the feed up for every consumer.
+//
+// No callTimeout here, deliberately, for the reason StreamContainerLogs gives:
+// the subscription's lifetime is ctx and nothing else.
+func (c *Client) StreamContainerEvents(ctx context.Context, onReady func(), emit func(ContainerEvent) error) error {
+	filters := make(client.Filters).Add("type", string(events.ContainerEventType))
+	res := c.api.Events(ctx, client.EventsListOptions{Filters: filters})
+
+	if onReady != nil {
+		onReady()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil // a cancelled subscription is a clean stop
+		case msg, ok := <-res.Messages:
+			if !ok {
+				return ErrEventFeedClosed
+			}
+			ev, forward := toContainerEvent(msg)
+			if !forward {
+				continue
+			}
+			if err := emit(ev); err != nil {
+				return err
+			}
+		case err, ok := <-res.Err:
+			if !ok {
+				return ErrEventFeedClosed
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			if errors.Is(err, io.EOF) {
+				return ErrEventFeedClosed
+			}
+			return classify("stream container events", err)
+		}
+	}
 }

--- a/internal/dockerx/events_test.go
+++ b/internal/dockerx/events_test.go
@@ -3,9 +3,13 @@
 package dockerx
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/events"
 )
 
 func TestHealthOrNone(t *testing.T) {
@@ -84,5 +88,222 @@ func TestContainerStateSummaryNamesEmpty(t *testing.T) {
 
 	if got.Name != "" {
 		t.Errorf("toContainerStateSummary() Name = %q, want empty", got.Name)
+	}
+}
+
+func TestToContainerEventAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		action    events.Action
+		wantEvent string
+		wantOK    bool
+	}{
+		{name: "health healthy", action: events.ActionHealthStatusHealthy, wantEvent: "health_status", wantOK: true},
+		{name: "health unhealthy", action: events.ActionHealthStatusUnhealthy, wantEvent: "health_status", wantOK: true},
+		{name: "die", action: events.ActionDie, wantEvent: "die", wantOK: true},
+		{name: "start", action: events.ActionStart, wantEvent: "start", wantOK: true},
+		{name: "stop", action: events.ActionStop, wantEvent: "stop", wantOK: true},
+		{name: "oom", action: events.ActionOOM, wantEvent: "oom", wantOK: true},
+		{name: "create", action: events.Action("create"), wantOK: false},
+		{name: "destroy", action: events.Action("destroy"), wantOK: false},
+		{name: "rename", action: events.Action("rename"), wantOK: false},
+		{name: "pause", action: events.Action("pause"), wantOK: false},
+		{name: "restart", action: events.Action("restart"), wantOK: false},
+		{name: "kill", action: events.Action("kill"), wantOK: false},
+		{name: "exec_create carries a command line", action: events.Action("exec_create: /bin/sh -c 'cat /run/secrets/db'"), wantOK: false},
+		{name: "health_status: running", action: events.ActionHealthStatusRunning, wantOK: false},
+		{name: "free-form health output", action: events.Action("health_status: connection refused to 10.0.0.5:5432"), wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := events.Message{
+				Type:   events.ContainerEventType,
+				Action: tt.action,
+				Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "/api"}},
+			}
+
+			got, ok := toContainerEvent(msg)
+
+			if ok != tt.wantOK {
+				t.Fatalf("toContainerEvent() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.Event != tt.wantEvent {
+				t.Errorf("toContainerEvent() Event = %q, want %q", got.Event, tt.wantEvent)
+			}
+		})
+	}
+}
+
+func TestToContainerEventHealthValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		action     events.Action
+		wantHealth string
+	}{
+		{name: "healthy", action: events.ActionHealthStatusHealthy, wantHealth: "healthy"},
+		{name: "unhealthy", action: events.ActionHealthStatusUnhealthy, wantHealth: "unhealthy"},
+		{name: "die carries no health", action: events.ActionDie, wantHealth: ""},
+		{name: "start carries no health", action: events.ActionStart, wantHealth: ""},
+		{name: "stop carries no health", action: events.ActionStop, wantHealth: ""},
+		{name: "oom carries no health", action: events.ActionOOM, wantHealth: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := events.Message{
+				Type:   events.ContainerEventType,
+				Action: tt.action,
+				Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "/api"}},
+			}
+
+			got, ok := toContainerEvent(msg)
+			if !ok {
+				t.Fatalf("toContainerEvent() ok = false, want true")
+			}
+			if got.Health != tt.wantHealth {
+				t.Errorf("toContainerEvent() Health = %q, want %q", got.Health, tt.wantHealth)
+			}
+		})
+	}
+}
+
+func TestToContainerEventNeverCarriesAttributes(t *testing.T) {
+	t.Parallel()
+
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: events.ActionDie,
+		Actor: events.Actor{
+			ID:         "abc123",
+			Attributes: map[string]string{"com.example.token": "hunter2", "name": "/api"},
+		},
+	}
+
+	got, ok := toContainerEvent(msg)
+	if !ok {
+		t.Fatalf("toContainerEvent() ok = false, want true")
+	}
+
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	if strings.Contains(string(body), "hunter2") {
+		t.Errorf("marshalled event %s contains the secret label value", body)
+	}
+	if strings.Contains(string(body), "com.example.token") {
+		t.Errorf("marshalled event %s contains the label key", body)
+	}
+	if !strings.Contains(string(body), "api") {
+		t.Errorf("marshalled event %s does not contain the container name", body)
+	}
+}
+
+func TestToContainerEventTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		time     int64
+		timeNano int64
+		want     string
+	}{
+		{
+			name:     "TimeNano set",
+			timeNano: time.Date(2026, 8, 25, 9, 14, 2, 0, time.UTC).UnixNano(),
+			want:     "2026-08-25T09:14:02Z",
+		},
+		{
+			name: "only Time set",
+			time: time.Date(2026, 8, 25, 9, 31, 47, 0, time.UTC).Unix(),
+			want: "2026-08-25T09:31:47Z",
+		},
+		{
+			name: "both zero",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := events.Message{
+				Type:     events.ContainerEventType,
+				Action:   events.ActionDie,
+				Actor:    events.Actor{ID: "abc123", Attributes: map[string]string{"name": "/api"}},
+				Time:     tt.time,
+				TimeNano: tt.timeNano,
+			}
+
+			got, ok := toContainerEvent(msg)
+			if !ok {
+				t.Fatalf("toContainerEvent() ok = false, want true")
+			}
+			if got.Time != tt.want {
+				t.Errorf("toContainerEvent() Time = %q, want %q", got.Time, tt.want)
+			}
+		})
+	}
+}
+
+func TestToContainerEventName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		attributes map[string]string
+		want       string
+	}{
+		{name: "name present", attributes: map[string]string{"name": "api"}, want: "api"},
+		{name: "name missing", attributes: map[string]string{}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := events.Message{
+				Type:   events.ContainerEventType,
+				Action: events.ActionDie,
+				Actor:  events.Actor{ID: "abc123", Attributes: tt.attributes},
+			}
+
+			got, ok := toContainerEvent(msg)
+			if !ok {
+				t.Fatalf("toContainerEvent() ok = false, want true")
+			}
+			if got.Name != tt.want {
+				t.Errorf("toContainerEvent() Name = %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}
+
+func TestToContainerEventIgnoresNonContainerType(t *testing.T) {
+	t.Parallel()
+
+	msg := events.Message{
+		Type:   events.ImageEventType,
+		Action: events.ActionDie,
+		Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "/api"}},
+	}
+
+	_, ok := toContainerEvent(msg)
+	if ok {
+		t.Errorf("toContainerEvent() ok = true, want false for non-container type")
 	}
 }

--- a/internal/dockerx/events_test.go
+++ b/internal/dockerx/events_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dockerx
+
+import (
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+)
+
+func TestHealthOrNone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		h    *container.HealthSummary
+		want string
+	}{
+		{name: "nil summary", h: nil, want: "none"},
+		{name: "no healthcheck", h: &container.HealthSummary{Status: container.NoHealthcheck}, want: "none"},
+		{name: "starting", h: &container.HealthSummary{Status: container.Starting}, want: "starting"},
+		{name: "healthy", h: &container.HealthSummary{Status: container.Healthy}, want: "healthy"},
+		{name: "unhealthy", h: &container.HealthSummary{Status: container.Unhealthy}, want: "unhealthy"},
+		{name: "unknown status", h: &container.HealthSummary{Status: "bogus"}, want: "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := healthOrNone(tt.h); got != tt.want {
+				t.Errorf("healthOrNone(%+v) = %q, want %q", tt.h, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToContainerStateSummary(t *testing.T) {
+	t.Parallel()
+
+	s := container.Summary{
+		ID:    "abc123",
+		Names: []string{"/api"},
+		State: container.ContainerState("running"),
+	}
+
+	got := toContainerStateSummary(s)
+
+	want := ContainerStateSummary{ID: "abc123", Name: "api", State: "running", Health: "none"}
+	if got != want {
+		t.Errorf("toContainerStateSummary() = %+v, want %+v", got, want)
+	}
+}
+
+func TestTrimContainerName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "leading slash stripped", input: "/api", want: "api"},
+		{name: "no leading slash", input: "api", want: "api"},
+		{name: "empty string", input: "", want: ""},
+		{name: "only one slash stripped", input: "//weird", want: "/weird"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := trimContainerName(tt.input); got != tt.want {
+				t.Errorf("trimContainerName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainerStateSummaryNamesEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := container.Summary{ID: "abc123", Names: nil, State: container.ContainerState("running")}
+
+	got := toContainerStateSummary(s)
+
+	if got.Name != "" {
+		t.Errorf("toContainerStateSummary() Name = %q, want empty", got.Name)
+	}
+}

--- a/internal/dockerx/types.go
+++ b/internal/dockerx/types.go
@@ -104,6 +104,41 @@ type ContainerDetail struct {
 	Protected bool `json:"protected"`
 }
 
+// ContainerStateSummary is one entry of the event stream's opening snapshot: the
+// minimum a client needs to reconcile its own view before live events start
+// arriving. 4 fields.
+//
+// It is deliberately not ContainerSummary. The snapshot is sent on every
+// reconnect, including on a flaky mobile connection, so it carries the four
+// fields the stream can change and nothing else — ports, labels, and image
+// identifiers do not belong in a frame whose job is "here is what moved".
+//
+// Health is one of container.NoHealthcheck, Starting, Healthy, Unhealthy —
+// "none", "starting", "healthy", "unhealthy". No omitempty: a client must be
+// able to tell "no healthcheck" from "this agent version does not report
+// health", exactly as ContainerSummary.Protected argues.
+type ContainerStateSummary struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"` // leading "/" stripped (D18); join on ID, not this
+	State  string `json:"state"`
+	Health string `json:"health"`
+}
+
+// ContainerEvent is one allowlisted Docker container event.
+//
+// Event is a NORMALISED literal from a fixed allowlist, never string(msg.Action):
+// a free-form health_status action carries the healthcheck's own output, which
+// this agent must not publish or log. Actor.Attributes is never mapped at all —
+// it is the container's label set (Phase 3 D2 applies verbatim); only the "name"
+// key is read.
+type ContainerEvent struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`             // leading "/" stripped (D18)
+	Event  string `json:"event"`            // "health_status" | "die" | "start" | "stop" | "oom"
+	Health string `json:"health,omitempty"` // set only for health_status; "healthy" | "unhealthy"
+	Time   string `json:"time"`             // RFC3339 UTC
+}
+
 // ImageSummary is one entry of an image list. 8 fields.
 type ImageSummary struct {
 	ID          string            `json:"id"`

--- a/internal/dockerx/types_test.go
+++ b/internal/dockerx/types_test.go
@@ -112,6 +112,78 @@ func TestContainerDetailFieldCount(t *testing.T) {
 	}
 }
 
+// TestContainerStateSummaryFieldCount is the D1 allowlist guard for the event
+// stream's snapshot entry: Health has no omitempty, so this must be exactly 4
+// keys regardless of population.
+func TestContainerStateSummaryFieldCount(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	css := ContainerStateSummary{
+		ID:     "abc123",
+		Name:   "api",
+		State:  "running",
+		Health: "healthy",
+	}
+
+	// Act
+	body := marshalToMap(t, css)
+
+	// Assert
+	if len(body) != 4 {
+		t.Fatalf("ContainerStateSummary payload has %d keys (%v), want exactly 4", len(body), keysOf(body))
+	}
+}
+
+// TestContainerEventFieldCount is the D1 allowlist guard for the event
+// stream's per-transition frame: Health is omitempty, so a lifecycle event
+// (no Health) marshals to 4 keys and a health event marshals to 5.
+func TestContainerEventFieldCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ev   ContainerEvent
+		want int
+	}{
+		{
+			name: "lifecycle event without health has four keys",
+			ev: ContainerEvent{
+				ID:    "abc123",
+				Name:  "api",
+				Event: "die",
+				Time:  "2023-11-14T22:13:20Z",
+			},
+			want: 4,
+		},
+		{
+			name: "health event has five keys",
+			ev: ContainerEvent{
+				ID:     "abc123",
+				Name:   "api",
+				Event:  "health_status",
+				Health: "healthy",
+				Time:   "2023-11-14T22:13:20Z",
+			},
+			want: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			body := marshalToMap(t, tt.ev)
+
+			// Assert
+			if len(body) != tt.want {
+				t.Fatalf("ContainerEvent payload has %d keys (%v), want exactly %d", len(body), keysOf(body), tt.want)
+			}
+		})
+	}
+}
+
 func TestImageSummaryFieldCount(t *testing.T) {
 	t.Parallel()
 

--- a/internal/e2e/api/contract_events_test.go
+++ b/internal/e2e/api/contract_events_test.go
@@ -253,9 +253,14 @@ func TestEventStreamHealthEventArrives(t *testing.T) {
 }
 
 // TestEventStreamLifecycleEvents asserts stopping a running container
-// produces both a "die" and a "stop" frame, in that order — the two
-// lifecycle actions eventActions allowlists besides health_status
-// (internal/dockerx/events.go).
+// produces both a "die" and a "stop" frame — the two lifecycle actions
+// eventActions allowlists besides health_status (internal/dockerx/events.go).
+// The two carry no ordering guarantee between them: on Docker Engine API
+// 1.55, stopping a container was observed to emit kill, kill, stop, die —
+// stop arrives before die — because the daemon's stop handler and the
+// containerd exit notification race independently to the event bus. This
+// test therefore asserts presence of both, in whichever order the daemon
+// happens to deliver them.
 func TestEventStreamLifecycleEvents(t *testing.T) {
 	engine := harness.RequireEngine(t)
 	_, d := readReadyAgent(t, "events-lifecycle")
@@ -275,14 +280,63 @@ func TestEventStreamLifecycleEvents(t *testing.T) {
 		t.Fatalf("POST .../stop: status = %d, want %d; body = %s", status, http.StatusNoContent, raw)
 	}
 
-	die := waitForContainerEvent(t, s, id, "die", 20*time.Second)
-	if die.ID != id {
+	events := waitForContainerEvents(t, s, id, []string{"die", "stop"}, 20*time.Second)
+	if die := events["die"]; die.ID != id {
 		t.Errorf("die event id = %q, want %q", die.ID, id)
 	}
-	stop := waitForContainerEvent(t, s, id, "stop", 20*time.Second)
-	if stop.ID != id {
+	if stop := events["stop"]; stop.ID != id {
 		t.Errorf("stop event id = %q, want %q", stop.ID, id)
 	}
+}
+
+// waitForContainerEvents reads frames off s until it has seen a container
+// event for id matching every action in wantEvents, in any order, or fails
+// the test after deadline. It mirrors waitForContainerEvent's structure (the
+// same "health" SSE-event-name assertion, the same closed-channel and
+// timeout fatals) but tracks a set of still-wanted actions instead of a
+// single one, since the daemon gives no ordering guarantee between them.
+func waitForContainerEvents(t *testing.T, s *harness.Stream, id string, wantEvents []string, deadline time.Duration) map[string]wireContainerEvent {
+	t.Helper()
+
+	remaining := make(map[string]struct{}, len(wantEvents))
+	for _, ev := range wantEvents {
+		remaining[ev] = struct{}{}
+	}
+	seen := make(map[string]wireContainerEvent, len(wantEvents))
+
+	timeout := time.After(deadline)
+	for len(remaining) > 0 {
+		select {
+		case f, ok := <-s.Frames:
+			if !ok {
+				t.Fatalf("stream closed while waiting for events %v on container %s (Err = %v)", remainingKeys(remaining), id, s.Err())
+			}
+			if f.Event != "health" {
+				t.Fatalf("frame event = %q, want %q (every container event frame this route sends uses that one SSE event name)", f.Event, "health")
+			}
+			ev := decodeContainerEvent(t, f.Data)
+			if ev.ID != id {
+				continue
+			}
+			if _, wanted := remaining[ev.Event]; wanted {
+				seen[ev.Event] = ev
+				delete(remaining, ev.Event)
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for events %v on container %s within %s", remainingKeys(remaining), id, deadline)
+		}
+	}
+	return seen
+}
+
+// remainingKeys returns the still-wanted event names out of remaining, for
+// use in a waitForContainerEvents failure message.
+func remainingKeys(remaining map[string]struct{}) []string {
+	keys := make([]string, 0, len(remaining))
+	for k := range remaining {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 // TestEventStreamSupersedesOnlySameDevice asserts D11's whole eviction

--- a/internal/e2e/api/contract_events_test.go
+++ b/internal/e2e/api/contract_events_test.go
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+
+	"github.com/scnplt/devmon-agent/internal/e2e/harness"
+)
+
+// This file replays the container health and lifecycle event stream
+// (GET /v1/events/stream) against a real Engine: the snapshot-first
+// guarantee, live health and lifecycle forwarding, the one-stream-per-device
+// eviction rule (D11), and that this route never touches the log-stream
+// budget (D11's own reasoning, restated in server.go).
+//
+// What this file deliberately does NOT cover: "the agent's own container
+// appears in the snapshot" is the self-exclusion story, and like
+// contract_lifecycle_test.go's own file comment already records for the
+// mutate routes, that needs a containerised agent and lives in
+// internal/e2e/incontainer. The host-binary group StartAgent starts here
+// runs as a bare process, not a Docker container, so there is no "own
+// container" for it to appear as. TestEventStreamSnapshotIncludesKnownContainer
+// below proves the substance the plan's snapshot-first bullet is actually
+// after — that the very first frame reflects a container that already
+// existed before the stream opened, not an empty scaffold — using an
+// ordinary fixture container instead.
+//
+// No test in this file runs t.Parallel(): every one of them opens at least
+// one SSE stream, and the assertions below depend on ordering (which frame
+// arrives first, which stream gets superseded) that a sibling test's own
+// stream traffic on the same agent could perturb — the identical reasoning
+// contract_logs_test.go's own file comment gives for the same choice.
+
+// wireContainerState mirrors one entry of the event stream's opening
+// snapshot (internal/dockerx/types.go's ContainerStateSummary), declared
+// here rather than imported (D4): the suite must notice a renamed field,
+// which it cannot do sharing a struct with the code that produces it.
+type wireContainerState struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	State  string `json:"state"`
+	Health string `json:"health"`
+}
+
+// wireContainerEvent mirrors one live container event
+// (internal/dockerx/types.go's ContainerEvent), for the same D4 reason
+// wireContainerState exists.
+type wireContainerEvent struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Event  string `json:"event"`
+	Health string `json:"health"`
+	Time   string `json:"time"`
+}
+
+// wireEventStreamError mirrors the terminal event: error frame's payload
+// (internal/httpapi/respond.go's errorBody), declared separately for the
+// same D4 reason.
+type wireEventStreamError struct {
+	Error string `json:"error"`
+}
+
+// decodeContainerStates unmarshals one snapshot frame's data into the slice
+// of states it carries, failing the test on a shape it cannot parse.
+func decodeContainerStates(t *testing.T, data []byte) []wireContainerState {
+	t.Helper()
+	var states []wireContainerState
+	if err := json.Unmarshal(data, &states); err != nil {
+		t.Fatalf("decode snapshot frame data: %v; data = %s", err, data)
+	}
+	return states
+}
+
+// decodeContainerEvent unmarshals one live event frame's data, failing the
+// test on a shape it cannot parse.
+func decodeContainerEvent(t *testing.T, data []byte) wireContainerEvent {
+	t.Helper()
+	var ev wireContainerEvent
+	if err := json.Unmarshal(data, &ev); err != nil {
+		t.Fatalf("decode container event frame data: %v; data = %s", err, data)
+	}
+	return ev
+}
+
+// findContainerState returns the entry for id out of states, so a caller can
+// assert on it rather than only on presence.
+func findContainerState(states []wireContainerState, id string) (wireContainerState, bool) {
+	for _, s := range states {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return wireContainerState{}, false
+}
+
+// healthTransitionHealthcheck is the fixture Cmd every healthcheck-driven
+// test in this file uses: a check that always fails, fast, so the Engine
+// reports "unhealthy" well within a test's deadline. Interval, Timeout and
+// Retries mirror TestContainerListReportsHealth's own fixture
+// (contract_reads_test.go) so the two suites' health-flip timing cannot
+// drift apart.
+var healthTransitionHealthcheck = &container.HealthConfig{
+	Test:        []string{"CMD-SHELL", "exit 1"},
+	Interval:    500 * time.Millisecond,
+	Timeout:     500 * time.Millisecond,
+	Retries:     1,
+	StartPeriod: 0,
+}
+
+// waitForContainerEvent reads frames off s until one carries a container
+// event for id whose normalised action equals wantEvent, or fails the test
+// after deadline. Every live container event this route serves is framed
+// under the single SSE event name "health" (events.go's handleEventStream:
+// sse.event("", sseEventHealth, ev) for every allowlisted action, not only
+// health_status) — this helper asserts that framing rather than assuming it,
+// so a change to it fails loudly here instead of silently making every
+// assertion below vacuous.
+func waitForContainerEvent(t *testing.T, s *harness.Stream, id, wantEvent string, deadline time.Duration) wireContainerEvent {
+	t.Helper()
+
+	timeout := time.After(deadline)
+	for {
+		select {
+		case f, ok := <-s.Frames:
+			if !ok {
+				t.Fatalf("stream closed while waiting for %q event on container %s (Err = %v)", wantEvent, id, s.Err())
+			}
+			if f.Event != "health" {
+				t.Fatalf("frame event = %q, want %q (every container event frame this route sends uses that one SSE event name)", f.Event, "health")
+			}
+			ev := decodeContainerEvent(t, f.Data)
+			if ev.ID == id && ev.Event == wantEvent {
+				return ev
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for a %q event on container %s within %s", wantEvent, id, deadline)
+		}
+	}
+	// unreachable: the loop above only returns or fails the test.
+}
+
+// TestEventStreamSnapshotIncludesKnownContainer asserts the very first frame
+// off a freshly opened event stream is event: snapshot, and that it already
+// carries a container started before the stream opened — the reconciliation
+// guarantee the snapshot exists for (D8): a client must never see a gap
+// between "I connected" and "I know what already exists".
+func TestEventStreamSnapshotIncludesKnownContainer(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	_, d := readReadyAgent(t, "events-snapshot")
+
+	id := harness.StartFixture(t, engine, harness.FixtureOptions{NameSuffix: "snapshot"})
+
+	s := harness.OpenStream(t, d, "/v1/events/stream")
+	defer s.Close(t)
+	if s.Status != http.StatusOK {
+		t.Fatalf("open event stream: status = %d, want %d; body = %s", s.Status, http.StatusOK, s.Body)
+	}
+
+	frames := collectFrames(t, s, 1, 10*time.Second)
+	if frames[0].Event != "snapshot" {
+		t.Fatalf("first frame event = %q, want %q", frames[0].Event, "snapshot")
+	}
+
+	states := decodeContainerStates(t, frames[0].Data)
+	if _, ok := findContainerState(states, id); !ok {
+		t.Errorf("snapshot does not contain container %s, which was already running when the stream opened", id)
+	}
+}
+
+// TestEventStreamSnapshotReflectsUnhealthy asserts a container the Engine
+// already reports unhealthy shows health: "unhealthy" in the very next
+// snapshot.
+//
+// Requires Engine 29+ / API v1.52, mirroring the e2e-health skip the
+// Makefile documents for TestContainerListReportsHealth (contract_reads_test.go):
+// ContainerStateSummary.Health is built from the same ContainerList response
+// as ContainerSummary.Health (internal/dockerx/events.go's
+// toContainerStateSummary), and Health was only added to that response in API
+// v1.52. Below that version the field is uniformly "none" no matter what the
+// fixture container actually does, so the assertion cannot hold and this
+// test skips rather than failing on an Engine that never claimed the
+// capability.
+func TestEventStreamSnapshotReflectsUnhealthy(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	harness.RequireEngineAPIAtLeast(t, engine, "1.52")
+	_, d := readReadyAgent(t, "events-snapshot-health")
+
+	id := harness.StartFixture(t, engine, harness.FixtureOptions{
+		NameSuffix:  "snapshot-health",
+		Healthcheck: healthTransitionHealthcheck,
+	})
+
+	waitContainerUnhealthy(t, engine, id, 20*time.Second)
+
+	s := harness.OpenStream(t, d, "/v1/events/stream")
+	defer s.Close(t)
+	if s.Status != http.StatusOK {
+		t.Fatalf("open event stream: status = %d, want %d; body = %s", s.Status, http.StatusOK, s.Body)
+	}
+
+	frames := collectFrames(t, s, 1, 10*time.Second)
+	if frames[0].Event != "snapshot" {
+		t.Fatalf("first frame event = %q, want %q", frames[0].Event, "snapshot")
+	}
+
+	states := decodeContainerStates(t, frames[0].Data)
+	state, ok := findContainerState(states, id)
+	if !ok {
+		t.Fatalf("snapshot does not contain container %s", id)
+	}
+	if state.Health != "unhealthy" {
+		t.Errorf("snapshot health for container %s = %q, want %q", id, state.Health, "unhealthy")
+	}
+}
+
+// TestEventStreamHealthEventArrives asserts a container whose healthcheck
+// flips to unhealthy after the stream opens produces a live event carrying
+// "health":"unhealthy" — the health_status forwarding
+// internal/dockerx/events.go's toContainerEvent exists for. Unlike
+// TestEventStreamSnapshotReflectsUnhealthy above, this needs no Engine
+// version guard: health_status events come off the raw Engine event feed,
+// not the v1.52-gated list response.
+func TestEventStreamHealthEventArrives(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	_, d := readReadyAgent(t, "events-health-live")
+
+	id := harness.StartFixture(t, engine, harness.FixtureOptions{
+		NameSuffix:  "health-live",
+		Healthcheck: healthTransitionHealthcheck,
+	})
+
+	s := harness.OpenStream(t, d, "/v1/events/stream")
+	defer s.Close(t)
+	if s.Status != http.StatusOK {
+		t.Fatalf("open event stream: status = %d, want %d; body = %s", s.Status, http.StatusOK, s.Body)
+	}
+	collectFrames(t, s, 1, 10*time.Second) // drain the opening snapshot
+
+	ev := waitForContainerEvent(t, s, id, "health_status", 20*time.Second)
+	if ev.Health != "unhealthy" {
+		t.Errorf("health event for container %s: health = %q, want %q", id, ev.Health, "unhealthy")
+	}
+}
+
+// TestEventStreamLifecycleEvents asserts stopping a running container
+// produces both a "die" and a "stop" frame, in that order — the two
+// lifecycle actions eventActions allowlists besides health_status
+// (internal/dockerx/events.go).
+func TestEventStreamLifecycleEvents(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	_, d := readReadyAgent(t, "events-lifecycle")
+
+	id := harness.StartFixture(t, engine, harness.FixtureOptions{NameSuffix: "lifecycle"})
+	waitContainerRunning(t, engine, id)
+
+	s := harness.OpenStream(t, d, "/v1/events/stream")
+	defer s.Close(t)
+	if s.Status != http.StatusOK {
+		t.Fatalf("open event stream: status = %d, want %d; body = %s", s.Status, http.StatusOK, s.Body)
+	}
+	collectFrames(t, s, 1, 10*time.Second) // drain the opening snapshot
+
+	status, _, raw := d.Do(t, http.MethodPost, "/v1/containers/"+id+"/stop", nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("POST .../stop: status = %d, want %d; body = %s", status, http.StatusNoContent, raw)
+	}
+
+	die := waitForContainerEvent(t, s, id, "die", 20*time.Second)
+	if die.ID != id {
+		t.Errorf("die event id = %q, want %q", die.ID, id)
+	}
+	stop := waitForContainerEvent(t, s, id, "stop", 20*time.Second)
+	if stop.ID != id {
+		t.Errorf("stop event id = %q, want %q", stop.ID, id)
+	}
+}
+
+// TestEventStreamSupersedesOnlySameDevice asserts D11's whole eviction
+// contract in one test: a second stream from the same device evicts the
+// first (which receives event: error carrying msgEventStreamSuperseded and
+// then closes) and itself gets a fresh snapshot; a second, independently
+// paired device's own stream is untouched by any of it throughout.
+func TestEventStreamSupersedesOnlySameDevice(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	a, deviceA := readReadyAgent(t, "events-superseded-a")
+	deviceB := harness.PairDevice(t, a, "events-superseded-b")
+
+	harness.StartFixture(t, engine, harness.FixtureOptions{NameSuffix: "superseded"})
+
+	first := harness.OpenStream(t, deviceA, "/v1/events/stream")
+	if first.Status != http.StatusOK {
+		t.Fatalf("open first event stream (device A): status = %d, want %d; body = %s", first.Status, http.StatusOK, first.Body)
+	}
+	collectFrames(t, first, 1, 10*time.Second) // drain the opening snapshot
+
+	other := harness.OpenStream(t, deviceB, "/v1/events/stream")
+	defer other.Close(t)
+	if other.Status != http.StatusOK {
+		t.Fatalf("open event stream (device B): status = %d, want %d; body = %s", other.Status, http.StatusOK, other.Body)
+	}
+	otherFrames := collectFrames(t, other, 1, 10*time.Second)
+	if otherFrames[0].Event != "snapshot" {
+		t.Fatalf("device B's first frame event = %q, want %q", otherFrames[0].Event, "snapshot")
+	}
+
+	second := harness.OpenStream(t, deviceA, "/v1/events/stream")
+	defer second.Close(t)
+	if second.Status != http.StatusOK {
+		t.Fatalf("open second event stream (device A): status = %d, want %d; body = %s", second.Status, http.StatusOK, second.Body)
+	}
+
+	// The evicted first stream must receive exactly one terminal error frame
+	// carrying the "do not retry" message, then close on its own.
+	termFrames := collectFrames(t, first, 1, 10*time.Second)
+	if termFrames[0].Event != "error" {
+		t.Fatalf("first stream's terminal frame event = %q, want %q", termFrames[0].Event, "error")
+	}
+	var termBody wireEventStreamError
+	if err := json.Unmarshal(termFrames[0].Data, &termBody); err != nil {
+		t.Fatalf("decode first stream's terminal frame data: %v; data = %s", err, termFrames[0].Data)
+	}
+	const wantSupersededMsg = "event stream superseded"
+	if termBody.Error != wantSupersededMsg {
+		t.Errorf("first stream's terminal error = %q, want %q", termBody.Error, wantSupersededMsg)
+	}
+	first.WaitClosed(t, 10*time.Second)
+
+	// The newer, second stream gets a fresh snapshot of its own.
+	secondFrames := collectFrames(t, second, 1, 10*time.Second)
+	if secondFrames[0].Event != "snapshot" {
+		t.Errorf("second stream's first frame event = %q, want %q", secondFrames[0].Event, "snapshot")
+	}
+
+	// Device B's independent stream must be untouched by any of the above.
+	if err := other.Err(); err != nil {
+		t.Errorf("device B's stream ended (Err = %v) while only device A's streams were superseded", err)
+	}
+}
+
+// TestEventStreamDoesNotConsumeLogStreamBudget asserts opening an event
+// stream first still leaves a device able to open its full
+// maxStreamsPerDevice worth of /logs/stream connections — the property D11
+// and server.go's own route comment both promise: an event stream is
+// registered through the `read` guard chain, never streamBudget, so it costs
+// this device nothing against the log-stream ceiling.
+func TestEventStreamDoesNotConsumeLogStreamBudget(t *testing.T) {
+	engine := harness.RequireEngine(t)
+	_, d := readReadyAgent(t, "events-log-budget")
+
+	id := harness.StartFixture(t, engine, harness.FixtureOptions{
+		NameSuffix: "log-budget",
+		Cmd:        logLinesCmd,
+	})
+
+	ev := harness.OpenStream(t, d, "/v1/events/stream")
+	defer ev.Close(t)
+	if ev.Status != http.StatusOK {
+		t.Fatalf("open event stream: status = %d, want %d; body = %s", ev.Status, http.StatusOK, ev.Body)
+	}
+	collectFrames(t, ev, 1, 10*time.Second) // drain the opening snapshot
+
+	// maxStreamsPerDevice duplicates internal/httpapi/server.go's own
+	// constant (D4, mirroring contract_logs_test.go's own duplication of it).
+	const maxStreamsPerDevice = 3
+
+	logStreams := make([]*harness.Stream, 0, maxStreamsPerDevice)
+	defer func() {
+		for _, s := range logStreams {
+			s.Close(t)
+		}
+	}()
+
+	for i := 0; i < maxStreamsPerDevice; i++ {
+		s := harness.OpenStream(t, d, "/v1/containers/"+id+"/logs/stream")
+		if s.Status != http.StatusOK {
+			t.Fatalf("log stream %d/%d after opening an event stream: status = %d, want %d; body = %s",
+				i+1, maxStreamsPerDevice, s.Status, http.StatusOK, s.Body)
+		}
+		logStreams = append(logStreams, s)
+	}
+}
+
+// waitContainerUnhealthy polls the Engine (never the agent) until id reports
+// health "unhealthy", bounded by a deadline rather than a fixed sleep —
+// mirrors waitContainerRunning's own reasoning in contract_lifecycle_test.go.
+func waitContainerUnhealthy(t *testing.T, engine *client.Client, id string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		res, err := engine.ContainerInspect(ctx, id, client.ContainerInspectOptions{})
+		cancel()
+		if err == nil && res.Container.State != nil && res.Container.State.Health != nil {
+			last = string(res.Container.State.Health.Status)
+			if last == string(container.Unhealthy) {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("container %s did not reach health %q within %s (last observed = %q)", id, container.Unhealthy, timeout, last)
+}

--- a/internal/httpapi/eventhub.go
+++ b/internal/httpapi/eventhub.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/scnplt/devmon-agent/internal/dockerx"
+)
+
+// eventCloseReason names why the hub closed a subscriber, so the handler can
+// send the right terminal frame and log at the right level.
+type eventCloseReason int
+
+const (
+	eventClosedEngine eventCloseReason = iota // the shared feed failed or ended
+	eventClosedLagged                         // this subscriber could not keep up
+)
+
+// eventClientBuffer bounds how far one subscriber may fall behind before it is
+// dropped. 64 is roughly two seconds of a very busy host's container churn: high
+// enough that an ordinary client on a slow link never trips it, low enough that
+// the hub's total buffering stays trivial.
+//
+// A package variable rather than a constant so a test can shrink it to 1 and
+// exercise the overflow path deterministically, exactly as keepaliveInterval is
+// a variable so a test can shorten it.
+var eventClientBuffer = 64
+
+// errEventHubUnavailable is returned by attach when the shared subscription's
+// run ended before it ever became ready and without a more specific Engine
+// error to report — a defensive fallback so attach never returns a nil
+// subscriber alongside a nil error.
+var errEventHubUnavailable = errors.New("event stream subscription unavailable")
+
+// eventSubscriber is one attached client's view of the hub.
+type eventSubscriber struct {
+	events chan dockerx.ContainerEvent
+	closed chan eventCloseReason // buffered 1; receives at most one value
+	once   sync.Once
+}
+
+// close records reason as this subscriber's terminal state. It is
+// sync.Once-guarded and sends on a buffered-1 channel via select/default, so a
+// second close (for example a lagged drop racing the hub's own feed-death
+// teardown) can never block or panic.
+func (s *eventSubscriber) close(reason eventCloseReason) {
+	s.once.Do(func() {
+		select {
+		case s.closed <- reason:
+		default:
+		}
+	})
+}
+
+// eventHub owns the agent's single Docker events subscription and fans it out
+// to every attached client.
+//
+// Exactly one subscription per process, not one per client: GET /events is a
+// long-lived Engine connection, and N clients receiving a byte-identical feed
+// through N connections is redundant file-descriptor pressure on the host this
+// agent exists to protect.
+//
+// Lazy: the subscription starts when the first client attaches and stops when
+// the last one detaches, so an agent nobody is watching holds no Engine
+// connection and needs no reconnect-forever machinery.
+//
+// The hub NEVER reconnects. When the feed fails or ends, every subscriber is
+// closed with eventClosedEngine and the hub stops. A hub that reconnected would
+// resume a feed with a hole in it and — because this feature has no replay —
+// no way to tell its clients what fell in. Turning every gap into a disconnect
+// makes the opening snapshot the single recovery path for every failure here.
+type eventHub struct {
+	dc  EventReader
+	log *slog.Logger
+
+	mu      sync.Mutex
+	subs    map[*eventSubscriber]struct{}
+	running bool
+	ready   chan struct{} // closed once the Engine subscription is live
+	failed  chan struct{} // closed if the run ends before ready
+	runErr  error         // the run's error, valid once failed is closed
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// newEventHub builds an eventHub with no subscription running.
+func newEventHub(dc EventReader, log *slog.Logger) *eventHub {
+	return &eventHub{dc: dc, log: log, subs: make(map[*eventSubscriber]struct{})}
+}
+
+// attach registers a subscriber and blocks until the shared subscription is
+// live, starting it if this is the first client.
+//
+// The subscriber is registered BEFORE the wait, so its buffer is already
+// collecting by the time the caller takes its snapshot — that ordering is the
+// whole reason an event cannot fall between the two (see the handler).
+//
+// parent is the server's lifetime context, not the request's: the shared
+// subscription must outlive whichever client happened to start it. reqCtx
+// bounds only how long this call waits for readiness — cancelling it while the
+// Engine is unreachable must not hang the caller.
+func (h *eventHub) attach(parent, reqCtx context.Context) (*eventSubscriber, error) {
+	sub := &eventSubscriber{
+		events: make(chan dockerx.ContainerEvent, eventClientBuffer),
+		closed: make(chan eventCloseReason, 1),
+	}
+
+	h.mu.Lock()
+	h.subs[sub] = struct{}{}
+
+	if !h.running {
+		h.running = true
+		h.runErr = nil
+		h.ready = make(chan struct{})
+		h.failed = make(chan struct{})
+
+		ctx, cancel := context.WithCancel(parent)
+		h.cancel = cancel
+
+		h.wg.Add(1)
+		go func() {
+			defer h.wg.Done()
+			h.run(ctx)
+		}()
+	}
+	ready := h.ready
+	failed := h.failed
+	h.mu.Unlock()
+
+	select {
+	case <-ready:
+		return sub, nil
+	case <-failed:
+		h.detach(sub)
+		h.mu.Lock()
+		err := h.runErr
+		h.mu.Unlock()
+		if err == nil {
+			err = errEventHubUnavailable
+		}
+		return nil, err
+	case <-reqCtx.Done():
+		h.detach(sub)
+		return nil, reqCtx.Err()
+	}
+}
+
+// detach removes sub and stops the subscription if it was the last one.
+func (h *eventHub) detach(sub *eventSubscriber) {
+	h.mu.Lock()
+	if _, ok := h.subs[sub]; !ok {
+		h.mu.Unlock()
+		return
+	}
+	delete(h.subs, sub)
+	last := len(h.subs) == 0 && h.running
+	cancel := h.cancel
+	h.mu.Unlock()
+
+	if last {
+		cancel()
+	}
+}
+
+// stop cancels the subscription and waits for its goroutine, bounded so it can
+// never consume the server's shutdownGrace window. Idempotent: a second call
+// finds no cancel to call and an already-finished wg.
+func (h *eventHub) stop() {
+	h.mu.Lock()
+	cancel := h.cancel
+	h.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	h.wg.Wait()
+}
+
+// run drives the shared Engine subscription for one lifecycle: start, fan
+// out until it ends, then tear every subscriber down. It never reconnects
+// (see eventHub's doc comment).
+func (h *eventHub) run(ctx context.Context) {
+	err := h.dc.StreamContainerEvents(ctx, h.markReady, h.fanout)
+
+	h.mu.Lock()
+	h.runErr = err
+	failed := h.failed
+	subs := make([]*eventSubscriber, 0, len(h.subs))
+	for sub := range h.subs {
+		subs = append(subs, sub)
+	}
+	h.subs = make(map[*eventSubscriber]struct{})
+	h.running = false
+	h.cancel = nil
+	h.mu.Unlock()
+
+	// Unblock any attach still waiting on this run's readiness, whether it
+	// already succeeded (harmless — select already chose the ready branch)
+	// or never got the chance to.
+	close(failed)
+
+	for _, sub := range subs {
+		sub.close(eventClosedEngine)
+	}
+
+	if err == nil {
+		return
+	}
+	// The error is an Engine transport error, never an event payload, so it
+	// is safe to log. Warn for an ordinary feed end (a daemon restart);
+	// Error for anything else.
+	if errors.Is(err, dockerx.ErrEventFeedClosed) {
+		h.log.Warn("container event feed closed", slog.Any("err", err))
+	} else {
+		h.log.Error("container event feed failed", slog.Any("err", err))
+	}
+}
+
+// markReady closes the current run's ready channel, signalling every
+// attach call waiting on it that the Engine subscription is live.
+func (h *eventHub) markReady() {
+	h.mu.Lock()
+	ready := h.ready
+	h.mu.Unlock()
+	close(ready)
+}
+
+// fanout is the emit callback passed to StreamContainerEvents. It must never
+// block: the Engine's message channel is unbuffered, so a stalled fan-out
+// stalls the Engine decoder goroutine for every subscriber, not just a slow
+// one.
+func (h *eventHub) fanout(ev dockerx.ContainerEvent) error {
+	h.mu.Lock()
+	subs := make([]*eventSubscriber, 0, len(h.subs))
+	for sub := range h.subs {
+		subs = append(subs, sub)
+	}
+	h.mu.Unlock()
+
+	for _, sub := range subs {
+		select {
+		case sub.events <- ev:
+		default:
+			// Bounded buffer full: drop the CLIENT, never the event. A dropped
+			// event leaves the client believing it has a complete picture with
+			// nothing on the wire to say otherwise; a dropped client reconnects
+			// and re-snapshots, which is self-correcting.
+			h.log.Warn("event subscriber fell behind, dropping it",
+				slog.String("container_id", ev.ID), slog.String("event", ev.Event))
+			sub.close(eventClosedLagged)
+			h.detach(sub)
+		}
+	}
+	return nil
+}

--- a/internal/httpapi/eventhub_test.go
+++ b/internal/httpapi/eventhub_test.go
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/dockerx"
+)
+
+// fakeEventReader implements EventReader with a single function field, so
+// each test injects exactly the StreamContainerEvents behaviour it needs.
+// ContainerStates is unused by eventHub and is not exercised here.
+type fakeEventReader struct {
+	streamContainerEventsFn func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error
+}
+
+var _ EventReader = (*fakeEventReader)(nil)
+
+func (f *fakeEventReader) ContainerStates(ctx context.Context) ([]dockerx.ContainerStateSummary, error) {
+	return nil, nil
+}
+
+func (f *fakeEventReader) StreamContainerEvents(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+	if f.streamContainerEventsFn == nil {
+		if onReady != nil {
+			onReady()
+		}
+		<-ctx.Done()
+		return nil
+	}
+	return f.streamContainerEventsFn(ctx, onReady, emit)
+}
+
+// blockingEventReader is a fakeEventReader whose default behaviour is "become
+// ready, then block on ctx until cancelled" — the shape most of the tests
+// below need, since they only care about lazy start/stop and fan-out.
+func blockingEventReader(onStart func()) *fakeEventReader {
+	return &fakeEventReader{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			if onStart != nil {
+				onStart()
+			}
+			if onReady != nil {
+				onReady()
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+}
+
+func TestEventHubStartsLazily(t *testing.T) {
+	t.Parallel()
+
+	var started atomic.Bool
+	fer := blockingEventReader(func() { started.Store(true) })
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	if started.Load() {
+		t.Fatal("StreamContainerEvents called before any attach")
+	}
+
+	sub, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	t.Cleanup(func() { h.detach(sub) })
+
+	if !started.Load() {
+		t.Fatal("StreamContainerEvents never called after the first attach")
+	}
+}
+
+func TestEventHubStopsAfterLastDetach(t *testing.T) {
+	t.Parallel()
+
+	var starts atomic.Int32
+	fer := blockingEventReader(func() { starts.Add(1) })
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	sub1, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("first attach: %v", err)
+	}
+
+	h.detach(sub1)
+
+	waitForCondition(t, time.Second, 5*time.Millisecond,
+		func() bool { h.mu.Lock(); defer h.mu.Unlock(); return !h.running },
+		func() string { return "hub still reports running after the last detach" })
+
+	sub2, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("second attach: %v", err)
+	}
+	t.Cleanup(func() { h.detach(sub2) })
+
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("StreamContainerEvents call count = %d, want 2 (a fresh subscription per run)", got)
+	}
+}
+
+func TestEventHubOneSubscriptionForManyClients(t *testing.T) {
+	t.Parallel()
+
+	var starts atomic.Int32
+	fer := blockingEventReader(func() { starts.Add(1) })
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	subs := make([]*eventSubscriber, 0, 3)
+	for i := 0; i < 3; i++ {
+		sub, err := h.attach(context.Background(), context.Background())
+		if err != nil {
+			t.Fatalf("attach %d: %v", i, err)
+		}
+		subs = append(subs, sub)
+	}
+	t.Cleanup(func() {
+		for _, sub := range subs {
+			h.detach(sub)
+		}
+	})
+
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("StreamContainerEvents call count = %d, want 1", got)
+	}
+}
+
+func TestEventHubFansOutToEverySubscriber(t *testing.T) {
+	t.Parallel()
+
+	emitCh := make(chan func(dockerx.ContainerEvent) error, 1)
+	fer := &fakeEventReader{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			emitCh <- emit
+			if onReady != nil {
+				onReady()
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	subs := make([]*eventSubscriber, 0, 3)
+	for i := 0; i < 3; i++ {
+		sub, err := h.attach(context.Background(), context.Background())
+		if err != nil {
+			t.Fatalf("attach %d: %v", i, err)
+		}
+		subs = append(subs, sub)
+	}
+	t.Cleanup(func() {
+		for _, sub := range subs {
+			h.detach(sub)
+		}
+	})
+
+	emit := <-emitCh
+	ev := dockerx.ContainerEvent{ID: "c1", Event: "die"}
+	if err := emit(ev); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	for i, sub := range subs {
+		select {
+		case got := <-sub.events:
+			if got != ev {
+				t.Fatalf("subscriber %d got %+v, want %+v", i, got, ev)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d never received the event", i)
+		}
+	}
+}
+
+func TestEventHubAttachFailsWhenEngineUnreachable(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("engine down")
+	fer := &fakeEventReader{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			return wantErr // never calls onReady
+		},
+	}
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	done := make(chan struct{})
+	var sub *eventSubscriber
+	var err error
+	go func() {
+		sub, err = h.attach(context.Background(), context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("attach hung instead of returning the engine error")
+	}
+
+	if sub != nil {
+		t.Fatalf("sub = %v, want nil", sub)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestEventHubAttachRespectsRequestCancellation(t *testing.T) {
+	t.Parallel()
+
+	fer := &fakeEventReader{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			<-ctx.Done() // never calls onReady
+			return nil
+		},
+	}
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	var sub *eventSubscriber
+	var err error
+	go func() {
+		sub, err = h.attach(context.Background(), reqCtx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("attach hung after the request context was cancelled")
+	}
+
+	if sub != nil {
+		t.Fatalf("sub = %v, want nil", sub)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// TestEventHubSlowSubscriberIsDropped is the "must not block the fan-out"
+// proof: with eventClientBuffer shrunk to 1, a subscriber that is never
+// drained is dropped on overflow, while a subscriber that IS drained keeps
+// receiving every event fanout sends after it.
+func TestEventHubSlowSubscriberIsDropped(t *testing.T) {
+	// Not t.Parallel(): mutates the package-level eventClientBuffer.
+	original := eventClientBuffer
+	eventClientBuffer = 1
+	t.Cleanup(func() { eventClientBuffer = original })
+
+	emitCh := make(chan func(dockerx.ContainerEvent) error, 1)
+	fer := &fakeEventReader{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			emitCh <- emit
+			if onReady != nil {
+				onReady()
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	stalled, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("attach stalled: %v", err)
+	}
+	reading, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("attach reading: %v", err)
+	}
+	t.Cleanup(func() {
+		h.detach(stalled)
+		h.detach(reading)
+	})
+
+	emit := <-emitCh
+
+	// First event: both buffers (size 1) have room, so both receive it.
+	// stalled is deliberately never drained from here on.
+	if err := emit(dockerx.ContainerEvent{ID: "c1", Event: "die"}); err != nil {
+		t.Fatalf("first emit: %v", err)
+	}
+	select {
+	case <-reading.events:
+	case <-time.After(time.Second):
+		t.Fatal("reading subscriber missed the first event")
+	}
+
+	// Second event: stalled's single slot is still full, so this overflows
+	// it and the hub must drop stalled rather than block fanout.
+	if err := emit(dockerx.ContainerEvent{ID: "c1", Event: "start"}); err != nil {
+		t.Fatalf("second emit: %v", err)
+	}
+
+	select {
+	case reason := <-stalled.closed:
+		if reason != eventClosedLagged {
+			t.Fatalf("stalled close reason = %v, want eventClosedLagged", reason)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stalled subscriber was never closed")
+	}
+
+	select {
+	case <-reading.events:
+	case <-time.After(time.Second):
+		t.Fatal("reading subscriber never received the second event; the stalled subscriber stalled fanout")
+	}
+}
+
+func TestEventHubFeedDeathClosesEverySubscriber(t *testing.T) {
+	t.Parallel()
+
+	endFeed := make(chan struct{})
+	fer := &fakeEventReader{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			if onReady != nil {
+				onReady()
+			}
+			<-endFeed
+			return dockerx.ErrEventFeedClosed
+		},
+	}
+	h := newEventHub(fer, testLogger())
+	t.Cleanup(h.stop)
+
+	sub1, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("attach1: %v", err)
+	}
+	sub2, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("attach2: %v", err)
+	}
+
+	close(endFeed)
+
+	for i, sub := range []*eventSubscriber{sub1, sub2} {
+		select {
+		case reason := <-sub.closed:
+			if reason != eventClosedEngine {
+				t.Fatalf("subscriber %d close reason = %v, want eventClosedEngine", i, reason)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d was never closed", i)
+		}
+	}
+}
+
+func TestEventHubStopIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	h := newEventHub(blockingEventReader(nil), testLogger())
+
+	sub, err := h.attach(context.Background(), context.Background())
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	_ = sub
+
+	h.stop()
+	h.stop() // must not panic or block
+}
+
+func TestEventHubConcurrentAttachDetach(t *testing.T) {
+	t.Parallel()
+
+	h := newEventHub(blockingEventReader(nil), testLogger())
+	t.Cleanup(h.stop)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sub, err := h.attach(context.Background(), context.Background())
+			if err != nil {
+				return
+			}
+			h.detach(sub)
+		}()
+	}
+	wg.Wait()
+}
+
+// eventHubRunGoroutineFrame is the stack-trace frame of the anonymous
+// goroutine attach starts to run the shared subscription. A renamed or moved
+// goroutine must fail TestEventHubGoroutineDoesNotLeak loudly rather than
+// pass vacuously — see countGoroutinesMatching (logs_test.go) for why a stack
+// frame is used instead of runtime.NumGoroutine().
+const eventHubRunGoroutineFrame = "internal/httpapi.(*eventHub).attach.func1"
+
+// TestEventHubGoroutineDoesNotLeak attaches and detaches 20 times and asserts
+// the count of the hub's run goroutine returns to zero, mirroring Phase 4's
+// TestStreamGoroutineDoesNotLeak.
+func TestEventHubGoroutineDoesNotLeak(t *testing.T) {
+	t.Parallel()
+
+	h := newEventHub(blockingEventReader(nil), testLogger())
+	t.Cleanup(h.stop)
+
+	for i := 0; i < 20; i++ {
+		sub, err := h.attach(context.Background(), context.Background())
+		if err != nil {
+			t.Fatalf("attach %d: %v", i, err)
+		}
+		h.detach(sub)
+	}
+
+	waitForCondition(t, 2*time.Second, 5*time.Millisecond,
+		func() bool { return countGoroutinesMatching(eventHubRunGoroutineFrame) == 0 },
+		func() string {
+			return fmt.Sprintf("event hub run goroutine count = %d, want 0",
+				countGoroutinesMatching(eventHubRunGoroutineFrame))
+		})
+}

--- a/internal/httpapi/eventregistry.go
+++ b/internal/httpapi/eventregistry.go
@@ -62,9 +62,18 @@ func (r *eventRegistry) register(deviceID string, cancel context.CancelFunc) (re
 	// Cancel the old slot only after releasing the mutex: the cancelled
 	// handler's unwind calls release, which takes r.mu, so cancelling while
 	// holding it is a lock-ordering hazard.
+	//
+	// superseded is closed before cancel is called (rather than after) so
+	// the evicted handler's select never has to observe ctx.Done() without
+	// superseded already being visible too — belt and braces alongside the
+	// handler-side fix (events.go's writeTerminalEventError) that is what
+	// actually makes the superseded frame reach the wire: gating "is the
+	// client gone" on the handler's own derived ctx, which this cancel call
+	// deliberately closes, made the terminal frame unreachable regardless of
+	// this ordering.
 	if old != nil {
-		old.cancel()
 		close(old.superseded)
+		old.cancel()
 	}
 
 	release = func() {

--- a/internal/httpapi/eventregistry.go
+++ b/internal/httpapi/eventregistry.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"sync"
+)
+
+// eventRegistry enforces one live event stream per paired device. A second
+// connection from the same device cancels the first and takes its place.
+//
+// This is deliberately NOT streamBudget. A log stream costs an Engine
+// connection, so it is rationed against a host-wide ceiling; an event stream
+// costs a channel and a goroutine against a subscription every stream shares,
+// so the only limit worth enforcing is "one per device" and no global ceiling
+// is needed — the count is bounded by the number of paired devices. Charging an
+// event stream to the log budget would let a client watching health lose its
+// ability to open a log view.
+//
+// Newest-wins rather than newest-refused: a second connection from one device is
+// in practice a client that reconnected before its old socket was reaped, and
+// refusing the new one would leave the device attached to a socket it has
+// already forgotten.
+type eventRegistry struct {
+	mu     sync.Mutex
+	active map[string]*eventSlot
+}
+
+// eventSlot is one device's live stream. The pointer is the identity token:
+// release deletes the map entry only when it still holds THIS slot, so a stream
+// that was superseded cannot, on its way out, evict the stream that superseded
+// it.
+type eventSlot struct {
+	cancel     context.CancelFunc
+	superseded chan struct{}
+	once       sync.Once
+}
+
+// newEventRegistry builds an empty eventRegistry.
+func newEventRegistry() *eventRegistry {
+	return &eventRegistry{active: make(map[string]*eventSlot)}
+}
+
+// register makes cancel the live stream for deviceID, cancelling and replacing
+// any stream that device already had. The returned release must be called
+// exactly once, and is safe to call after this slot has already been
+// superseded.
+//
+// superseded is closed when — and only when — this slot is later evicted by a
+// newer registration for the same device, so the handler that owns it can
+// distinguish "superseded" from an ordinary client disconnect and write the
+// right terminal frame.
+func (r *eventRegistry) register(deviceID string, cancel context.CancelFunc) (release func(), superseded <-chan struct{}) {
+	slot := &eventSlot{cancel: cancel, superseded: make(chan struct{})}
+
+	r.mu.Lock()
+	old := r.active[deviceID]
+	r.active[deviceID] = slot
+	r.mu.Unlock()
+
+	// Cancel the old slot only after releasing the mutex: the cancelled
+	// handler's unwind calls release, which takes r.mu, so cancelling while
+	// holding it is a lock-ordering hazard.
+	if old != nil {
+		old.cancel()
+		close(old.superseded)
+	}
+
+	release = func() {
+		slot.once.Do(func() {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+
+			if r.active[deviceID] == slot {
+				delete(r.active, deviceID)
+			}
+		})
+	}
+	return release, slot.superseded
+}
+
+// count returns the number of devices with a live stream, for tests and for the
+// shutdown log line.
+func (r *eventRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.active)
+}

--- a/internal/httpapi/eventregistry_test.go
+++ b/internal/httpapi/eventregistry_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestEventRegistrySecondConnectionCancelsFirst(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	r := newEventRegistry()
+	firstCtx, firstCancel := context.WithCancel(context.Background())
+	secondCtx, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+
+	// Act
+	_, firstSuperseded := r.register("device-a", firstCancel)
+	_, secondSuperseded := r.register("device-a", secondCancel)
+
+	// Assert
+	select {
+	case <-firstCtx.Done():
+	default:
+		t.Fatal("first stream's context should have been cancelled")
+	}
+	select {
+	case <-firstSuperseded:
+	default:
+		t.Fatal("first slot's superseded channel should be closed")
+	}
+	select {
+	case <-secondCtx.Done():
+		t.Fatal("second stream's context should not have been cancelled")
+	default:
+	}
+	select {
+	case <-secondSuperseded:
+		t.Fatal("second slot's superseded channel should not be closed")
+	default:
+	}
+}
+
+func TestEventRegistryDevicesAreIndependent(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	r := newEventRegistry()
+	aCtx, aCancel := context.WithCancel(context.Background())
+	defer aCancel()
+	_, aSuperseded := r.register("device-a", aCancel)
+
+	// Act
+	_, bCancel := context.WithCancel(context.Background())
+	defer bCancel()
+	r.register("device-b", bCancel)
+
+	// Assert
+	select {
+	case <-aCtx.Done():
+		t.Fatal("registering device-b should not cancel device-a's stream")
+	default:
+	}
+	select {
+	case <-aSuperseded:
+		t.Fatal("registering device-b should not supersede device-a's slot")
+	default:
+	}
+	if got := r.count(); got != 2 {
+		t.Fatalf("count() = %d, want 2", got)
+	}
+}
+
+func TestEventRegistryReleaseAfterSupersededDoesNotEvictNewer(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	r := newEventRegistry()
+	_, firstCancel := context.WithCancel(context.Background())
+	firstRelease, _ := r.register("device-a", firstCancel)
+	_, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+	secondRelease, _ := r.register("device-a", secondCancel)
+	defer secondRelease()
+
+	// Act: the superseded (first) slot releases on its way out.
+	firstRelease()
+
+	// Assert: the newer slot is still live.
+	if got := r.count(); got != 1 {
+		t.Fatalf("count() = %d, want 1", got)
+	}
+}
+
+func TestEventRegistryReleaseDeletesEntry(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	r := newEventRegistry()
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	release, _ := r.register("device-a", cancel)
+
+	// Act
+	release()
+
+	// Assert
+	if got := r.count(); got != 0 {
+		t.Fatalf("count() = %d, want 0", got)
+	}
+}
+
+func TestEventRegistryDoubleReleaseIsSafe(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	r := newEventRegistry()
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	release, _ := r.register("device-a", cancel)
+
+	// Act
+	release()
+	release()
+
+	// Assert
+	if got := r.count(); got != 0 {
+		t.Fatalf("count() = %d, want 0", got)
+	}
+}
+
+func TestEventRegistryConcurrent(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	r := newEventRegistry()
+	const devices = 8
+	const attemptsPerDevice = 20
+
+	var wg sync.WaitGroup
+	var maxObserved int
+	var maxMu sync.Mutex
+
+	// Act
+	for d := 0; d < devices; d++ {
+		deviceID := deviceIDFor(d)
+		for a := 0; a < attemptsPerDevice; a++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, cancel := context.WithCancel(context.Background())
+				release, _ := r.register(deviceID, cancel)
+
+				maxMu.Lock()
+				if got := r.count(); got > maxObserved {
+					maxObserved = got
+				}
+				maxMu.Unlock()
+
+				release()
+			}()
+		}
+	}
+	wg.Wait()
+
+	// Assert
+	if maxObserved > devices {
+		t.Fatalf("count() reached %d, want <= %d distinct device IDs", maxObserved, devices)
+	}
+	if got := r.count(); got != 0 {
+		t.Fatalf("count() = %d after all releases, want 0", got)
+	}
+}
+
+func deviceIDFor(i int) string {
+	return "device-" + string(rune('a'+i))
+}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -4,6 +4,10 @@ package httpapi
 
 import (
 	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
 
 	"github.com/scnplt/devmon-agent/internal/dockerx"
 )
@@ -14,4 +18,157 @@ import (
 type EventReader interface {
 	ContainerStates(ctx context.Context) ([]dockerx.ContainerStateSummary, error)
 	StreamContainerEvents(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error
+}
+
+const (
+	// msgEventStreamLagged is the terminal frame served to a client the hub
+	// dropped for falling behind. Distinct from the Engine failure below so
+	// the client can tell "consume faster" from "the host's Docker died" —
+	// the same argument that keeps 401, 403, 429 and 502 distinct on the
+	// request itself.
+	msgEventStreamLagged = "event stream fell behind"
+
+	// msgEventStreamSuperseded is the terminal frame served to a device's
+	// older event stream when that device opens a newer one. It is the one
+	// terminal error a client must NOT retry: reconnecting would fight the
+	// newer stream.
+	msgEventStreamSuperseded = "event stream superseded"
+)
+
+// handleEventStream opens the container health event stream: one
+// event: snapshot frame with the current state of every container, then one
+// event: health frame per allowlisted Engine transition, until the client
+// disconnects, this device's stream is superseded by a newer one, or the
+// shared Engine subscription fails.
+//
+// Ordering mirrors handleStreamContainerLogs (logs.go:126-247) step for
+// step; the comments here call out only where this handler differs.
+func (s *Server) handleEventStream(w http.ResponseWriter, r *http.Request) {
+	if !s.requireDocker(w) {
+		return
+	}
+
+	// A missing device in the request context is a 500, not a silent
+	// fallback: this handler only ever runs behind requireDevice, and
+	// degrading to an unkeyed stream would silently remove the
+	// one-stream-per-device rule (mirrors withDeviceLimit's reasoning).
+	device, ok := DeviceFrom(r.Context())
+	if !ok {
+		s.log.Error("handleEventStream ran without a resolved device in the request context")
+		s.writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// wg.Wait() is deferred BEFORE cancel(), so defer's LIFO order runs
+	// cancel() first. Reversing these deadlocks the handler for a full
+	// eventHeartbeatInterval on every request (see logs.go's doc comment for
+	// the full argument).
+	ctx, cancel := context.WithCancel(r.Context())
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	defer cancel()
+
+	// Registering before attaching is deliberate: a device reconnecting must
+	// evict its own stale stream first. If attach then fails below, the only
+	// way this device could have had a live stream is if the hub was already
+	// running — in which case attach cannot fail — so no working stream is
+	// ever destroyed by a failure here.
+	release, superseded := s.eventStreams.register(device.ID, cancel)
+	defer release()
+
+	// parent is the server's lifetime context, not the request's: the shared
+	// subscription must outlive whichever client happened to start it.
+	sub, err := s.events.attach(s.lifecycleCtx, ctx)
+	if err != nil {
+		// Nothing has been written to w yet, so this is a real 502/404-style
+		// mapping through writeDockerError, not a terminal frame.
+		s.writeDockerError(w, r, "attach event stream", err)
+		return
+	}
+	defer s.events.detach(sub)
+
+	// D7's ordering pays off here: sub has been buffering since attach
+	// returned, so an event that fires during this call is already sitting
+	// in sub.events by the time the snapshot below is sent.
+	states, err := s.dc.ContainerStates(ctx)
+	if err != nil {
+		s.writeDockerError(w, r, "container states", err)
+		return
+	}
+
+	sse := newSSEWriter(w)
+
+	// The snapshot is the first thing on the wire, before anything buffered
+	// in sub.events is drained.
+	if err := sse.event("", sseEventSnapshot, states); err != nil {
+		return
+	}
+
+	// Started only after the snapshot, mirroring handleStreamContainerLogs's
+	// keepalive goroutine verbatim — see its doc comment for the wg/cancel
+	// ordering argument that also applies here.
+	ticker := time.NewTicker(eventHeartbeatInterval)
+	defer ticker.Stop()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// A failed heartbeat write means the client is gone; the
+				// main loop's next send will discover the same thing on its
+				// own next write.
+				_ = sse.comment("heartbeat")
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-superseded:
+			// A newer stream from the same device evicted this one. This is
+			// the one terminal error the client must not retry, so it gets
+			// its own message distinct from an ordinary Engine failure.
+			s.writeTerminalEventError(ctx, sse, msgEventStreamSuperseded)
+			return
+		case <-ctx.Done():
+			// Client gone, or the server is shutting down. Nothing to send:
+			// there is no reason to attempt for a plain disconnect.
+			return
+		case ev := <-sub.events:
+			if err := sse.event("", sseEventHealth, ev); err != nil {
+				return
+			}
+		case reason := <-sub.closed:
+			msg := msgEngineUnavailable
+			if reason == eventClosedLagged {
+				msg = msgEventStreamLagged
+			}
+			s.writeTerminalEventError(ctx, sse, msg)
+			return
+		}
+	}
+}
+
+// writeTerminalEventError sends the terminal event: error frame carrying
+// msg, mirroring logs.go:227-247 exactly: the frame is skipped entirely when
+// the client is already gone (isClientGone(ctx, ctx.Err())), and a failed
+// send logs at Debug for a gone client, Error otherwise. Headers are always
+// already committed by the time this is called — the snapshot frame sent
+// them — so there is no writeDockerError path left to fall back to.
+func (s *Server) writeTerminalEventError(ctx context.Context, sse *sseWriter, msg string) {
+	if isClientGone(ctx, ctx.Err()) {
+		return
+	}
+
+	if err := sse.event("", sseEventError, errorBody{Error: msg}); err != nil {
+		if isClientGone(ctx, err) {
+			s.log.Debug("stream container events: write terminal error frame", slog.Any("err", err))
+		} else {
+			s.log.Error("stream container events: write terminal error frame", slog.Any("err", err))
+		}
+	}
 }

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -132,7 +132,7 @@ func (s *Server) handleEventStream(w http.ResponseWriter, r *http.Request) {
 			// A newer stream from the same device evicted this one. This is
 			// the one terminal error the client must not retry, so it gets
 			// its own message distinct from an ordinary Engine failure.
-			s.writeTerminalEventError(ctx, sse, msgEventStreamSuperseded)
+			s.writeTerminalEventError(r, sse, msgEventStreamSuperseded)
 			return
 		case <-ctx.Done():
 			// Client gone, or the server is shutting down. Nothing to send:
@@ -147,25 +147,38 @@ func (s *Server) handleEventStream(w http.ResponseWriter, r *http.Request) {
 			if reason == eventClosedLagged {
 				msg = msgEventStreamLagged
 			}
-			s.writeTerminalEventError(ctx, sse, msg)
+			s.writeTerminalEventError(r, sse, msg)
 			return
 		}
 	}
 }
 
 // writeTerminalEventError sends the terminal event: error frame carrying
-// msg, mirroring logs.go:227-247 exactly: the frame is skipped entirely when
-// the client is already gone (isClientGone(ctx, ctx.Err())), and a failed
-// send logs at Debug for a gone client, Error otherwise. Headers are always
-// already committed by the time this is called — the snapshot frame sent
-// them — so there is no writeDockerError path left to fall back to.
-func (s *Server) writeTerminalEventError(ctx context.Context, sse *sseWriter, msg string) {
-	if isClientGone(ctx, ctx.Err()) {
+// msg, mirroring logs.go:227-247 in spirit but NOT in the context it checks
+// for "is the client gone": it gates on r.Context(), not the handler's own
+// derived ctx.
+//
+// That distinction is load-bearing. handleStreamContainerLogs's ctx is
+// cancelled only by a real client disconnect or server shutdown, so
+// isClientGone(ctx, ctx.Err()) there really does mean "the client is gone".
+// handleEventStream's derived ctx is ALSO cancelled by
+// eventRegistry.register when this device opens a newer stream (D11) — the
+// very case msgEventStreamSuperseded exists to report. Gating on that same
+// ctx would make the superseded frame unreachable: by the time this
+// function runs for that case, ctx.Err() is already non-nil because OF the
+// eviction, not because the client left, so isClientGone would report "gone"
+// on every single supersede and silently drop the one terminal frame the
+// feature spec requires. r.Context() carries no such internal signal — it is
+// cancelled only by the underlying connection actually closing or the
+// server shutting down — so it is what genuinely answers "is anyone still
+// listening".
+func (s *Server) writeTerminalEventError(r *http.Request, sse *sseWriter, msg string) {
+	if isClientGone(r.Context(), r.Context().Err()) {
 		return
 	}
 
 	if err := sse.event("", sseEventError, errorBody{Error: msg}); err != nil {
-		if isClientGone(ctx, err) {
+		if isClientGone(r.Context(), err) {
 			s.log.Debug("stream container events: write terminal error frame", slog.Any("err", err))
 		} else {
 			s.log.Error("stream container events: write terminal error frame", slog.Any("err", err))

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+
+	"github.com/scnplt/devmon-agent/internal/dockerx"
+)
+
+// EventReader is the container event surface, named separately from the read
+// interfaces because one of its two methods never returns until the caller
+// stops it — the same reason LogReader is its own interface.
+type EventReader interface {
+	ContainerStates(ctx context.Context) ([]dockerx.ContainerStateSummary, error)
+	StreamContainerEvents(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error
+}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -41,8 +41,8 @@ const (
 // disconnects, this device's stream is superseded by a newer one, or the
 // shared Engine subscription fails.
 //
-// Ordering mirrors handleStreamContainerLogs (logs.go:126-247) step for
-// step; the comments here call out only where this handler differs.
+// Ordering mirrors handleStreamContainerLogs (logs.go) step for step; the
+// comments here call out only where this handler differs.
 func (s *Server) handleEventStream(w http.ResponseWriter, r *http.Request) {
 	if !s.requireDocker(w) {
 		return
@@ -154,9 +154,9 @@ func (s *Server) handleEventStream(w http.ResponseWriter, r *http.Request) {
 }
 
 // writeTerminalEventError sends the terminal event: error frame carrying
-// msg, mirroring logs.go:227-247 in spirit but NOT in the context it checks
-// for "is the client gone": it gates on r.Context(), not the handler's own
-// derived ctx.
+// msg, mirroring handleStreamContainerLogs's terminal-frame path in spirit
+// but NOT in the context it checks for "is the client gone": it gates on
+// r.Context(), not the handler's own derived ctx.
 //
 // That distinction is load-bearing. handleStreamContainerLogs's ctx is
 // cancelled only by a real client disconnect or server shutdown, so

--- a/internal/httpapi/events_test.go
+++ b/internal/httpapi/events_test.go
@@ -1,0 +1,1070 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+	"github.com/scnplt/devmon-agent/internal/dockerx"
+	"github.com/scnplt/devmon-agent/internal/policy"
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// writeCountingRecorder wraps deadlineAwareRecorder (server_test.go) and
+// atomically counts calls to Write, so a test running the event-stream
+// handler in its own goroutine can safely learn "N frames have reached the
+// wire" — via waitForCondition polling the counter — without ever reading
+// rec.Body from a second goroutine while the handler is still writing to it.
+// That is the mandatory GOTCHA for this task: never read an
+// httptest.ResponseRecorder while its handler goroutine is still running.
+type writeCountingRecorder struct {
+	*deadlineAwareRecorder
+	writes atomic.Int64
+}
+
+func newWriteCountingRecorder() *writeCountingRecorder {
+	return &writeCountingRecorder{deadlineAwareRecorder: &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}}
+}
+
+func (w *writeCountingRecorder) Write(p []byte) (int, error) {
+	n, err := w.deadlineAwareRecorder.Write(p)
+	w.writes.Add(1)
+	return n, err
+}
+
+// startEventStream runs the event route for req, whose context it makes
+// cancellable, in its own goroutine, and blocks only until minWrites frames
+// have reached the wire — observed through rec's atomic counter, never by
+// reading rec.Body, which would race the handler goroutine still running.
+// The caller cancels the returned context (via the returned cancel) and
+// drains done before reading rec.
+func startEventStream(t *testing.T, s *Server, req *http.Request, rec *writeCountingRecorder, minWrites int64) (cancel context.CancelFunc, done <-chan struct{}) {
+	t.Helper()
+
+	ctx, cancelFn := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		s.routes().ServeHTTP(rec, req)
+	}()
+	waitForCondition(t, 2*time.Second, 2*time.Millisecond,
+		func() bool { return rec.writes.Load() >= minWrites },
+		func() string { return fmt.Sprintf("writes = %d, want >= %d", rec.writes.Load(), minWrites) })
+	return cancelFn, doneCh
+}
+
+// sseFrame is one parsed id:/event:/data: frame.
+type sseFrame struct {
+	id    string
+	event string
+	data  string
+}
+
+// parseSSEFrames splits body on the blank-line frame terminator sseWriter's
+// event and comment methods both use, and parses each id:/event:/data:
+// frame, skipping bare comment lines (heartbeats), which carry no event: or
+// data: line at all.
+func parseSSEFrames(body string) []sseFrame {
+	var frames []sseFrame
+	for _, chunk := range strings.Split(strings.TrimRight(body, "\n"), "\n\n") {
+		if chunk == "" || strings.HasPrefix(chunk, ": ") {
+			continue
+		}
+		var f sseFrame
+		for _, line := range strings.Split(chunk, "\n") {
+			switch {
+			case strings.HasPrefix(line, "id: "):
+				f.id = strings.TrimPrefix(line, "id: ")
+			case strings.HasPrefix(line, "event: "):
+				f.event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				f.data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		frames = append(frames, f)
+	}
+	return frames
+}
+
+// TestEventStreamSnapshotIsFirstFrame is the feature spec's core ordering
+// requirement: the body's first frame is event: snapshot, its data is a JSON
+// array, and it appears before any event: health frame.
+func TestEventStreamSnapshotIsFirstFrame(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		containerStatesFn: func(context.Context) ([]dockerx.ContainerStateSummary, error) {
+			return []dockerx.ContainerStateSummary{{ID: "c1", Name: "api", State: "running", Health: "healthy"}}, nil
+		},
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			if err := emit(dockerx.ContainerEvent{ID: "c1", Name: "api", Event: "die", Time: "2026-01-01T00:00:00Z"}); err != nil {
+				return err
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 2)
+	cancel()
+	<-done
+
+	// Assert
+	frames := parseSSEFrames(rec.Body.String())
+	if len(frames) < 2 {
+		t.Fatalf("got %d frames, want at least 2 (snapshot, then health); body: %q", len(frames), rec.Body.String())
+	}
+	if frames[0].event != sseEventSnapshot {
+		t.Fatalf("first frame event = %q, want %q", frames[0].event, sseEventSnapshot)
+	}
+	if !strings.HasPrefix(frames[0].data, "[") {
+		t.Errorf("snapshot data = %q, want a JSON array", frames[0].data)
+	}
+	var sawHealth bool
+	for _, f := range frames[1:] {
+		if f.event == sseEventHealth {
+			sawHealth = true
+		}
+	}
+	if !sawHealth {
+		t.Errorf("no event: health frame followed the snapshot; frames: %+v", frames)
+	}
+}
+
+// TestEventStreamSnapshotShape asserts each snapshot element has exactly
+// id, name, state, health, and that a "none" health value round-trips.
+func TestEventStreamSnapshotShape(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		containerStatesFn: func(context.Context) ([]dockerx.ContainerStateSummary, error) {
+			return []dockerx.ContainerStateSummary{
+				{ID: "c1", Name: "api", State: "running", Health: "healthy"},
+				{ID: "c2", Name: "cron", State: "exited", Health: "none"},
+			}, nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 1)
+	cancel()
+	<-done
+
+	// Assert
+	frames := parseSSEFrames(rec.Body.String())
+	if len(frames) == 0 || frames[0].event != sseEventSnapshot {
+		t.Fatalf("frames = %+v, want the first to be event: snapshot", frames)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(frames[0].data), &items); err != nil {
+		t.Fatalf("decode snapshot data: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("snapshot has %d items, want 2", len(items))
+	}
+	for _, item := range items {
+		if len(item) != 4 {
+			t.Errorf("item %+v has %d keys, want exactly 4 (id, name, state, health)", item, len(item))
+		}
+		for _, key := range []string{"id", "name", "state", "health"} {
+			if _, ok := item[key]; !ok {
+				t.Errorf("item %+v is missing key %q", item, key)
+			}
+		}
+	}
+	if items[1]["health"] != "none" {
+		t.Errorf("second item health = %v, want %q", items[1]["health"], "none")
+	}
+}
+
+// TestEventStreamForwardsHealthStatus is the feature spec's requirement: a
+// fake emitting healthy then unhealthy produces two event: health frames
+// carrying the right health value and the "health_status" event literal.
+func TestEventStreamForwardsHealthStatus(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			if err := emit(dockerx.ContainerEvent{ID: "c1", Name: "db", Event: "health_status", Health: "healthy", Time: "2026-01-01T00:00:00Z"}); err != nil {
+				return err
+			}
+			if err := emit(dockerx.ContainerEvent{ID: "c1", Name: "db", Event: "health_status", Health: "unhealthy", Time: "2026-01-01T00:00:01Z"}); err != nil {
+				return err
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 3)
+	cancel()
+	<-done
+
+	// Assert
+	var healthValues []string
+	for _, f := range parseSSEFrames(rec.Body.String()) {
+		if f.event != sseEventHealth {
+			continue
+		}
+		var ev dockerx.ContainerEvent
+		if err := json.Unmarshal([]byte(f.data), &ev); err != nil {
+			t.Fatalf("decode health frame: %v", err)
+		}
+		if ev.Event != "health_status" {
+			t.Errorf("event field = %q, want health_status", ev.Event)
+		}
+		healthValues = append(healthValues, ev.Health)
+	}
+	want := []string{"healthy", "unhealthy"}
+	if len(healthValues) != len(want) {
+		t.Fatalf("got %d health frames (%v), want %d", len(healthValues), healthValues, len(want))
+	}
+	for i := range want {
+		if healthValues[i] != want[i] {
+			t.Errorf("frame %d health = %q, want %q", i, healthValues[i], want[i])
+		}
+	}
+}
+
+// TestEventStreamForwardsLifecycleEvents asserts die/start/stop/oom each
+// arrive as event: health frames whose data carries no "health" key.
+func TestEventStreamForwardsLifecycleEvents(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	lifecycle := []string{"die", "start", "stop", "oom"}
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			for i, action := range lifecycle {
+				ev := dockerx.ContainerEvent{ID: "c1", Name: "api", Event: action, Time: fmt.Sprintf("2026-01-01T00:00:0%dZ", i)}
+				if err := emit(ev); err != nil {
+					return err
+				}
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, int64(1+len(lifecycle)))
+	cancel()
+	<-done
+
+	// Assert
+	var got []string
+	for _, f := range parseSSEFrames(rec.Body.String()) {
+		if f.event != sseEventHealth {
+			continue
+		}
+		if strings.Contains(f.data, `"health"`) {
+			t.Errorf("lifecycle frame carries a health key: %s", f.data)
+		}
+		var ev dockerx.ContainerEvent
+		if err := json.Unmarshal([]byte(f.data), &ev); err != nil {
+			t.Fatalf("decode frame: %v", err)
+		}
+		got = append(got, ev.Event)
+	}
+	if len(got) != len(lifecycle) {
+		t.Fatalf("got %d lifecycle frames (%v), want %d", len(got), got, len(lifecycle))
+	}
+	for i := range lifecycle {
+		if got[i] != lifecycle[i] {
+			t.Errorf("frame %d event = %q, want %q", i, got[i], lifecycle[i])
+		}
+	}
+}
+
+// TestEventStreamEventsAfterSnapshotAreNotLost is D7's proof: the fake blocks
+// ContainerStates until an event has already been emitted (queued into
+// sub.events), so the event fired strictly between the subscription going
+// live and the snapshot call returning. It must still reach the client.
+func TestEventStreamEventsAfterSnapshotAreNotLost(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	emitted := make(chan struct{})
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			if err := emit(dockerx.ContainerEvent{ID: "c1", Name: "api", Event: "die", Time: "2026-01-01T00:00:00Z"}); err != nil {
+				return err
+			}
+			close(emitted)
+			<-ctx.Done()
+			return nil
+		},
+		containerStatesFn: func(ctx context.Context) ([]dockerx.ContainerStateSummary, error) {
+			<-emitted // the event is already queued by the time this returns
+			return []dockerx.ContainerStateSummary{}, nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 2)
+	cancel()
+	<-done
+
+	// Assert
+	frames := parseSSEFrames(rec.Body.String())
+	if len(frames) < 2 || frames[0].event != sseEventSnapshot {
+		t.Fatalf("frames = %+v, want a snapshot followed by the health frame that fired before it", frames)
+	}
+	if frames[1].event != sseEventHealth {
+		t.Fatalf("second frame event = %q, want %q", frames[1].event, sseEventHealth)
+	}
+}
+
+// TestEventStreamPerDeviceSingleStream is D11's spec requirement: a second
+// connection from the same device evicts the first, which ends with a
+// terminal event: error / "event stream superseded" frame, while the second
+// stays live. Per the mandatory GOTCHA, the first recorder is never read
+// while its handler goroutine is still running: the second request is only
+// fired once the first's snapshot write is observed via its write counter,
+// and the first recorder is only read after its own goroutine has returned.
+func TestEventStreamPerDeviceSingleStream(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+
+	req1 := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec1 := newWriteCountingRecorder()
+	done1 := make(chan struct{})
+	go func() {
+		defer close(done1)
+		s.routes().ServeHTTP(rec1, req1)
+	}()
+	waitForCondition(t, 2*time.Second, 2*time.Millisecond,
+		func() bool { return rec1.writes.Load() >= 1 },
+		func() string { return "first stream never sent its snapshot" })
+
+	// Act — a second connection from the same device.
+	req2 := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec2 := newWriteCountingRecorder()
+	ctx2, cancel2 := context.WithCancel(req2.Context())
+	req2 = req2.WithContext(ctx2)
+	done2 := make(chan struct{})
+	go func() {
+		defer close(done2)
+		s.routes().ServeHTTP(rec2, req2)
+	}()
+	waitForCondition(t, 2*time.Second, 2*time.Millisecond,
+		func() bool { return rec2.writes.Load() >= 1 },
+		func() string { return "second stream never sent its snapshot" })
+
+	// Assert — the first stream ends on its own, evicted by the second.
+	select {
+	case <-done1:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first stream did not end after being superseded")
+	}
+	if rec1.Code != http.StatusOK {
+		t.Errorf("first stream status = %d, want 200 (it committed before being superseded)", rec1.Code)
+	}
+	body1 := rec1.Body.String()
+	if !strings.Contains(body1, "event: error") || !strings.Contains(body1, msgEventStreamSuperseded) {
+		t.Errorf("first stream body = %q, want a terminal event: error frame carrying %q", body1, msgEventStreamSuperseded)
+	}
+
+	// Cleanup — the second stream stays live until cancelled here.
+	cancel2()
+	<-done2
+}
+
+// TestEventStreamDevicesAreIndependent proves a second connection from a
+// DIFFERENT device does not touch the first device's stream: device A ends
+// on a plain disconnect, carrying no terminal error frame.
+func TestEventStreamDevicesAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serialA := pairDeviceForRead(t, st)
+	serialB := pairDeviceForRead(t, st)
+
+	reqA := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serialA)
+	recA := newWriteCountingRecorder()
+	cancelA, doneA := startEventStream(t, s, reqA, recA, 1)
+
+	// Act
+	reqB := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serialB)
+	recB := newWriteCountingRecorder()
+	cancelB, doneB := startEventStream(t, s, reqB, recB, 1)
+
+	cancelA()
+	<-doneA
+	cancelB()
+	<-doneB
+
+	// Assert
+	if strings.Contains(recA.Body.String(), "event: error") {
+		t.Errorf("device A body = %q, want no terminal error frame: device B must never touch A's stream", recA.Body.String())
+	}
+}
+
+// TestEventStreamDoesNotConsumeLogStreamBudget is D11's spec requirement:
+// with s.streams driven to the host ceiling by log streams, the event route
+// still answers 200 — it never touches streamBudget.
+func TestEventStreamDoesNotConsumeLogStreamBudget(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — fill every log-stream slot across maxConcurrentStreams
+	// distinct devices, mirroring TestStreamSlotExhaustion.
+	started := make(chan struct{}, maxConcurrentStreams)
+	release := make(chan struct{})
+	fd := &fakeDocker{
+		streamContainerLogsFn: func(ctx context.Context, _ string, _ dockerx.LogOptions, _ func(dockerx.LogLine) error) error {
+			started <- struct{}{}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serials := make([]*big.Int, maxConcurrentStreams)
+	for i := range serials {
+		serials[i] = pairDeviceForRead(t, st)
+	}
+
+	done := make(chan struct{}, maxConcurrentStreams)
+	for _, serial := range serials {
+		serial := serial
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			req := requestWithPeerSerial(http.MethodGet, "/v1/containers/c1/logs/stream", nil, serial).WithContext(ctx)
+			rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+			s.routes().ServeHTTP(rec, req)
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < maxConcurrentStreams; i++ {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of %d log streams reported started", i, maxConcurrentStreams)
+		}
+	}
+
+	// Act — the event route, from a device already holding a log stream,
+	// must still succeed.
+	eventReq := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serials[0])
+	rec := newWriteCountingRecorder()
+	cancel, streamDone := startEventStream(t, s, eventReq, rec, 1)
+	cancel()
+	<-streamDone
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("event stream status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Cleanup — release the held log streams.
+	close(release)
+	for i := 0; i < maxConcurrentStreams; i++ {
+		<-done
+	}
+}
+
+// TestEventStreamRequiresDevice asserts no req.TLS answers 401 with the
+// standard terse body.
+func TestEventStreamRequiresDevice(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, _ := testServerWithDocker(t, policy.ModeDefault, &fakeDocker{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/events/stream", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error != msgClientCertRequired {
+		t.Errorf("error = %q, want %q", body.Error, msgClientCertRequired)
+	}
+}
+
+// TestEventStreamRevokedDeviceIs401 mirrors middleware_test.go's revoked
+// device case on the event route.
+func TestEventStreamRevokedDeviceIs401(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st := testServerWithDocker(t, policy.ModeDefault, &fakeDocker{})
+	serial := pairDeviceForRead(t, st)
+	ctx := context.Background()
+	device, err := st.DeviceByCertSerial(ctx, serial.Text(16))
+	if err != nil {
+		t.Fatalf("DeviceByCertSerial: %v", err)
+	}
+	if err := st.RevokeDevice(ctx, device.ID); err != nil {
+		t.Fatalf("RevokeDevice: %v", err)
+	}
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error != msgClientCertRequired {
+		t.Errorf("error = %q, want %q", body.Error, msgClientCertRequired)
+	}
+}
+
+// TestEventStreamPolicyForbidden asserts requireOp's fail-closed branch.
+// policy.Mode(-1) is SYNTHETIC: no shipped mode denies OpRead (every mode
+// permits it, D3), so this out-of-range value is the only way to exercise
+// this branch on this route — Allows returns false for any Mode below
+// minMode[OpRead] (ModeReadOnly), which -1 satisfies by construction.
+func TestEventStreamPolicyForbidden(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.Mode(-1), fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error != msgPolicyForbidden {
+		t.Errorf("error = %q, want %q", body.Error, msgPolicyForbidden)
+	}
+}
+
+// TestEventStreamReadOnlyModeIs200 is D3's real-world counterpart: the
+// stream is served under the most restrictive shipped policy mode.
+func TestEventStreamReadOnlyModeIs200(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.ModeReadOnly, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 1)
+	cancel()
+	<-done
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Errorf("status under read-only policy = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestEventStreamRateLimited mirrors ratelimit_test.go's guarded-tier
+// pattern: a burst of 2 (guardedPerSec 1 x guardedBurstMultiplier), each
+// request resolving without ever entering the streaming loop by having
+// ContainerStates fail fast, so the third request's 429 is unambiguously the
+// limiter's doing.
+func TestEventStreamRateLimited(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	cfg := config.Config{StateDir: dir, ListenAddr: ":8443", PolicyMode: policy.ModeDefault, RateGuardedPerSec: 1}
+	st, err := state.Open(context.Background(), filepath.Join(dir, "devmon.db"), testLogger())
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	fd := &fakeDocker{
+		containerStatesFn: func(context.Context) ([]dockerx.ContainerStateSummary, error) {
+			return nil, errors.New("engine unreachable")
+		},
+	}
+	s := NewServer(cfg, st, nil, fd, nil, testLogger())
+	serial := pairDeviceForRead(t, st)
+
+	// Act — drain the burst of 2.
+	for i := 0; i < 2; i++ {
+		req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+		rec := httptest.NewRecorder()
+		s.routes().ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("request %d status = %d, want 502 (past the limiter, failing at the Engine call); body: %s", i, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Act — a third request, past the burst.
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := httptest.NewRecorder()
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	assertRateLimitedResponse(t, rec)
+}
+
+// TestEventStreamEngineUnavailable asserts attach failing (before onReady)
+// answers a real 502, not a stream that turns out to carry nothing (D4).
+func TestEventStreamEngineUnavailable(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(context.Context, func(), func(dockerx.ContainerEvent) error) error {
+			return errors.New("engine unreachable")
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error != msgEngineUnavailable {
+		t.Errorf("error = %q, want %q", body.Error, msgEngineUnavailable)
+	}
+}
+
+// TestEventStreamSnapshotFailureIsJSON asserts a ContainerStates failure —
+// after a successful attach — is still a 502 JSON body, headers never
+// committed to SSE.
+func TestEventStreamSnapshotFailureIsJSON(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		containerStatesFn: func(context.Context) ([]dockerx.ContainerStateSummary, error) {
+			return nil, errors.New("engine unreachable")
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (headers never committed to SSE)", ct)
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error != msgEngineUnavailable {
+		t.Errorf("error = %q, want %q", body.Error, msgEngineUnavailable)
+	}
+}
+
+// TestEventStreamNilDockerReader asserts a nil s.dc answers 502 without
+// panicking.
+func TestEventStreamNilDockerReader(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, st := testServerWithDocker(t, policy.ModeDefault, nil)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error != msgEngineUnavailable {
+		t.Errorf("error = %q, want %q", body.Error, msgEngineUnavailable)
+	}
+}
+
+// TestEventStreamFeedDeathSendsTerminalError asserts a hub feed ending
+// after the snapshot has committed produces the "docker engine unavailable"
+// terminal frame, and the handler then returns on its own.
+func TestEventStreamFeedDeathSendsTerminalError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(_ context.Context, onReady func(), _ func(dockerx.ContainerEvent) error) error {
+			onReady()
+			return dockerx.ErrEventFeedClosed
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the snapshot already committed); body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if got := strings.Count(body, "event: error\n"); got != 1 {
+		t.Errorf("body has %d event: error frames, want 1; body: %q", got, body)
+	}
+	wantSuffix := fmt.Sprintf("event: error\ndata: {\"error\":%q}\n\n", msgEngineUnavailable)
+	if !strings.HasSuffix(body, wantSuffix) {
+		t.Errorf("body = %q, want it to end with %q", body, wantSuffix)
+	}
+}
+
+// TestEventStreamLaggedClientTerminalError shrinks eventClientBuffer to 1
+// and drives two emits before ContainerStates is allowed to return, so the
+// overflow (and the resulting drop) is guaranteed to happen before the
+// handler even starts its select loop — the same synchronization technique
+// TestEventStreamEventsAfterSnapshotAreNotLost uses, rather than a timing
+// sleep.
+func TestEventStreamLaggedClientTerminalError(t *testing.T) {
+	// Not t.Parallel(): mutates the package-level eventClientBuffer.
+	original := eventClientBuffer
+	eventClientBuffer = 1
+	t.Cleanup(func() { eventClientBuffer = original })
+
+	// Arrange
+	pushed := make(chan struct{})
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			_ = emit(dockerx.ContainerEvent{ID: "c1", Event: "die", Time: "2026-01-01T00:00:00Z"})
+			_ = emit(dockerx.ContainerEvent{ID: "c2", Event: "start", Time: "2026-01-01T00:00:01Z"})
+			close(pushed)
+			<-ctx.Done()
+			return nil
+		},
+		containerStatesFn: func(ctx context.Context) ([]dockerx.ContainerStateSummary, error) {
+			<-pushed
+			return []dockerx.ContainerStateSummary{}, nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if got := strings.Count(body, "event: error\n"); got != 1 {
+		t.Errorf("body has %d event: error frames, want 1; body: %q", got, body)
+	}
+	wantSuffix := fmt.Sprintf("event: error\ndata: {\"error\":%q}\n\n", msgEventStreamLagged)
+	if !strings.HasSuffix(body, wantSuffix) {
+		t.Errorf("body = %q, want it to end with %q", body, wantSuffix)
+	}
+}
+
+// TestEventStreamHeartbeat shortens eventHeartbeatInterval so a heartbeat
+// comment appears well within the test's deadline.
+func TestEventStreamHeartbeat(t *testing.T) {
+	// Not t.Parallel(): mutates the package-level eventHeartbeatInterval.
+	original := eventHeartbeatInterval
+	eventHeartbeatInterval = 2 * time.Millisecond
+	t.Cleanup(func() { eventHeartbeatInterval = original })
+
+	// Arrange
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act — snapshot, then at least one heartbeat.
+	cancel, done := startEventStream(t, s, req, rec, 2)
+	cancel()
+	<-done
+
+	// Assert
+	if !strings.Contains(rec.Body.String(), ": heartbeat\n\n") {
+		t.Errorf("body = %q, want at least one heartbeat comment", rec.Body.String())
+	}
+}
+
+// TestEventStreamHeartbeatIsRaceFree runs a fake that emits events while the
+// shortened heartbeat ticker fires concurrently, under -race.
+func TestEventStreamHeartbeatIsRaceFree(t *testing.T) {
+	// Not t.Parallel(): mutates the package-level eventHeartbeatInterval.
+	original := eventHeartbeatInterval
+	eventHeartbeatInterval = 2 * time.Millisecond
+	t.Cleanup(func() { eventHeartbeatInterval = original })
+
+	// Arrange
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			for i := 0; i < 10; i++ {
+				if err := emit(dockerx.ContainerEvent{ID: "c1", Event: "die", Time: "2026-01-01T00:00:00Z"}); err != nil {
+					return err
+				}
+				// Bounded, short sleep to give the 2ms heartbeat ticker room
+				// to race with this write on the shared sseWriter, mirroring
+				// TestStreamKeepaliveIsRaceFree (logs_test.go). The real
+				// assertion is `-race`, not any state this sleep could
+				// instead wait on.
+				time.Sleep(time.Millisecond)
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act — the real assertion here is `go test -race`.
+	cancel, done := startEventStream(t, s, req, rec, 5)
+	cancel()
+	<-done
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// eventStreamHeartbeatGoroutineFrame is the stack-trace frame of the
+// anonymous heartbeat goroutine handleEventStream starts. A renamed or moved
+// goroutine must fail TestEventStreamGoroutineDoesNotLeak loudly instead of
+// passing vacuously — see countGoroutinesMatching (logs_test.go).
+const eventStreamHeartbeatGoroutineFrame = "internal/httpapi.(*Server).handleEventStream.func1"
+
+// TestEventStreamGoroutineDoesNotLeak opens and closes 20 streams and
+// asserts the heartbeat goroutine count returns to zero.
+func TestEventStreamGoroutineDoesNotLeak(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	inFlightCount := 0
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+
+	// Act
+	for i := 0; i < 20; i++ {
+		req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+		rec := newWriteCountingRecorder()
+		cancel, done := startEventStream(t, s, req, rec, 1)
+		if got := countGoroutinesMatching(eventStreamHeartbeatGoroutineFrame); got > inFlightCount {
+			inFlightCount = got
+		}
+		cancel()
+		<-done
+	}
+	if inFlightCount == 0 {
+		t.Fatalf("eventStreamHeartbeatGoroutineFrame %q never matched a running goroutine; "+
+			"the frame name likely drifted from handleEventStream.func1", eventStreamHeartbeatGoroutineFrame)
+	}
+
+	// Assert
+	waitForCondition(t, 2*time.Second, 5*time.Millisecond,
+		func() bool { return countGoroutinesMatching(eventStreamHeartbeatGoroutineFrame) == 0 },
+		func() string {
+			return fmt.Sprintf("heartbeat goroutine count = %d, want 0", countGoroutinesMatching(eventStreamHeartbeatGoroutineFrame))
+		})
+}
+
+// TestEventStreamAgentLogNeverCarriesAttributes mirrors
+// TestAgentLogNeverCarriesLineContent: an event carrying a value that would
+// have come from the container's own labels (D14) must never reach the
+// agent's own log.
+func TestEventStreamAgentLogNeverCarriesAttributes(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	const secretName = "hunter2"
+	fd := &fakeDocker{
+		streamContainerEventsFn: func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+			onReady()
+			ev := dockerx.ContainerEvent{ID: "c1", Name: secretName, Event: "die", Time: "2026-01-01T00:00:00Z"}
+			if err := emit(ev); err != nil {
+				return err
+			}
+			<-ctx.Done()
+			return nil
+		},
+	}
+	log, buf := newCapturingLogger()
+	s, st := testServerWithDockerAndLogger(t, policy.ModeDefault, fd, log)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 2)
+	cancel()
+	<-done
+
+	// Assert
+	if bodyContains(buf.String(), secretName) {
+		t.Errorf("agent log contains a value derived from the event's attributes: %s", buf.String())
+	}
+}
+
+// TestEventStreamErrorBodiesLeakNothing asserts every failure path on this
+// route keeps the host's state directory, the Docker socket, and the state
+// database filename out of the response body.
+func TestEventStreamErrorBodiesLeakNothing(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	var bodies []string
+
+	// Act — collect every failure body: 401 (no cert), 405 (wrong method),
+	// and the mapped 502 failures for attach and the snapshot call.
+	unauth := httptest.NewRequest(http.MethodGet, "/v1/events/stream", nil)
+	unauthRec := httptest.NewRecorder()
+	s.routes().ServeHTTP(unauthRec, unauth)
+	bodies = append(bodies, unauthRec.Body.String())
+
+	wrongMethod := httptest.NewRequest(http.MethodPost, "/v1/events/stream", nil)
+	wrongMethodRec := httptest.NewRecorder()
+	s.routes().ServeHTTP(wrongMethodRec, wrongMethod)
+	bodies = append(bodies, wrongMethodRec.Body.String())
+
+	fd.streamContainerEventsFn = func(context.Context, func(), func(dockerx.ContainerEvent) error) error {
+		return errors.New("dial unix " + `/var/run/docker.sock` + ": connect: no such file or directory")
+	}
+	attachFail := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	attachFailRec := httptest.NewRecorder()
+	s.routes().ServeHTTP(attachFailRec, attachFail)
+	bodies = append(bodies, attachFailRec.Body.String())
+
+	fd.streamContainerEventsFn = nil
+	fd.containerStatesFn = func(context.Context) ([]dockerx.ContainerStateSummary, error) {
+		return nil, errors.New("dial unix " + `/var/run/docker.sock` + ": connect: no such file or directory")
+	}
+	snapshotFail := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	snapshotFailRec := httptest.NewRecorder()
+	s.routes().ServeHTTP(snapshotFailRec, snapshotFail)
+	bodies = append(bodies, snapshotFailRec.Body.String())
+
+	// Assert
+	for _, leak := range []string{s.cfg.StateDir, "docker.sock", "devmon.db"} {
+		for _, body := range bodies {
+			if leak != "" && bodyContains(body, leak) {
+				t.Errorf("a failure body leaks %q: %s", leak, body)
+			}
+		}
+	}
+}
+
+// TestEventRouteRejectsOtherMethods asserts POST on the event route answers
+// 405.
+func TestEventRouteRejectsOtherMethods(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s, _ := testServerWithDocker(t, policy.ModeDefault, &fakeDocker{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/events/stream", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.routes().ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /v1/events/stream = %d, want 405", rec.Code)
+	}
+}

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -55,6 +55,9 @@ type DockerReader interface {
 	VolumeReader
 	LogReader
 	ContainerController
+	// EventReader joins the surface the same way (D21): the consumer owns
+	// the contract, and NewServer's signature stays untouched.
+	EventReader
 }
 
 // Compile-time proof the concrete client still satisfies the contract. A

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -50,6 +50,16 @@ type fakeDocker struct {
 	stopContainerFn    func(ctx context.Context, ref string) error
 	killContainerFn    func(ctx context.Context, ref string) error
 	removeContainerFn  func(ctx context.Context, ref string) error
+
+	// containerStatesFn and streamContainerEventsFn back EventReader (D21).
+	// Nil-safe like every field above: a nil containerStatesFn answers with
+	// an empty, non-nil slice; a nil streamContainerEventsFn calls onReady
+	// (mirroring "the subscription is live") and then blocks until ctx is
+	// cancelled, so the many existing tests that never touch the event
+	// stream keep working unmodified — the hub never calls this at all
+	// unless a test actually attaches to it.
+	containerStatesFn       func(ctx context.Context) ([]dockerx.ContainerStateSummary, error)
+	streamContainerEventsFn func(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error
 }
 
 var _ DockerReader = (*fakeDocker)(nil)
@@ -157,6 +167,24 @@ func (fd *fakeDocker) RemoveContainer(ctx context.Context, ref string) error {
 		return nil
 	}
 	return fd.removeContainerFn(ctx, ref)
+}
+
+func (fd *fakeDocker) ContainerStates(ctx context.Context) ([]dockerx.ContainerStateSummary, error) {
+	if fd.containerStatesFn == nil {
+		return []dockerx.ContainerStateSummary{}, nil
+	}
+	return fd.containerStatesFn(ctx)
+}
+
+func (fd *fakeDocker) StreamContainerEvents(ctx context.Context, onReady func(), emit func(dockerx.ContainerEvent) error) error {
+	if fd.streamContainerEventsFn == nil {
+		if onReady != nil {
+			onReady()
+		}
+		<-ctx.Done()
+		return nil
+	}
+	return fd.streamContainerEventsFn(ctx, onReady, emit)
 }
 
 // testServerWithDocker is a fifth Server helper, additive to testServer,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -59,6 +59,13 @@ const (
 	// their own cap sum past eight, so the host-wide limit stays meaningful
 	// and testable rather than becoming unreachable dead code.
 	maxStreamsPerDevice = 3
+
+	// maxEventStreamsPerDevice is documentation, not an enforced ceiling: it
+	// records that eventRegistry admits exactly one live event stream per
+	// device by construction (D11) — a second register() call for the same
+	// device evicts the first rather than being refused, so there is no
+	// counter here to compare this constant against.
+	maxEventStreamsPerDevice = 1
 )
 
 // Server owns the HTTPS listener and its routes.
@@ -75,6 +82,14 @@ type Server struct {
 	// use, and this way construction failure is impossible by
 	// construction — NewServer always builds one.
 	streams *streamBudget
+
+	// events owns the agent's single shared Docker events subscription and
+	// fans it out to every attached client (D5/D6); eventStreams enforces
+	// one live event stream per paired device, newest wins (D11). Built
+	// here, never lazily, for the same "construction failure is impossible
+	// by construction" reason streams is.
+	events       *eventHub
+	eventStreams *eventRegistry
 
 	// unauthGlobal is the shared, unkeyed backstop bucket every
 	// pre-authentication request checks first (D8).
@@ -133,6 +148,8 @@ type Server struct {
 func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger) *Server {
 	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log, streams: newStreamBudget(maxConcurrentStreams, maxStreamsPerDevice)}
 	s.lifecycleCtx, s.cancelLifecycle = context.WithCancel(context.Background())
+	s.events = newEventHub(dc, log)
+	s.eventStreams = newEventRegistry()
 
 	s.unauthGlobal = rate.NewLimiter(rate.Limit(unauthGlobalPerSec), unauthGlobalBurst)
 
@@ -252,6 +269,13 @@ func (s *Server) routes() http.Handler {
 	logs("GET /v1/containers/{id}/logs", s.handleContainerLogs)
 	logs("GET /v1/containers/{id}/logs/stream", s.handleStreamContainerLogs)
 
+	// The container event stream. Registered through `read`, not a bespoke
+	// chain: it discloses a strict subset of GET /v1/containers, so
+	// policy.OpRead is its honest tier (D3), and reusing the same closure is
+	// what guarantees the three guards match rather than merely resemble the
+	// read routes'.
+	read("GET /v1/events/stream", s.handleEventStream)
+
 	// Mutating operations. Four guards, and the order is load-bearing (D7,
 	// D15): requireDevice proves who is calling, withDeviceLimit bounds how
 	// often before anything is recorded, withAudit records the attempt
@@ -308,6 +332,12 @@ func (s *Server) shutdown() error {
 	// this is what makes a live SSE log stream (issue #41) return promptly
 	// instead of pinning Shutdown below for the full shutdownGrace window.
 	s.cancelLifecycle()
+
+	// The hub's goroutine already unwinds on the cancelled lifecycle context
+	// above; stop() is what makes that deterministic rather than eventual,
+	// so a goroutine-leak test can assert it right after shutdown returns
+	// instead of racing the hub's own teardown.
+	s.events.stop()
 
 	// A fresh context: ctx is already cancelled, and Shutdown needs a live
 	// deadline to drain against.

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -59,14 +59,12 @@ const (
 	// their own cap sum past eight, so the host-wide limit stays meaningful
 	// and testable rather than becoming unreachable dead code.
 	maxStreamsPerDevice = 3
-
-	// maxEventStreamsPerDevice is documentation, not an enforced ceiling: it
-	// records that eventRegistry admits exactly one live event stream per
-	// device by construction (D11) — a second register() call for the same
-	// device evicts the first rather than being refused, so there is no
-	// counter here to compare this constant against.
-	maxEventStreamsPerDevice = 1
 )
+
+// There is deliberately no maxEventStreamsPerDevice constant: eventRegistry
+// admits exactly one live event stream per device by construction — a second
+// register() call for the same device evicts the first rather than being
+// refused, so there is no counter to compare a constant against.
 
 // Server owns the HTTPS listener and its routes.
 type Server struct {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -233,6 +234,75 @@ func TestLogRoutePrecedence(t *testing.T) {
 			tc.verify(t, rec.Body.Bytes())
 		})
 	}
+}
+
+// TestEventRoutePrecedence proves GET /v1/events/stream reaches its own
+// handler rather than being shadowed by, or shadowing, any of the
+// /v1/containers/... patterns registered alongside it.
+func TestEventRoutePrecedence(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fd := &fakeDocker{
+		containerStatesFn: func(context.Context) ([]dockerx.ContainerStateSummary, error) {
+			return []dockerx.ContainerStateSummary{{ID: "from-events", Name: "api", State: "running", Health: "healthy"}}, nil
+		},
+	}
+	s, st := testServerWithDocker(t, policy.ModeDefault, fd)
+	serial := pairDeviceForRead(t, st)
+	req := requestWithPeerSerial(http.MethodGet, "/v1/events/stream", nil, serial)
+	rec := newWriteCountingRecorder()
+
+	// Act
+	cancel, done := startEventStream(t, s, req, rec, 1)
+	cancel()
+	<-done
+
+	// Assert
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if !bodyContains(rec.Body.String(), "from-events") {
+		t.Errorf("body = %q, want it to contain from-events, proving this request reached "+
+			"handleEventStream rather than a neighbouring /v1/containers/... pattern", rec.Body.String())
+	}
+}
+
+// TestShutdownStopsEventHub asserts that after shutdown() returns, the event
+// hub reports not running and its run goroutine has actually exited —
+// deterministic, not merely eventual, per shutdown()'s own doc comment.
+func TestShutdownStopsEventHub(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := config.Config{StateDir: t.TempDir(), ListenAddr: ":0", PolicyMode: policy.ModeDefault}
+	fd := &fakeDocker{}
+	s := NewServer(cfg, nil, nil, fd, nil, testLogger())
+
+	sub, err := s.events.attach(s.lifecycleCtx, context.Background())
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	_ = sub
+
+	// Act
+	if err := s.shutdown(); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	// Assert
+	s.events.mu.Lock()
+	running := s.events.running
+	s.events.mu.Unlock()
+	if running {
+		t.Error("event hub still reports running after shutdown")
+	}
+
+	waitForCondition(t, 2*time.Second, 5*time.Millisecond,
+		func() bool { return countGoroutinesMatching(eventHubRunGoroutineFrame) == 0 },
+		func() string {
+			return fmt.Sprintf("event hub run goroutine count = %d, want 0", countGoroutinesMatching(eventHubRunGoroutineFrame))
+		})
 }
 
 // TestRunReturnsShutdownError covers both shutdown's error branch and Run's

--- a/internal/httpapi/sse.go
+++ b/internal/httpapi/sse.go
@@ -12,9 +12,11 @@ import (
 
 // SSE framing and liveness constants.
 const (
-	sseContentType = "text/event-stream"
-	sseEventLog    = "log"
-	sseEventError  = "error"
+	sseContentType   = "text/event-stream"
+	sseEventLog      = "log"
+	sseEventError    = "error"
+	sseEventSnapshot = "snapshot"
+	sseEventHealth   = "health"
 )
 
 // keepaliveInterval bounds how long the stream may be silent. A container
@@ -27,6 +29,14 @@ const (
 // A package variable rather than a const so Task 9's race test can shorten it
 // and observe a keepalive without waiting 20 real seconds.
 var keepaliveInterval = 20 * time.Second
+
+// eventHeartbeatInterval bounds how long the container event stream may be
+// silent. It is 25s rather than keepaliveInterval's 20s because the two routes
+// have different silence profiles and the event stream's interval is fixed by
+// its own contract. A separate package variable rather than a shared one: both
+// exist as variables so tests can shorten them, and a shared variable would
+// mean one route's test silently retiming the other route's stream.
+var eventHeartbeatInterval = 25 * time.Second
 
 // sseWriter frames one SSE response. Headers are written lazily, on the first
 // event: once 200 and the headers are committed the status can never be
@@ -128,19 +138,24 @@ func (s *sseWriter) event(id, name string, data any) error {
 	return nil
 }
 
-// keepalive writes a bare SSE comment frame. It does not count as an event
-// and carries no id or data; its only purpose is to keep the connection warm
-// through NAT and proxy idle timeouts.
+// comment writes a bare SSE comment frame. It does not count as an event and
+// carries no id or data; its only purpose is to keep the connection warm
+// through NAT and proxy idle timeouts, and to discover a client that vanished
+// without closing — the write fails, and the stream unwinds.
 //
-// It calls startLocked first if the response has not been committed yet,
-// exactly as event does — a silent container's first activity may well be a
-// keepalive tick rather than a log line, and without this the response would
-// commit as a plain 200 with none of the SSE headers and, critically, the
-// server's write deadline never cleared, so the stream would still die at the
-// server's WriteTimeout. Committing here cannot steal D12's 404 window: the
-// pre-stream inspect is bounded by callTimeout and always returns well before
-// the first keepaliveInterval tick.
-func (s *sseWriter) keepalive() error {
+// It calls startLocked first if the response has not been committed yet, for
+// the reason keepalive's doc comment gives — a silent container's first
+// activity may well be a comment tick rather than a log line, and without
+// this the response would commit as a plain 200 with none of the SSE
+// headers and, critically, the server's write deadline never cleared, so the
+// stream would still die at the server's WriteTimeout. Committing here
+// cannot steal D12's 404 window: the pre-stream inspect is bounded by
+// callTimeout and always returns well before the first tick.
+//
+// text must be a compile-time literal with no embedded newline: the only two
+// call sites pass "keepalive" and "heartbeat", so there is no runtime check
+// for a case that cannot occur.
+func (s *sseWriter) comment(text string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -150,14 +165,18 @@ func (s *sseWriter) keepalive() error {
 		}
 	}
 
-	if _, err := fmt.Fprint(s.w, ": keepalive\n\n"); err != nil {
-		return fmt.Errorf("write sse keepalive: %w", err)
+	if _, err := fmt.Fprintf(s.w, ": %s\n\n", text); err != nil {
+		return fmt.Errorf("write sse comment: %w", err)
 	}
 	if err := s.rc.Flush(); err != nil {
-		return fmt.Errorf("flush sse keepalive: %w", err)
+		return fmt.Errorf("flush sse comment: %w", err)
 	}
 	return nil
 }
+
+// keepalive writes the log stream's comment frame. Kept as a named method so
+// that route's exact wire bytes cannot drift.
+func (s *sseWriter) keepalive() error { return s.comment("keepalive") }
 
 // Started reports whether the response has been committed. Callers use it
 // after a stream ends to decide between writeDockerError (nothing sent yet)

--- a/internal/httpapi/sse_test.go
+++ b/internal/httpapi/sse_test.go
@@ -83,6 +83,81 @@ func TestSSEKeepaliveBytes(t *testing.T) {
 	}
 }
 
+// TestSSECommentBytes pins the exact bytes of a comment frame written
+// through comment directly, with a text other than "keepalive" — the event
+// stream's heartbeat is the other caller and uses "heartbeat".
+func TestSSECommentBytes(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+	sw := newSSEWriter(rec)
+
+	// Act
+	err := sw.comment("heartbeat")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("comment() error = %v, want nil", err)
+	}
+	want := ": heartbeat\n\n"
+	if got := rec.Body.String(); got != want {
+		t.Errorf("comment() body = %q, want %q", got, want)
+	}
+}
+
+// TestSSEKeepaliveBytesUnchanged is a regression guard on a shipped
+// contract: keepalive() must still emit exactly ": keepalive\n\n" now that
+// its body has been extracted into comment, so the log route's wire format
+// cannot drift as a side effect of that refactor.
+func TestSSEKeepaliveBytesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+	sw := newSSEWriter(rec)
+
+	// Act
+	err := sw.keepalive()
+
+	// Assert
+	if err != nil {
+		t.Fatalf("keepalive() error = %v, want nil", err)
+	}
+	want := ": keepalive\n\n"
+	if got := rec.Body.String(); got != want {
+		t.Errorf("keepalive() body = %q, want %q", got, want)
+	}
+}
+
+// TestSSECommentStartsLazily asserts comment on an uncommitted writer
+// commits the response exactly as event and keepalive do: SSE headers set
+// and Started() true, even though nothing was ever sent as an event.
+func TestSSECommentStartsLazily(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	rec := &deadlineAwareRecorder{ResponseRecorder: httptest.NewRecorder()}
+	sw := newSSEWriter(rec)
+
+	// Act / Assert — before any comment
+	if sw.Started() {
+		t.Fatal("Started() = true before any comment, want false")
+	}
+
+	if err := sw.comment("heartbeat"); err != nil {
+		t.Fatalf("comment() error = %v, want nil", err)
+	}
+
+	// Assert — after the comment
+	if !sw.Started() {
+		t.Error("Started() = false after comment(), want true")
+	}
+	if got := rec.Header().Get("Content-Type"); got != sseContentType {
+		t.Errorf("Content-Type = %q, want %q", got, sseContentType)
+	}
+}
+
 // TestSSELazyStart is D12's contract: nothing is written to the underlying
 // ResponseWriter, and Started() stays false, until the first event is
 // emitted. Committing headers eagerly would make a pre-stream failure (a


### PR DESCRIPTION
## Summary

Adds `GET /v1/events/stream` — a Server-Sent Events stream of container health and lifecycle transitions — so a paired client (the Android app) can show notifications the moment a container turns unhealthy or dies, instead of polling `GET /v1/containers` on a timer.

### Wire contract

- One `event: snapshot` frame first, always: a JSON array of `{id, name, state, health}` for every container, `health` one of `healthy|unhealthy|starting|none`. The snapshot replaces any replay mechanism — there is deliberately no `?since=` and no `Last-Event-ID`.
- Then `event: health` frames as Engine events arrive: `{id, name, event, health, time}` (RFC 3339; `health` only on `health_status` events). Forwarded events are exactly `health_status: healthy`, `health_status: unhealthy`, `die`, `start`, `stop`, `oom`.
- A `: heartbeat` comment every 25 seconds keeps NAT/proxies from reaping the connection and lets the client detect a dead stream.
- Unrecoverable failure after the stream starts arrives as a terminal `event: error` with the standard error body, then the stream closes.

### Design

- **Same guard chain as every read route.** The route registers through the shared `read` closure — mTLS device auth, per-device rate limit, `policy.OpRead` — so 401/403/429 behave identically to the sibling routes, and Engine faults answer 502 per the repository taxonomy (the spec originally said 503; changed on review because 503 already means "stream budget exhausted" on `/logs/stream`).
- **One Engine subscription per process.** An `eventHub` opens Docker's `/events` feed lazily on the first client and fans it out through bounded per-client buffers; a client that cannot keep up is dropped with `event stream fell behind` rather than silently losing events. The hub never reconnects: any gap becomes a disconnect, so the opening snapshot is the single recovery path.
- **Ordering is guaranteed the strong way round.** The subscription is confirmed live (verified against the moby v0.5.1 SDK: `client.Events` blocks until `GET /events` has a response) before the snapshot is taken, so an event firing during the snapshot lands in the client's buffer instead of a gap. Proven by a test that emits in exactly that window.
- **One stream per device, newest wins**, in its own `eventRegistry` — the older connection ends with `event stream superseded` (the one terminal error a client must not retry). Event streams consume none of the log-stream budget; `streambudget.go` is untouched.
- **The action allowlist is a security control.** Docker's raw health action string can carry the healthcheck's own output, and an event's attributes are the container's label set — the allowlist matches exact SDK constants, only the `name` attribute is ever read, and log lines carry only container IDs and normalised event types. Tests plant a fake secret in the actor attributes and assert it reaches neither the wire nor `agent.log`.

### Docs

`docs/openapi.yaml` gains the `events` tag, path, `ContainerStateSummary`/`ContainerEvent` schemas and a `PolicyForbidden` response; README gains the route row and a "Container health event stream" section with the reasoning. Documented caveats: `name` strips the Engine's leading `/` (join on `id`), and snapshot `health` is uniformly `none` on Engines older than API v1.52 while events still work.

## Test plan

- [x] `go test ./internal/... -race` green; coverage 93.8% (floor 90%)
- [x] Unit + handler matrix: snapshot-first ordering, no-event-lost-during-snapshot, health/lifecycle forwarding, newest-wins supersede, per-device independence, log-budget isolation, 401/403/429/502/500, heartbeat, goroutine-leak and log-hygiene guards
- [x] `gofmt`, `go vet`, `golangci-lint`, `gosec`, `go vet -tags e2e`, `make openapi-lint`, `make doc-citations`, `make build`, `docker build` all clean; `go.mod` unchanged
- [x] e2e contract suite (`contract_events_test.go`) executed against a real Docker Engine (API 1.55, WSL2): all six event-stream contract tests pass, and the full api suite (124 tests) and incontainer suite (50 tests) are green with `-race`. One test fix came out of it (7658bd1): the Engine emits `stop` *before* `die`, so the lifecycle test now accepts the two events in either order.
- [x] Verified live against the local Engine via the e2e suite: snapshot reconciliation, health flip to `unhealthy`, `die`/`stop` frames, same-device supersede, log-budget isolation. Still unexercised on a real host: a 60s+ idle heartbeat soak, an `oom` event, and daemon-restart teardown (disruptive on a workstation) — covered at the unit level.
- Testing also reproduced a pre-existing, unrelated flaky shutdown race on `dev` — filed as #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
