### PR TITLE
feat: add devmon symlink alias for docker exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
       -X github.com/scnplt/devmon-agent/internal/version.BuildTime=${BUILD_TIME}" \
     -o /out/devmon-agent ./cmd/devmon-agent
 
+# `devmon` is the documented short name for docker exec (`docker exec <name>
+# devmon device list`). It has to be staged as a symlink inside a directory:
+# COPY of a single symlink dereferences it, which would duplicate the whole
+# binary in the final layer, while symlinks inside a copied directory are
+# preserved. The link target is relative so it resolves at /usr/local/bin too.
+RUN mkdir -p /out/bin \
+    && cp /out/devmon-agent /out/bin/devmon-agent \
+    && ln -s devmon-agent /out/bin/devmon
+
 # The default DEVMON_STATE_DIR (internal/config/config.go), staged here so the
 # final stage can COPY it in with the right owner. distroless has no shell, so
 # `RUN mkdir` is not available there and this is the only way to put a directory
@@ -47,7 +56,7 @@ RUN mkdir -m 0700 -p /out/state
 # distroless/static already carries a bundle if a later phase needs one.
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
 
-COPY --from=build /out/devmon-agent /usr/local/bin/devmon-agent
+COPY --from=build /out/bin/ /usr/local/bin/
 
 # Pre-created and owned by the nonroot UID. UID 65532 cannot MkdirAll under a
 # root-owned /var, so without this a bare `docker run` with no bind mount dies

--- a/README.md
+++ b/README.md
@@ -716,8 +716,7 @@ in transit or at rest anywhere but on the device that owns it.
 ### 1. Mint a code on the host
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent \
-  device pair-code --name "pixel-8"
+docker exec devmon-agent devmon device pair-code --name "pixel-8"
 # Pairing code: B4HJFH3KEAZ2QMY546LLN3IDOW
 # Expires:      2026-08-07T20:12:00Z
 ```
@@ -791,10 +790,12 @@ cannot lock a device out.
 
 These run against the same state directory the agent is using. The image is
 `distroless/static:nonroot` — no shell, no second binary — so the host CLI is
-subcommands on the agent binary itself:
+subcommands on the agent binary itself. `devmon` is a symlink to
+`/usr/local/bin/devmon-agent`, so the full path and the `devmon-agent` name
+work just as well:
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
+docker exec devmon-agent devmon device <subcommand>
 ```
 
 | Subcommand | Effect |
@@ -804,11 +805,11 @@ docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
 | `device revoke <id>` | Withdraw a device's access, effective immediately |
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device list
+$ docker exec devmon-agent devmon device list
 ID                NAME     PAIRED                LAST SEEN             STATE
 3f9a1c74b2e05d68  pixel-8  2026-08-07T20:02:00Z  2026-08-07T21:14:33Z  active
 
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device revoke 3f9a1c74b2e05d68
+$ docker exec devmon-agent devmon device revoke 3f9a1c74b2e05d68
 revoked 3f9a1c74b2e05d68 (pixel-8)
 ```
 
@@ -843,7 +844,7 @@ alone only reacts to the process exiting; this also catches a listener that is
 up but no longer answering.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent health
+$ docker exec devmon-agent devmon health
 healthy: GET /v1/status returned 200
 
 $ docker inspect -f '{{.State.Health.Status}}' devmon-agent
@@ -871,7 +872,7 @@ a row per list refresh would drown the record the log exists for and then push
 the destructive-operation history out under retention.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent audit list --limit 5
+$ docker exec devmon-agent devmon audit list --limit 5
 WHEN                  DEVICE            OPERATION  TARGET  OUTCOME        DETAIL
 2026-08-08T21:06:40Z  3f9a1c… (pixel-8) delete     devmon  denied_self
 2026-08-08T21:05:02Z  3f9a1c… (pixel-8) kill       api     denied_policy

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -2,8 +2,9 @@
 
 // Host-side `device` subcommands (D8 in the Phase 2 plan). The image is
 // distroless/static:nonroot — there is no shell and no second binary — so
-// `docker exec devmon-agent /usr/local/bin/devmon-agent device ...` is the
-// only shape that works for an operator managing paired devices.
+// `docker exec devmon-agent devmon device ...` (with `devmon` a symlink to
+// /usr/local/bin/devmon-agent) is the only shape that works for an operator
+// managing paired devices.
 package main
 
 import (

--- a/install.sh
+++ b/install.sh
@@ -35,11 +35,13 @@ NONROOT_GID='65532'
 # Docker host is outside what this installer sets up.
 SOCKET_PATH='/var/run/docker.sock'
 
-# CONTAINER_BINARY is the absolute path of the agent binary inside the image.
-# The image is distroless/static:nonroot — there is no shell in it — so every
-# in-container command must name the binary directly. `docker compose exec sh
-# -c ...` does not work and never will.
-CONTAINER_BINARY='/usr/local/bin/devmon-agent'
+# CONTAINER_BINARY is the agent CLI name inside the image: a symlink to
+# /usr/local/bin/devmon-agent, resolved through the container's default PATH
+# (docker exec does the lookup, no absolute path needed). The image is
+# distroless/static:nonroot — there is no shell in it — so every in-container
+# command must name the binary directly. `docker compose exec sh -c ...` does
+# not work and never will.
+CONTAINER_BINARY='devmon'
 
 # SERVICE_NAME is the compose service the exec and log commands address.
 SERVICE_NAME='devmon-agent'

--- a/internal/e2e/incontainer/main_test.go
+++ b/internal/e2e/incontainer/main_test.go
@@ -20,6 +20,7 @@ package incontainer
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,4 +91,49 @@ func TestContainerSmoke(t *testing.T) {
 	if restartCount != 0 {
 		t.Fatalf("agent container %s restart count = %d, want 0", c.ID, restartCount)
 	}
+
+	// `devmon` is the documented short alias `docker exec <name> devmon ...`
+	// depends on (Dockerfile): a symlink to devmon-agent, staged into a
+	// directory that is on the container's default PATH. Resolving the BARE
+	// name — never the absolute path — must produce the exact same `device
+	// list` table header as the canonical binary does.
+	canonicalOut, canonicalExit := c.Exec(t, "/usr/local/bin/devmon-agent", "device", "list")
+	if canonicalExit != 0 {
+		t.Fatalf("device list (canonical path): exit code %d", canonicalExit)
+	}
+	aliasOut, aliasExit := c.Exec(t, "devmon", "device", "list")
+	if aliasExit != 0 {
+		t.Fatalf("device list (via `devmon` PATH alias): exit code %d", aliasExit)
+	}
+
+	const wantHeaderFields = "ID NAME PAIRED LAST SEEN STATE"
+	canonicalHeader := normalizeHeader(firstLine(t, canonicalOut))
+	aliasHeader := normalizeHeader(firstLine(t, aliasOut))
+	if canonicalHeader != wantHeaderFields {
+		t.Fatalf("device list (canonical path) header = %q, want %q", canonicalHeader, wantHeaderFields)
+	}
+	if aliasHeader != canonicalHeader {
+		t.Fatalf("device list (via `devmon` PATH alias) header = %q, want the canonical path's header %q", aliasHeader, canonicalHeader)
+	}
+}
+
+// normalizeHeader collapses a tabwriter table's inter-column padding down to
+// single spaces, so the header's field text can be compared against a fixed
+// literal regardless of the terminal-driven column widths TTY: true exec
+// produces.
+func normalizeHeader(line string) string {
+	return strings.Join(strings.Fields(line), " ")
+}
+
+// firstLine returns the first non-empty line of a tabwriter table's output —
+// the header row `device list` prints as its first line.
+func firstLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			return strings.TrimSpace(line)
+		}
+	}
+	t.Fatalf("output has no non-empty lines: %q", out)
+	return ""
 }


### PR DESCRIPTION
## Summary

The operator CLI can now be invoked with a short name:

```
docker exec devmon-agent devmon device list
```

- **Dockerfile**: `/usr/local/bin` is now staged as a directory copy from the build stage so the `devmon -> devmon-agent` symlink survives (`COPY` of a single symlink dereferences it, which would duplicate the ~13 MB binary). `ENTRYPOINT` and `HEALTHCHECK` stay on the canonical `/usr/local/bin/devmon-agent` path, so nothing existing breaks.
- **install.sh**: `CONTAINER_BINARY` is now the bare `devmon` name — `docker exec` resolves it through the container''s default `PATH`, which already includes `/usr/local/bin` (the absolute path was never actually required on distroless).
- **README**: all six exec examples switched to the short form, with a note that the full path and the `devmon-agent` name keep working.
- **e2e**: `TestContainerSmoke` asserts the bare, PATH-resolved `devmon` produces the same `device list` table header as the canonical path.

## Test plan

- [x] `docker build -t devmon-agent:dev .`
- [x] `docker run --rm --entrypoint devmon devmon-agent:dev -version` (and `--entrypoint devmon-agent`) both print the version
- [x] Image layer for `/usr/local/bin` is 13.4 MB — symlink preserved, binary not duplicated
- [x] `gofmt -l .`, `go vet ./...`, `go vet -tags e2e ./internal/e2e/...` clean
- [x] `shellcheck -s sh install.sh scripts/check-doc-citations.sh` clean
- [x] `go test -tags e2e ./internal/e2e/incontainer/... -run ^TestContainerSmoke$` passes against a real Docker Engine (WSL2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)