### PR TITLE
fix: consistent image and image_id fields in container detail response

### DIFF
--- a/internal/dockerx/containers.go
+++ b/internal/dockerx/containers.go
@@ -104,7 +104,7 @@ func toContainerDetail(r container.InspectResponse, selfID string) ContainerDeta
 	d := ContainerDetail{
 		ID:           r.ID,
 		Name:         r.Name,
-		Image:        r.Image,
+		ImageID:      r.Image,
 		CreatedAt:    r.Created,
 		Command:      r.Path,
 		Platform:     r.Platform,
@@ -131,6 +131,7 @@ func toContainerDetail(r container.InspectResponse, selfID string) ContainerDeta
 	}
 
 	if r.Config != nil {
+		d.Image = r.Config.Image
 		d.Labels = r.Config.Labels
 		d.WorkingDir = r.Config.WorkingDir
 		d.User = r.Config.User

--- a/internal/dockerx/containers_test.go
+++ b/internal/dockerx/containers_test.go
@@ -52,6 +52,7 @@ func TestToContainerDetailNilState(t *testing.T) {
 	// Arrange
 	r := container.InspectResponse{
 		ID:         "abc123",
+		Image:      "sha256:abcdef",
 		State:      nil,
 		Config:     nil,
 		HostConfig: nil,
@@ -61,6 +62,12 @@ func TestToContainerDetailNilState(t *testing.T) {
 	got := toContainerDetail(r, "")
 
 	// Assert
+	if got.Image != "" {
+		t.Errorf("got.Image = %q, want empty when Config is nil", got.Image)
+	}
+	if got.ImageID != "sha256:abcdef" {
+		t.Errorf("got.ImageID = %q, want sha256:abcdef", got.ImageID)
+	}
 	if got.State != "" {
 		t.Errorf("got.State = %q, want empty", got.State)
 	}
@@ -229,7 +236,7 @@ func TestToContainerDetailFullState(t *testing.T) {
 	r := container.InspectResponse{
 		ID:      "abc123",
 		Name:    "/api",
-		Image:   "myapp:1.4",
+		Image:   "sha256:abcdef",
 		Created: "2023-11-14T22:13:20Z",
 		Path:    "/app/server",
 		Args:    []string{"--port", "8080"},
@@ -243,6 +250,7 @@ func TestToContainerDetailFullState(t *testing.T) {
 		},
 		Config: &container.Config{
 			Env:        []string{"DB_PASSWORD=hunter2"},
+			Image:      "myapp:1.4",
 			WorkingDir: "/app",
 			User:       "nobody",
 			Labels:     map[string]string{"app": "myapp"},
@@ -272,6 +280,12 @@ func TestToContainerDetailFullState(t *testing.T) {
 	got := toContainerDetail(r, "")
 
 	// Assert
+	if got.Image != "myapp:1.4" {
+		t.Errorf("got.Image = %q, want myapp:1.4 (from Config.Image)", got.Image)
+	}
+	if got.ImageID != "sha256:abcdef" {
+		t.Errorf("got.ImageID = %q, want sha256:abcdef (from the top-level Image digest)", got.ImageID)
+	}
 	if got.FinishedAt != "" {
 		t.Errorf("got.FinishedAt = %q, want empty for the zero timestamp", got.FinishedAt)
 	}

--- a/internal/dockerx/types.go
+++ b/internal/dockerx/types.go
@@ -72,12 +72,13 @@ type ContainerSummary struct {
 	Protected bool `json:"protected"`
 }
 
-// ContainerDetail is the full projection of a single container. 25 fields.
+// ContainerDetail is the full projection of a single container. 26 fields.
 // NO env. NO raw Engine payload.
 type ContainerDetail struct {
 	ID            string            `json:"id"`
 	Name          string            `json:"name"`
 	Image         string            `json:"image"`
+	ImageID       string            `json:"image_id"`
 	CreatedAt     string            `json:"created_at"` // RFC3339 UTC
 	State         string            `json:"state"`
 	Running       bool              `json:"running"`

--- a/internal/dockerx/types_test.go
+++ b/internal/dockerx/types_test.go
@@ -79,6 +79,7 @@ func TestContainerDetailFieldCount(t *testing.T) {
 		ID:            "abc123",
 		Name:          "/api",
 		Image:         "myapp:1.4",
+		ImageID:       "sha256:abcdef",
 		CreatedAt:     "2023-11-14T22:13:20Z",
 		State:         "running",
 		Running:       true,
@@ -107,8 +108,8 @@ func TestContainerDetailFieldCount(t *testing.T) {
 	body := marshalToMap(t, cd)
 
 	// Assert
-	if len(body) != 25 {
-		t.Fatalf("ContainerDetail payload has %d keys (%v), want exactly 25", len(body), keysOf(body))
+	if len(body) != 26 {
+		t.Fatalf("ContainerDetail payload has %d keys (%v), want exactly 26", len(body), keysOf(body))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the field-meaning mismatch between the container list and detail endpoints: `GET /v1/containers/{id}` returned the sha256 image ID under `image`, while `GET /v1/containers` returns the human-readable tag there.

- `ContainerDetail` gains an `image_id` field (sha256 digest from the inspect response's top-level `Image`), mirroring `ContainerSummary`. Field count 25 → 26; the D1 allowlist guard test is updated.
- `toContainerDetail` now maps `image` from `Config.Image` inside the existing nil-`Config` guard (empty string when `Config` is nil) and `image_id` unconditionally from the top-level digest.
- No other `Config` fields are mapped — D2 (no env leakage) is untouched, and the existing env-leak assertion still passes.

## Test plan

- [x] `TestContainerDetailFieldCount` passes at 26 fields
- [x] `TestToContainerDetailFullState` asserts `image` = `Config.Image` and `image_id` = top-level digest
- [x] `TestToContainerDetailNilState` asserts nil `Config` yields `image: ""` without panic, `image_id` still populated
- [x] `gofmt -l .` clean, `go vet`, `golangci-lint run` (0 issues), `gosec` (0 issues)
- [x] `go test ./internal/... -race` passes; total coverage 93.8% (floor 90%)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)