### PR TITLE
chore: prepare the 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,59 @@ changes nothing about the agent's behaviour, but this is an open repository and
 a contributor reading the history should not have to reconstruct why the build
 moved.
 
+## [0.4.0] - 2026-08-26
+
+A feature release. The agent gains `GET /v1/events/stream`, a live feed of
+container health and lifecycle transitions, so a paired client can show a
+notification the moment a container turns unhealthy or dies instead of polling
+`GET /v1/containers` on a timer.
+
+The configuration surface is unchanged: every `DEVMON_*` variable means in
+0.4.0 exactly what it meant in 0.3.0, and no variable was added or removed.
+The new route is additive — no existing route changed its behaviour.
+
+### Added
+
+- **`GET /v1/events/stream` — a Server-Sent Events stream of container health
+  and lifecycle transitions.** The stream always opens with one
+  `event: snapshot` frame carrying `{id, name, state, health}` for every
+  container, then forwards `event: health` frames as Engine events arrive —
+  exactly `health_status: healthy`, `health_status: unhealthy`, `die`, `start`,
+  `stop` and `oom`. There is deliberately no replay (`?since=`,
+  `Last-Event-ID`): the snapshot is the single recovery path after any gap. A
+  `: heartbeat` comment every 25 seconds keeps intermediaries from reaping an
+  idle connection. The route sits behind the same guard chain as every other
+  read route, one Docker `/events` subscription is fanned out to all clients
+  through bounded per-client buffers, and each device holds at most one stream
+  — a newer connection supersedes the older one. The Engine's raw event action
+  and attributes can carry healthcheck output and container labels, so a closed
+  action allowlist and a `name`-only attribute read keep them off the wire and
+  out of the log. Event streams consume none of the log-stream budget.
+  ([#116](https://github.com/scnplt/devmon-agent/pull/116))
+
+### Changed
+
+- **`modernc.org/sqlite` bumped from 1.56.0 to 1.57.0** — the release's only
+  runtime dependency change.
+  ([#112](https://github.com/scnplt/devmon-agent/pull/112))
+
+### Internal
+
+- The builder image moved from `golang:1.26-alpine` to `golang:1.27-alpine`
+  and the `distroless/static-debian12` digest pin was refreshed; both stay
+  digest-pinned under `GOTOOLCHAIN=local`.
+  ([#110](https://github.com/scnplt/devmon-agent/pull/110),
+  [#111](https://github.com/scnplt/devmon-agent/pull/111))
+- `actions/deploy-pages` and `actions/upload-pages-artifact` moved to v5 in the
+  Pages workflow.
+  ([#113](https://github.com/scnplt/devmon-agent/pull/113),
+  [#114](https://github.com/scnplt/devmon-agent/pull/114))
+- The git workflow rules now require labels on every issue and PR and an issue
+  link on every PR, and code comments cite sibling code by name rather than
+  line number so the references survive edits.
+  ([#109](https://github.com/scnplt/devmon-agent/pull/109),
+  [#115](https://github.com/scnplt/devmon-agent/pull/115))
+
 ## [0.3.0] - 2026-08-20
 
 A hardening release. Two of the agent's shared budgets — the live log stream

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.3.0 — the full surface.** The agent is its own certificate
+**Status: 0.4.0 — live container health events.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -75,7 +75,7 @@ docker run -d --name devmon-agent \
   --read-only --tmpfs /tmp \
   --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.3.0
+  ghcr.io/scnplt/devmon-agent:0.4.0
 ```
 
 The four hardening flags are not needed to run the agent and none of them
@@ -99,7 +99,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.3.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.4.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -37,7 +37,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.3.0
+    image: ghcr.io/scnplt/devmon-agent:0.4.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.3.0
+  version: 0.4.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -123,7 +123,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.3.0
+                    agent_version: 0.4.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -975,7 +975,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.3.0"]
+          examples: ["0.4.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.3.0'
+IMAGE_TAG='0.4.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
## Summary

Records **0.4.0** in `CHANGELOG.md` and bumps the version every document names — the README status line and its `docker run` / `/v1/status` examples, `install.sh` `IMAGE_TAG`, `compose.example.yaml`, and the OpenAPI info block with its two `agent_version` examples.

0.4.0 rather than 0.3.1: the release adds `GET /v1/events/stream` (#116), a new caller-visible capability. No `DEVMON_*` variable was added, removed, or given a new meaning, and no existing route changed behaviour, so nothing here is breaking.

Once this lands on `dev`, the `dev` -> `main` release PR follows, mirroring #97 -> #98 for 0.3.0.

## Test plan

- [x] `make openapi-lint` — valid
- [x] `make doc-citations` — all citations resolve
- [x] Version pins consistent across README, `install.sh`, `compose.example.yaml`, `docs/openapi.yaml` (grep shows no remaining `0.3.0` pin)
- [ ] CI green (`shellcheck` runs there; not installed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)