### PR TITLE
fix: stop request-less StateNew connections from pinning graceful shutdown

### DIFF
--- a/internal/e2e/api/contract_startup_test.go
+++ b/internal/e2e/api/contract_startup_test.go
@@ -135,8 +135,10 @@ func TestGracefulShutdown(t *testing.T) {
 	a := harness.StartAgent(t, harness.AgentOptions{})
 
 	// Agent.Stop already asserts a clean (0) exit within its own
-	// shutdownTimeout (5s, matching server.go's own drain budget) — a
-	// timeout or a non-zero exit fails the test right here.
+	// shutdownTimeout (7s — it deliberately exceeds server.go's 5s drain
+	// budget by design, so SIGKILL only fires on a genuine hang, never on a
+	// correct full-grace drain; issue #117) — a timeout or a non-zero exit
+	// fails the test right here.
 	exitCode := a.Stop(t)
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", exitCode)

--- a/internal/e2e/harness/agent.go
+++ b/internal/e2e/harness/agent.go
@@ -26,10 +26,17 @@ import (
 // Timing budgets for the agent subprocess. readinessTimeout is generous: the
 // state store and CA are built on first start, which is slower than a warm
 // restart.
+//
+// shutdownTimeout must strictly exceed the agent's own drain grace
+// (shutdownGrace in internal/httpapi/server.go, currently 5s — unexported, so
+// it can't be imported here and the two values are kept aligned by this
+// comment) plus roughly 2s of scheduling margin. Setting it equal to the
+// drain grace put SIGTERM-to-SIGKILL on a knife edge where even a correct
+// full-grace drain got killed as if it were a hang (issue #117).
 const (
 	readinessTimeout = 15 * time.Second
 	readinessPoll    = 100 * time.Millisecond
-	shutdownTimeout  = 5 * time.Second
+	shutdownTimeout  = 7 * time.Second
 	killTimeout      = 10 * time.Second
 )
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -131,6 +132,23 @@ type Server struct {
 	// with a sleep. It is per-instance rather than a package-level var so
 	// setting it on one test's Server can never race a different test's.
 	afterCreateHook func()
+
+	// newConnMu guards newConns and draining below (issue #117). A
+	// connection that completed its TLS handshake but never sent a request
+	// sits in http.StateNew for the rest of its life; http.Server.Shutdown
+	// only treats such a connection as closable-idle once its state stamp
+	// is more than shutdownGrace old, with one-second stamp granularity, so
+	// it can pin Shutdown for the entire grace window. Tracking every
+	// StateNew connection here lets shutdown close them itself instead of
+	// waiting on that stamp.
+	newConnMu sync.Mutex
+	newConns  map[net.Conn]struct{}
+	// draining is set by shutdown before it closes the tracked connections
+	// above. The ConnState hook checks it so a connection that reaches
+	// StateNew after draining started — in the window between shutdown
+	// beginning and http.Server.Shutdown closing the listener — is closed
+	// immediately too, rather than surviving to pin the grace window.
+	draining bool
 }
 
 // NewServer wires the API. tlsCfg carries the server certificate, so the
@@ -144,7 +162,11 @@ type Server struct {
 // likewise be nil in tests that do not exercise the Docker read routes; every
 // read handler tolerates that by serving 502 instead of panicking.
 func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger) *Server {
-	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log, streams: newStreamBudget(maxConcurrentStreams, maxStreamsPerDevice)}
+	s := &Server{
+		cfg: cfg, st: st, ca: ca, dc: dc, log: log,
+		streams:  newStreamBudget(maxConcurrentStreams, maxStreamsPerDevice),
+		newConns: make(map[net.Conn]struct{}),
+	}
 	s.lifecycleCtx, s.cancelLifecycle = context.WithCancel(context.Background())
 	s.events = newEventHub(dc, log)
 	s.eventStreams = newEventRegistry()
@@ -194,8 +216,70 @@ func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader
 		// in one step, which is how a live SSE stream (issue #41) learns to
 		// stop without Shutdown having to wait out the client.
 		BaseContext: func(net.Listener) context.Context { return s.lifecycleCtx },
+		// ConnState tracks every connection whose current state is
+		// http.StateNew (issue #117): shutdown closes them directly instead
+		// of waiting on Shutdown's own idle-since-state-stamp check, which a
+		// handshake-only, request-less connection can outlive for the whole
+		// shutdownGrace window. See trackConnState's doc comment.
+		ConnState: s.trackConnState,
 	}
 	return s
+}
+
+// trackConnState is the http.Server ConnState hook (issue #117). It keeps
+// newConns as the current set of connections in http.StateNew — added on
+// StateNew, removed the moment a connection leaves it for StateActive,
+// StateIdle, StateHijacked, or StateClosed — so shutdown can close every
+// still-StateNew connection itself rather than rely on Shutdown's own
+// idle-since-state-stamp check, which treats a StateNew connection as
+// closable-idle only once that stamp is more than shutdownGrace old.
+//
+// If draining is already true when a connection reaches StateNew, shutdown
+// has already swept the connections it knew about; this one arrived in the
+// gap between that sweep and http.Server.Shutdown closing the listener, so
+// it is closed here immediately instead of being left to pin the grace
+// window on its own.
+//
+// There is an acknowledged, accepted race: a connection can transition
+// StateNew -> StateActive concurrently with shutdown closing it here. That
+// is fine during shutdown — the lifecycle context is already cancelled by
+// the time shutdown reaches this path, so any handler that connection's
+// request might have reached is already unwinding.
+func (s *Server) trackConnState(conn net.Conn, state http.ConnState) {
+	switch state {
+	case http.StateNew:
+		s.newConnMu.Lock()
+		draining := s.draining
+		if !draining {
+			s.newConns[conn] = struct{}{}
+		}
+		s.newConnMu.Unlock()
+		if draining {
+			_ = conn.Close()
+		}
+	case http.StateActive, http.StateIdle, http.StateHijacked, http.StateClosed:
+		s.newConnMu.Lock()
+		delete(s.newConns, conn)
+		s.newConnMu.Unlock()
+	}
+}
+
+// closeNewConns marks the server as draining and closes every connection
+// currently tracked as http.StateNew (issue #117). Called from shutdown
+// before http.Server.Shutdown, so a handshake-only, request-less connection
+// — which carries no request context for lifecycleCtx cancellation to reach
+// — is closed directly instead of pinning Shutdown for the whole
+// shutdownGrace window waiting on its state stamp to age out.
+func (s *Server) closeNewConns() {
+	s.newConnMu.Lock()
+	s.draining = true
+	conns := s.newConns
+	s.newConns = make(map[net.Conn]struct{})
+	s.newConnMu.Unlock()
+
+	for conn := range conns {
+		_ = conn.Close()
+	}
 }
 
 // routes builds the mux and wraps it in the middleware chain.
@@ -336,6 +420,18 @@ func (s *Server) shutdown() error {
 	// so a goroutine-leak test can assert it right after shutdown returns
 	// instead of racing the hub's own teardown.
 	s.events.stop()
+
+	// Close every connection still in http.StateNew (issue #117) before
+	// asking http.Server to drain. A connection that completed its TLS
+	// handshake but never sent a request has no request context for
+	// cancelLifecycle above to reach, and Shutdown itself only treats a
+	// StateNew connection as closable-idle once its state stamp is more
+	// than shutdownGrace old — with one-second stamp granularity, that can
+	// pin Shutdown for the entire grace window on a connection that was
+	// never going to send anything. See trackConnState's doc comment for
+	// why closing it here, mid-transition, is an accepted race rather than
+	// a bug.
+	s.closeNewConns()
 
 	// A fresh context: ctx is already cancelled, and Shutdown needs a live
 	// deadline to drain against.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -590,3 +590,62 @@ func TestShutdownEndsLiveStreamPromptlyAndReturnsNil(t *testing.T) {
 		t.Fatal("the client's stream read did not end after shutdown")
 	}
 }
+
+// TestShutdownNotPinnedByRequestlessConnection is issue #117's regression: a
+// connection that completed its TLS handshake but never sent a request sits
+// in http.StateNew for the server's whole life. That state has no request
+// context for shutdown to cancel — TestShutdownEndsLiveStreamPromptlyAndReturnsNil's
+// fix does not reach it — and http.Server.Shutdown only treats a StateNew
+// connection as closable-idle once its state stamp is more than five seconds
+// old, with one-second stamp granularity (issue #72). shutdownGrace is
+// exactly five seconds, so such a connection pins Shutdown for the entire
+// grace window rather than returning promptly. This is not a synthetic case:
+// Go's own http.Transport sometimes dials an extra connection during pool
+// contention that never carries a request and sits in the client's idle pool
+// while the server still sees it as StateNew.
+func TestShutdownNotPinnedByRequestlessConnection(t *testing.T) {
+	// Not t.Parallel(), for the same reason TestRunReturnsShutdownError is
+	// not: this test's assertion window overlaps shutdownGrace closely
+	// enough that running alongside other goroutine-heavy tests could skew
+	// TestStreamGoroutineDoesNotLeak's before/after count.
+
+	// Arrange — a known port, since this test dials the server itself.
+	addr := freeTCPAddr(t)
+	s := runnableServer(t, addr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() { done <- s.Run(ctx) }()
+	waitForListening(t, addr, 2*time.Second)
+
+	// A real TLS handshake, then deliberately no request: this is the
+	// server-side http.StateNew, request-less keep-alive connection the fix
+	// targets.
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec // test-only, talks to our own ephemeral server
+	if err != nil {
+		t.Fatalf("dial server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+
+	// Act
+	shutdownStart := time.Now()
+	cancel()
+
+	// Assert — Shutdown completes well under shutdownGrace: a request-less
+	// handshake-only connection must not pin it for the full grace window.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run() = %v, want nil with only a request-less connection open", err)
+		}
+		if elapsed := time.Since(shutdownStart); elapsed >= 2*time.Second {
+			t.Errorf("shutdown took %v, want well under the %v grace period", elapsed, shutdownGrace)
+		}
+	case <-time.After(shutdownGrace + 5*time.Second):
+		t.Fatal("Run() did not return after shutdown with only a request-less connection open")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent e2e failure where the agent consumed its full 5s `shutdownGrace` on SIGTERM and got SIGKILLed by the harness's identical 5s deadline.

Two separable changes, one commit each:

- **Agent** (`internal/httpapi/server.go`): a connection that completed its TLS handshake but never sent a request sits in `http.StateNew` — it has no request context for the lifecycle-context cancellation (issue #41) to reach, and `http.Server.Shutdown` only treats it as closable-idle once its state stamp is more than 5s old (one-second granularity), i.e. exactly `shutdownGrace`, so it pinned `Shutdown` for the entire grace. Such connections arise naturally from `http.Transport` pool contention (an extra dialed conn that never carries a request). A `ConnState` hook now tracks `StateNew` connections and `shutdown` closes them directly before draining; a connection reaching `StateNew` after draining begins is closed on entry. `readHeaderTimeout` and all other constants are unchanged, so Slowloris protection during normal serving is intact, and no configuration surface is added.
- **Harness** (`internal/e2e/harness/agent.go`): `shutdownTimeout` raised from 5s to 7s (drain grace + ~2s scheduling margin) with a comment deriving it, so SIGKILL fires only on a genuine hang, never on a correct full-grace drain. The knife-edge comment in `TestGracefulShutdown` is updated to match.

## Test plan

- [x] New unit regression test `TestShutdownNotPinnedByRequestlessConnection`: fails against the previous code (`Shutdown` returns `context.DeadlineExceeded` after 5.03s) and passes in 0.02s with the fix.
- [x] Issue #41's regression test `TestShutdownEndsLiveStreamPromptlyAndReturnsNil` still passes; `TestRunReturnsShutdownError` still passes (a blocking `StateActive` handler still times out — the fix never touches active connections).
- [x] `go test ./internal/... -race`: all pass; coverage 93.8% (floor 90%).
- [x] `gofmt -l`, `go vet`, `golangci-lint run`, `gosec`: all clean; e2e packages verified with `-tags e2e` vet/build/lint.
- [x] E2e flake repro run from WSL2 Ubuntu (Go 1.26.7, Docker Engine API 1.55): `go test -tags e2e ./internal/e2e/api/... -race -count=20 -run TestReadsRejectInvalidAndUnknownRefs` passes 20/20 on this branch (twice, with `DEVMON_E2E_REQUIRE=1`). Control run of the same command on unfixed `dev` (dd33c8b): 16/20 iterations fail with the exact issue signature (`devmon-agent did not exit within 5s of SIGTERM` / `shut down http server: context deadline exceeded`).
- [x] Full e2e suite (`go test -tags e2e ./internal/e2e/... -race -count=1`, WSL2): api, harness, and incontainer packages all pass.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
