### PR TITLE
feat: operator CLI help and devmon alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,21 @@ ARG BUILD_TIME=unknown
 # it run on distroless/static. With cgo left on, the binary links against musl
 # and distroless reports "no such file or directory" for a file that plainly
 # exists, which is a genuinely confusing way to spend an afternoon.
+#
+# The `devmon` symlink is the operator-CLI alias: distroless has no shell and
+# no ln, so the link must be created here and carried over by a *directory*
+# COPY (a single-file COPY would dereference it into a second full copy of the
+# binary). The relative target keeps the link valid wherever the directory
+# lands. main.go dispatches on argv[0]: under the `devmon` name a bare
+# invocation prints help instead of starting the daemon.
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
     -ldflags "-s -w \
       -X github.com/scnplt/devmon-agent/internal/version.Version=${VERSION} \
       -X github.com/scnplt/devmon-agent/internal/version.Commit=${COMMIT} \
       -X github.com/scnplt/devmon-agent/internal/version.BuildTime=${BUILD_TIME}" \
-    -o /out/devmon-agent ./cmd/devmon-agent
+    -o /out/bin/devmon-agent ./cmd/devmon-agent \
+ && ln -s devmon-agent /out/bin/devmon
 
 # The default DEVMON_STATE_DIR (internal/config/config.go), staged here so the
 # final stage can COPY it in with the right owner. distroless has no shell, so
@@ -47,7 +55,11 @@ RUN mkdir -m 0700 -p /out/state
 # distroless/static already carries a bundle if a later phase needs one.
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
 
-COPY --from=build /out/devmon-agent /usr/local/bin/devmon-agent
+# Directory COPY, deliberately: it preserves the `devmon` symlink next to the
+# binary, so `docker exec devmon-agent devmon ...` resolves via the image PATH
+# (/usr/local/bin is on distroless's default PATH) at the cost of a symlink,
+# not a second copy of the binary.
+COPY --from=build /out/bin/ /usr/local/bin/
 
 # Pre-created and owned by the nonroot UID. UID 65532 cannot MkdirAll under a
 # root-owned /var, so without this a bare `docker run` with no bind mount dies

--- a/README.md
+++ b/README.md
@@ -716,8 +716,7 @@ in transit or at rest anywhere but on the device that owns it.
 ### 1. Mint a code on the host
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent \
-  device pair-code --name "pixel-8"
+docker exec devmon-agent devmon device pair-code --name "pixel-8"
 # Pairing code: B4HJFH3KEAZ2QMY546LLN3IDOW
 # Expires:      2026-08-07T20:12:00Z
 ```
@@ -791,11 +790,17 @@ cannot lock a device out.
 
 These run against the same state directory the agent is using. The image is
 `distroless/static:nonroot` — no shell, no second binary — so the host CLI is
-subcommands on the agent binary itself:
+subcommands on the agent binary itself, reachable through the `devmon` alias
+(a symlink the image ships next to the binary):
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
+docker exec devmon-agent devmon device <subcommand>
 ```
+
+`docker exec devmon-agent devmon` on its own (or `devmon help`, or
+`devmon <command> --help`) prints a usage screen listing every command. The
+long form `docker exec devmon-agent /usr/local/bin/devmon-agent …` still works
+— `devmon` is the same binary under a different name.
 
 | Subcommand | Effect |
 |---|---|
@@ -804,11 +809,11 @@ docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
 | `device revoke <id>` | Withdraw a device's access, effective immediately |
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device list
+$ docker exec devmon-agent devmon device list
 ID                NAME     PAIRED                LAST SEEN             STATE
 3f9a1c74b2e05d68  pixel-8  2026-08-07T20:02:00Z  2026-08-07T21:14:33Z  active
 
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device revoke 3f9a1c74b2e05d68
+$ docker exec devmon-agent devmon device revoke 3f9a1c74b2e05d68
 revoked 3f9a1c74b2e05d68 (pixel-8)
 ```
 
@@ -843,7 +848,7 @@ alone only reacts to the process exiting; this also catches a listener that is
 up but no longer answering.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent health
+$ docker exec devmon-agent devmon health
 healthy: GET /v1/status returned 200
 
 $ docker inspect -f '{{.State.Health.Status}}' devmon-agent
@@ -871,7 +876,7 @@ a row per list refresh would drown the record the log exists for and then push
 the destructive-operation history out under retention.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent audit list --limit 5
+$ docker exec devmon-agent devmon audit list --limit 5
 WHEN                  DEVICE            OPERATION  TARGET  OUTCOME        DETAIL
 2026-08-08T21:06:40Z  3f9a1c… (pixel-8) delete     devmon  denied_self
 2026-08-08T21:05:02Z  3f9a1c… (pixel-8) kill       api     denied_policy

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -73,6 +74,20 @@ func runDeviceCommand(ctx context.Context, cfg config.Config, args []string) err
 		return fmt.Errorf("device: missing subcommand (want one of: %s, %s, %s)",
 			subcommandList, subcommandRevoke, subcommandPairCode)
 	}
+	if isHelpSubcommand(args[0]) {
+		printDeviceUsage(os.Stdout)
+		return nil
+	}
+
+	// Validated before openDeviceStore opens the SQLite file: an unknown
+	// subcommand (or a help request, handled above) must not pay for a store
+	// open it will never use.
+	switch args[0] {
+	case subcommandList, subcommandRevoke, subcommandPairCode:
+	default:
+		return fmt.Errorf("device: unknown subcommand %q (want one of: %s, %s, %s)",
+			args[0], subcommandList, subcommandRevoke, subcommandPairCode)
+	}
 
 	st, err := openDeviceStore(ctx, cfg)
 	if err != nil {
@@ -88,9 +103,20 @@ func runDeviceCommand(ctx context.Context, cfg config.Config, args []string) err
 	case subcommandPairCode:
 		return runDevicePairCode(ctx, st, args[1:])
 	default:
-		return fmt.Errorf("device: unknown subcommand %q (want one of: %s, %s, %s)",
-			args[0], subcommandList, subcommandRevoke, subcommandPairCode)
+		// Unreachable: args[0] was already validated above.
+		return nil
 	}
+}
+
+// isHelpSubcommand reports whether a would-be subcommand argument (args[0] to
+// runDeviceCommand or runAuditCommand) is actually a request for help rather
+// than a real subcommand name.
+func isHelpSubcommand(a string) bool {
+	switch a {
+	case "help", "-h", "-help", "--help":
+		return true
+	}
+	return false
 }
 
 // openDeviceStore opens the state store without constructing a logging.Sink.
@@ -152,7 +178,13 @@ func deviceStateOf(d state.Device) string {
 // no name, only an error.
 func runDeviceRevoke(ctx context.Context, st *state.Store, args []string) error {
 	fs := flag.NewFlagSet(subcommandRevoke, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeviceUsage(os.Stdout)
+			return nil
+		}
 		return fmt.Errorf("device revoke: %w", err)
 	}
 	if fs.NArg() != 1 {
@@ -188,8 +220,14 @@ func deviceNameByID(devices []state.Device, id string) string {
 // rotated, so a pairing code in agent.log would be a durable credential.
 func runDevicePairCode(ctx context.Context, st *state.Store, args []string) error {
 	fs := flag.NewFlagSet(subcommandPairCode, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 	name := fs.String(pairCodeNameFlag, "", "name of the device to mint a pairing code for")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeviceUsage(os.Stdout)
+			return nil
+		}
 		return fmt.Errorf("device pair-code: %w", err)
 	}
 	if strings.TrimSpace(*name) == "" {
@@ -218,6 +256,16 @@ func runAuditCommand(ctx context.Context, cfg config.Config, args []string) erro
 	if len(args) == 0 {
 		return fmt.Errorf("audit: missing subcommand (want one of: %s)", subcommandList)
 	}
+	if isHelpSubcommand(args[0]) {
+		printAuditUsage(os.Stdout)
+		return nil
+	}
+
+	// Validated before openDeviceStore opens the SQLite file — see
+	// runDeviceCommand's identical reordering and its comment.
+	if args[0] != subcommandList {
+		return fmt.Errorf("audit: unknown subcommand %q (want one of: %s)", args[0], subcommandList)
+	}
 
 	st, err := openDeviceStore(ctx, cfg)
 	if err != nil {
@@ -225,20 +273,21 @@ func runAuditCommand(ctx context.Context, cfg config.Config, args []string) erro
 	}
 	defer func() { _ = st.Close() }()
 
-	switch args[0] {
-	case subcommandList:
-		return runAuditListCommand(ctx, st, args[1:])
-	default:
-		return fmt.Errorf("audit: unknown subcommand %q (want one of: %s)", args[0], subcommandList)
-	}
+	return runAuditListCommand(ctx, st, args[1:])
 }
 
 // runAuditListCommand parses the `audit list` flags and prints the result to
 // stdout.
 func runAuditListCommand(ctx context.Context, st *state.Store, args []string) error {
 	fs := flag.NewFlagSet(subcommandList, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 	limit := fs.Int(auditLimitFlag, defaultAuditLimit, "maximum number of audit rows to print, most recent first")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printAuditUsage(os.Stdout)
+			return nil
+		}
 		return fmt.Errorf("audit list: %w", err)
 	}
 	return runAuditList(ctx, st, os.Stdout, *limit)

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -6,11 +6,39 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/scnplt/devmon-agent/internal/state"
 )
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// whatever fn wrote to it. Used to prove a parse error never reaches
+// stdout — only requested help does (see runAuditListCommand's ErrHelp
+// branch and the plan note it implements).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() unexpected error: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return buf.String()
+}
 
 func openTestStore(t *testing.T) *state.Store {
 	t.Helper()
@@ -501,6 +529,222 @@ func TestAuditDeviceColumnReturnsBareIDWhenUnknown(t *testing.T) {
 	// Assert
 	if got != "deadbeefcafefeed" {
 		t.Errorf("auditDeviceColumn() = %q, want the bare id when no device matches", got)
+	}
+}
+
+func TestRunDeviceCommandHelpPrintsUsageWithoutOpeningStore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{"help", "help"},
+		{"-h", "-h"},
+		{"-help", "-help"},
+		{"--help", "--help"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — StateDir is never prepared: a store open would fail
+			// noisily if the help path tried to touch it.
+			cfg := testStateConfig(t)
+
+			// Act
+			err := runDeviceCommand(context.Background(), cfg, []string{tt.arg})
+
+			// Assert
+			if err != nil {
+				t.Fatalf("runDeviceCommand(%q) unexpected error: %v", tt.arg, err)
+			}
+			if _, statErr := os.Stat(cfg.DBPath()); !os.IsNotExist(statErr) {
+				t.Errorf("runDeviceCommand(%q) created a store file at %s, want none for help", tt.arg, cfg.DBPath())
+			}
+			if entries, readErr := os.ReadDir(cfg.StateDir); readErr == nil && len(entries) != 0 {
+				t.Errorf("runDeviceCommand(%q) left %d entries under %s, want an untouched state dir", tt.arg, len(entries), cfg.StateDir)
+			}
+		})
+	}
+}
+
+func TestRunAuditCommandHelpPrintsUsageWithoutOpeningStore(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+
+	// Act
+	err := runAuditCommand(context.Background(), cfg, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runAuditCommand(--help) unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(cfg.DBPath()); !os.IsNotExist(statErr) {
+		t.Errorf("runAuditCommand(--help) created a store file at %s, want none for help", cfg.DBPath())
+	}
+}
+
+func TestRunDeviceRevokeHelpReturnsNilWithoutWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDeviceRevoke(context.Background(), st, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDeviceRevoke(--help) = %v, want nil", err)
+	}
+}
+
+func TestRunDevicePairCodeHelpReturnsNilWithoutWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDevicePairCode(context.Background(), st, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDevicePairCode(--help) = %v, want nil", err)
+	}
+}
+
+func TestRunAuditListCommandHelpReturnsNilWithoutWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runAuditListCommand(context.Background(), st, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runAuditListCommand(--help) = %v, want nil", err)
+	}
+}
+
+// TestRunAuditListCommandBadFlagErrorsWithoutStdoutOutput and its two
+// siblings below deliberately do NOT call t.Parallel(): they redirect the
+// package-level os.Stdout for the duration of the call, which would race
+// with any concurrently running parallel test that also writes to stdout.
+func TestRunAuditListCommandBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+	var err error
+
+	// Act — capture stdout around the call: a genuine parse error must print
+	// nothing there, only the wrapped error (which main sends to stderr).
+	got := captureStdout(t, func() {
+		err = runAuditListCommand(context.Background(), st, []string{"--bogus"})
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runAuditListCommand(--bogus) = nil error, want one for an unknown flag")
+	}
+	if got != "" {
+		t.Errorf("runAuditListCommand(--bogus) wrote %q to stdout, want nothing", got)
+	}
+}
+
+func TestRunDeviceRevokeBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+	var err error
+
+	// Act
+	got := captureStdout(t, func() {
+		err = runDeviceRevoke(context.Background(), st, []string{"--bogus"})
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDeviceRevoke(--bogus) = nil error, want one for an unknown flag")
+	}
+	if got != "" {
+		t.Errorf("runDeviceRevoke(--bogus) wrote %q to stdout, want nothing", got)
+	}
+}
+
+func TestRunDevicePairCodeBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
+	// Arrange — the bad-flag case matters most here: pair-code's stdout is a
+	// pairing code a script may parse, so a flag error must never pollute it.
+	st := openTestStore(t)
+	var err error
+
+	// Act
+	got := captureStdout(t, func() {
+		err = runDevicePairCode(context.Background(), st, []string{"--bogus"})
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDevicePairCode(--bogus) = nil error, want one for an unknown flag")
+	}
+	if got != "" {
+		t.Errorf("runDevicePairCode(--bogus) wrote %q to stdout, want nothing", got)
+	}
+}
+
+func TestIsHelpSubcommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"help literal", "help", true},
+		{"short flag", "-h", true},
+		{"single-dash long flag", "-help", true},
+		{"double-dash long flag", "--help", true},
+		{"real subcommand", subcommandList, false},
+		{"empty string", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := isHelpSubcommand(tt.in)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("isHelpSubcommand(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunDeviceCommandUnknownSubcommandDoesNotOpenStore proves the reordered
+// check pays no SQLite open for a typo'd subcommand: the state dir is left
+// untouched by prepareStateDir's own directories only, no devmon.db appears.
+func TestRunDeviceCommandUnknownSubcommandDoesNotOpenStore(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+	if err := prepareStateDir(cfg); err != nil {
+		t.Fatalf("prepareStateDir() unexpected error: %v", err)
+	}
+
+	// Act
+	if err := runDeviceCommand(context.Background(), cfg, []string{"bogus"}); err == nil {
+		t.Fatal("runDeviceCommand() = nil, want an error for an unknown subcommand")
+	}
+
+	// Assert
+	if _, statErr := os.Stat(cfg.DBPath()); !os.IsNotExist(statErr) {
+		t.Errorf("runDeviceCommand(bogus) created a store file at %s, want none for an unknown subcommand", cfg.DBPath())
 	}
 }
 

--- a/cmd/devmon-agent/health.go
+++ b/cmd/devmon-agent/health.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/scnplt/devmon-agent/internal/config"
@@ -52,6 +53,10 @@ const loopbackHost = "127.0.0.1"
 // second process touching certs/ could race the running agent's own startup
 // exactly as cli.go's comment on runDeviceCommand explains.
 func runHealthCommand(ctx context.Context, cfg config.Config, args []string) error {
+	if helpRequested(args) {
+		printHealthUsage(os.Stdout)
+		return nil
+	}
 	if len(args) != 0 {
 		return fmt.Errorf("health: unexpected argument %q (health takes no arguments)", args[0])
 	}

--- a/cmd/devmon-agent/health_test.go
+++ b/cmd/devmon-agent/health_test.go
@@ -123,3 +123,33 @@ func TestRunHealthCommandRejectsTrailingArgument(t *testing.T) {
 		t.Fatal("runHealthCommand() = nil error, want one for an unexpected trailing argument")
 	}
 }
+
+func TestRunHealthCommandHelpReturnsNilWithoutProbing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{"-h", "-h"},
+		{"-help", "-help"},
+		{"--help", "--help"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — an unresolvable listen address proves probeStatus was
+			// never reached: a real probe attempt would return an error.
+			cfg := config.Config{ListenAddr: "not-a-host-port"}
+
+			// Act
+			err := runHealthCommand(context.Background(), cfg, []string{tt.arg})
+
+			// Assert
+			if err != nil {
+				t.Fatalf("runHealthCommand(%q) = %v, want nil", tt.arg, err)
+			}
+		})
+	}
+}

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -24,8 +25,9 @@ import (
 	"github.com/scnplt/devmon-agent/internal/version"
 )
 
-// Exit codes. 2 is reserved for configuration faults so an operator (or an
-// installer script) can tell "you typed something wrong" apart from "it broke".
+// Exit codes. 2 is reserved for configuration faults and CLI usage mistakes
+// so an operator (or an installer script) can tell "you typed something
+// wrong" apart from "it broke".
 const (
 	exitOK      = 0
 	exitFailure = 1
@@ -35,14 +37,35 @@ const (
 // stateDirMode keeps the state directory owner-only; it holds the key material.
 const stateDirMode = 0o700
 
+// usageError is returned for a CLI mistake that a config.ValidationError
+// cannot represent — an unknown command or a bad global flag. main() maps it
+// to exitConfig, the same code as a configuration fault, since both mean
+// "you typed something wrong" rather than "the agent broke".
+type usageError struct {
+	msg string
+}
+
+func (e *usageError) Error() string { return e.msg }
+
+// unknownCommandHint is appended to the unknown-command error so it is
+// visible on stderr even though the full root usage screen is not — an
+// unknown command is a mistake, not a help request, and only requested help
+// goes to stdout.
+const unknownCommandHint = "Run 'devmon help' for usage."
+
 // main does nothing but map run's error to an exit code. os.Exit skips deferred
 // calls, so any defer placed here would silently never run — including the log
 // flush.
 func main() {
-	if err := run(); err != nil {
+	if err := run(os.Args, os.Getenv, os.Stdout, os.Stderr); err != nil {
 		var vErr *config.ValidationError
 		if errors.As(err, &vErr) {
 			fmt.Fprintln(os.Stderr, vErr.Error())
+			os.Exit(exitConfig)
+		}
+		var uErr *usageError
+		if errors.As(err, &uErr) {
+			fmt.Fprintln(os.Stderr, uErr.Error())
 			os.Exit(exitConfig)
 		}
 		fmt.Fprintf(os.Stderr, "devmon-agent: %v\n", err)
@@ -51,19 +74,60 @@ func main() {
 	os.Exit(exitOK)
 }
 
-func run() error {
-	showVersion := flag.Bool("version", false, "print version information and exit")
-	flag.Parse()
+// run holds every path through the binary: the operator CLI (device, audit,
+// health, help) and the daemon path (container ENTRYPOINT). argv, getenv,
+// stdout, and stderr are injected so tests can exercise it without touching
+// the process's real os.Args, environment, or standard streams.
+//
+// Every help path below returns before config.Load is reached — a `--help`
+// invocation must not require DEVMON_PUBLIC_ADDR or any other env var, and
+// must never open the SQLite state store.
+func run(argv []string, getenv func(string) string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("devmon-agent", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { printRootUsage(stderr) }
+	showVersion := fs.Bool("version", false, "print version information and exit")
+
+	if err := fs.Parse(argv[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRootUsage(stdout)
+			return nil
+		}
+		return &usageError{msg: err.Error()}
+	}
+
 	if *showVersion {
-		fmt.Printf("devmon-agent %s (commit %s, built %s)\n",
+		_, _ = fmt.Fprintf(stdout, "devmon-agent %s (commit %s, built %s)\n",
 			version.Version, version.Commit, version.BuildTime)
 		return nil
+	}
+
+	cmd := fs.Arg(0)
+	rest := fs.Args()[min(1, fs.NArg()):]
+
+	switch {
+	case cmd == "help":
+		printRootUsage(stdout)
+		return nil
+	case cmd == "" && isDevmonAlias(argv[0]):
+		printRootUsage(stdout)
+		return nil
+	case cmd == "":
+		// No subcommand under the devmon-agent name: this is the container
+		// ENTRYPOINT starting the daemon, unchanged.
+	case (cmd == "device" || cmd == "audit" || cmd == "health") && helpRequested(rest):
+		printCommandUsage(stdout, cmd)
+		return nil
+	case cmd == "device" || cmd == "audit" || cmd == "health":
+		// Handled below, after config.Load.
+	default:
+		return &usageError{msg: fmt.Sprintf("unknown command %q\n%s", cmd, unknownCommandHint)}
 	}
 
 	// Configuration is read and validated before the log sink exists, so a bad
 	// docker run line lands on stderr as plain readable text rather than as
 	// structured slog lines an operator has to squint at.
-	cfg, err := config.Load(os.Getenv)
+	cfg, err := config.Load(getenv)
 	if err != nil {
 		return err
 	}
@@ -73,8 +137,8 @@ func run() error {
 	// or touch certs/ — see cli.go for why. It is dispatched before the
 	// server path so it never triggers state-dir prep, log-sink construction,
 	// or certificate loading meant only for the long-running agent.
-	if flag.Arg(0) == "device" {
-		return runDeviceCommand(context.Background(), cfg, flag.Args()[1:])
+	if cmd == "device" {
+		return runDeviceCommand(context.Background(), cfg, rest)
 	}
 
 	// The `audit list` CLI (D19) is the audit trail's only reader — it is
@@ -82,8 +146,8 @@ func run() error {
 	// for the same reason as `device`: it must never trigger state-dir prep,
 	// log-sink construction, or certificate loading meant only for the
 	// long-running agent.
-	if flag.Arg(0) == "audit" {
-		return runAuditCommand(context.Background(), cfg, flag.Args()[1:])
+	if cmd == "audit" {
+		return runAuditCommand(context.Background(), cfg, rest)
 	}
 
 	// `health` (issue #56) backs the Dockerfile's HEALTHCHECK. It is
@@ -91,8 +155,8 @@ func run() error {
 	// never trigger state-dir prep, log-sink construction, or certificate
 	// loading meant only for the long-running agent — and doubly so here,
 	// since Docker invokes it every 30 seconds for the life of the container.
-	if flag.Arg(0) == "health" {
-		return runHealthCommand(context.Background(), cfg, flag.Args()[1:])
+	if cmd == "health" {
+		return runHealthCommand(context.Background(), cfg, rest)
 	}
 
 	if err := prepareStateDir(cfg); err != nil {
@@ -112,6 +176,20 @@ func run() error {
 	defer stop()
 
 	return serve(ctx, cfg, sink, log)
+}
+
+// printCommandUsage prints the per-command usage screen for one of
+// "device", "audit", or "health". It is only ever called with those three
+// values, guarded by the switch in run.
+func printCommandUsage(w io.Writer, cmd string) {
+	switch cmd {
+	case "device":
+		printDeviceUsage(w)
+	case "audit":
+		printAuditUsage(w)
+	case "health":
+		printHealthUsage(w)
+	}
 }
 
 // prepareStateDir creates the bind-mounted layout. A failure here is almost

--- a/cmd/devmon-agent/run_test.go
+++ b/cmd/devmon-agent/run_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestRunPrintsRootUsage(t *testing.T) {
 		argv []string
 	}{
 		{name: "devmon with no args", argv: []string{"devmon"}},
-		{name: "devmon.exe path with no args", argv: []string{`C:\x\devmon.exe`}},
+		{name: "devmon.exe with no args", argv: []string{filepath.Join("x", "devmon.exe")}},
 		{name: "devmon-agent help", argv: []string{"devmon-agent", "help"}},
 		{name: "devmon-agent -h", argv: []string{"devmon-agent", "-h"}},
 		{name: "devmon-agent -help", argv: []string{"devmon-agent", "-help"}},
@@ -161,7 +162,7 @@ func TestIsDevmonAlias(t *testing.T) {
 	}{
 		{name: "bare name", argv0: "devmon", want: true},
 		{name: "unix path", argv0: "/usr/local/bin/devmon", want: true},
-		{name: "windows path with .exe", argv0: `C:\x\devmon.exe`, want: true},
+		{name: "path with .exe", argv0: filepath.Join("x", "devmon.exe"), want: true},
 		{name: "mixed case", argv0: "DevMon", want: true},
 		{name: "devmon-agent is not the alias", argv0: "devmon-agent", want: false},
 		{name: "unrelated name", argv0: "bash", want: false},

--- a/cmd/devmon-agent/run_test.go
+++ b/cmd/devmon-agent/run_test.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+)
+
+// emptyEnv is a getenv that answers every lookup with "". Passing it into
+// run() proves a help path never reaches config.Load — if it did, the
+// missing required variables would surface as a *config.ValidationError
+// instead of the expected nil.
+func emptyEnv(string) string { return "" }
+
+func TestRunPrintsRootUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		argv []string
+	}{
+		{name: "devmon with no args", argv: []string{"devmon"}},
+		{name: "devmon.exe path with no args", argv: []string{`C:\x\devmon.exe`}},
+		{name: "devmon-agent help", argv: []string{"devmon-agent", "help"}},
+		{name: "devmon-agent -h", argv: []string{"devmon-agent", "-h"}},
+		{name: "devmon-agent -help", argv: []string{"devmon-agent", "-help"}},
+		{name: "devmon-agent --help", argv: []string{"devmon-agent", "--help"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			var stdout, stderr bytes.Buffer
+
+			// Act
+			err := run(tt.argv, emptyEnv, &stdout, &stderr)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("run() = %v, want nil", err)
+			}
+			if stdout.String() != rootUsage {
+				t.Errorf("stdout = %q, want root usage", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunPrintsPerCommandUsageWithoutLoadingConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{name: "device --help", argv: []string{"devmon-agent", "device", "--help"}, want: deviceUsage},
+		{name: "device pair-code --help", argv: []string{"devmon-agent", "device", "pair-code", "--help"}, want: deviceUsage},
+		{name: "audit --help", argv: []string{"devmon-agent", "audit", "--help"}, want: auditUsage},
+		{name: "health --help", argv: []string{"devmon-agent", "health", "--help"}, want: healthUsage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — empty env: if run() reached config.Load, this would
+			// fail validation and return a *config.ValidationError instead
+			// of nil, so a nil result here is itself proof config was never
+			// loaded.
+			var stdout, stderr bytes.Buffer
+
+			// Act
+			err := run(tt.argv, emptyEnv, &stdout, &stderr)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("run() = %v, want nil", err)
+			}
+			if stdout.String() != tt.want {
+				t.Errorf("stdout = %q, want %q", stdout.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRunVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	var stdout, stderr bytes.Buffer
+
+	// Act
+	err := run([]string{"devmon-agent", "--version"}, emptyEnv, &stdout, &stderr)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("run() = %v, want nil", err)
+	}
+	if !strings.HasPrefix(stdout.String(), "devmon-agent ") {
+		t.Errorf("stdout = %q, want it to start with the version string", stdout.String())
+	}
+}
+
+func TestRunUnknownCommandIsAUsageError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	var stdout, stderr bytes.Buffer
+
+	// Act
+	err := run([]string{"devmon-agent", "bogus"}, emptyEnv, &stdout, &stderr)
+
+	// Assert
+	var uErr *usageError
+	if !errors.As(err, &uErr) {
+		t.Fatalf("run() error = %v (%T), want *usageError", err, err)
+	}
+	if !strings.Contains(uErr.Error(), `unknown command "bogus"`) {
+		t.Errorf("usageError message = %q, want it to name the unknown command", uErr.Error())
+	}
+	if !strings.Contains(uErr.Error(), unknownCommandHint) {
+		t.Errorf("usageError message = %q, want the %q hint", uErr.Error(), unknownCommandHint)
+	}
+}
+
+func TestRunWithNoArgsUnderDevmonAgentNameReachesDaemonPath(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — devmon-agent with no subcommand and no args is the daemon
+	// path (container ENTRYPOINT). With an empty environment, config.Load
+	// fails validation before anything is constructed, which is exactly the
+	// proof this test wants: the daemon path was reached, not skipped as a
+	// help screen would skip it, and nothing beyond config.Load ran.
+	var stdout, stderr bytes.Buffer
+
+	// Act
+	err := run([]string{"devmon-agent"}, emptyEnv, &stdout, &stderr)
+
+	// Assert
+	var vErr *config.ValidationError
+	if !errors.As(err, &vErr) {
+		t.Fatalf("run() error = %v (%T), want *config.ValidationError", err, err)
+	}
+}
+
+func TestIsDevmonAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		argv0 string
+		want  bool
+	}{
+		{name: "bare name", argv0: "devmon", want: true},
+		{name: "unix path", argv0: "/usr/local/bin/devmon", want: true},
+		{name: "windows path with .exe", argv0: `C:\x\devmon.exe`, want: true},
+		{name: "mixed case", argv0: "DevMon", want: true},
+		{name: "devmon-agent is not the alias", argv0: "devmon-agent", want: false},
+		{name: "unrelated name", argv0: "bash", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isDevmonAlias(tt.argv0); got != tt.want {
+				t.Errorf("isDevmonAlias(%q) = %v, want %v", tt.argv0, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelpRequested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty", args: nil, want: false},
+		{name: "no help flag", args: []string{"list"}, want: false},
+		{name: "-h", args: []string{"-h"}, want: true},
+		{name: "-help", args: []string{"-help"}, want: true},
+		{name: "--help", args: []string{"--help"}, want: true},
+		{name: "help flag not first", args: []string{"revoke", "some-id", "--help"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := helpRequested(tt.args); got != tt.want {
+				t.Errorf("helpRequested(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/devmon-agent/usage.go
+++ b/cmd/devmon-agent/usage.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// devmonAliasName is the symlink name the Dockerfile installs alongside the
+// real binary (`ln -s devmon-agent devmon`), so an operator can run
+// `docker exec devmon-agent devmon` instead of the full binary path.
+const devmonAliasName = "devmon"
+
+// rootUsage is shown for `devmon` with no args, `devmon help`,
+// `-h`/`-help`/`--help`, and any invocation under the `devmon` alias name. It
+// must stay verbatim in sync with the plan's help screen — operators run this
+// via `docker exec` and it is the only discovery mechanism the image offers.
+const rootUsage = `DevMon agent — mTLS-authenticated Docker control agent.
+
+Usage:
+  devmon <command> [flags]   operator CLI (docker exec devmon-agent devmon ...)
+  devmon-agent               run the agent daemon (container entrypoint)
+
+Commands:
+  device list                     list paired devices
+  device revoke <id>              revoke a device's access
+  device pair-code --name <name>  mint a single-use pairing code
+  audit list [--limit N]          print recent audit entries (default 100)
+  health                          probe the running agent's listener
+  help                            show this help
+
+Flags:
+  --version   print version information and exit
+
+Run 'devmon <command> --help' for details on a command.
+`
+
+// deviceUsage is shown for `device --help` and for `--help` on any of its
+// three subcommands — a single screen instead of six near-identical ones,
+// since `--help` is detected before the subcommand itself is dispatched.
+const deviceUsage = `Usage: devmon device <subcommand> [flags]
+
+Subcommands:
+  list                     list paired devices
+  revoke <id>              revoke a device's access
+  pair-code --name <name>  mint a single-use pairing code
+`
+
+// auditUsage is shown for `audit --help`.
+const auditUsage = `Usage: devmon audit list [--limit N]
+
+--limit N   maximum number of audit rows to print, most recent first (default 100)
+`
+
+// healthUsage is shown for `health --help`. health takes no arguments — it
+// backs the Dockerfile's HEALTHCHECK, which invokes it on a fixed 30-second
+// interval for the life of the container.
+const healthUsage = `Usage: devmon health
+
+Probes the running agent's own listener and exits 0 if healthy, 1 otherwise.
+Takes no arguments. This is what the image's HEALTHCHECK runs.
+`
+
+// printRootUsage writes rootUsage to w. A write failure here is not
+// actionable — w is stdout or stderr — so it is intentionally ignored, as
+// the other usage printers below also do.
+func printRootUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, rootUsage)
+}
+
+// printDeviceUsage writes deviceUsage to w.
+func printDeviceUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, deviceUsage)
+}
+
+// printAuditUsage writes auditUsage to w.
+func printAuditUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, auditUsage)
+}
+
+// printHealthUsage writes healthUsage to w.
+func printHealthUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, healthUsage)
+}
+
+// isDevmonAlias reports whether argv0 — typically os.Args[0] — is an
+// invocation of the `devmon` symlink the Dockerfile installs next to the real
+// binary, rather than devmon-agent itself. A no-args run under that name
+// shows help instead of starting the daemon, since `devmon` (unlike
+// `devmon-agent`) is never the container's ENTRYPOINT.
+func isDevmonAlias(argv0 string) bool {
+	base := strings.ToLower(filepath.Base(argv0))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == devmonAliasName
+}
+
+// helpRequested reports whether any of args asks for help. It scans every
+// remaining argument rather than only args[0], so `device revoke --help`
+// shows the device usage screen instead of treating "--help" as a device id
+// — "--help" was never a valid id.
+func helpRequested(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "-h", "-help", "--help":
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- `docker exec devmon-agent devmon` (no args) now prints a one-screen help listing every operator command; the same screen backs `help`, `-h`, `-help`, and `--help`.
- Per-command help: `devmon device --help`, `devmon audit list --help`, `devmon health --help` print concise usage, exit 0, and never require `DEVMON_*` env vars or open the SQLite store.
- The image ships a `devmon` symlink next to the binary (relative link, directory COPY — no size cost); `main.go` dispatches on argv[0], so `devmon-agent` with no args still starts the daemon (ENTRYPOINT unchanged).
- Bug fix: an unknown command previously started the daemon silently; it now fails with exit 2 and `Run 'devmon help' for usage.` on stderr.
- `run()` refactored to take injected argv/env/streams, making all dispatch paths unit-testable; flag errors stay on stderr, requested help goes to stdout.
- README examples switched to the short `devmon` form; the absolute-path long form still works.

## Test plan

- [x] `gofmt`, `go vet`, `golangci-lint`, `gosec` clean; `go test ./... -race` green; coverage 93.8% (floor 90%)
- [x] `docker build` and in-image checks: `devmon` → help exit 0; `devmon device --help` / `audit list --help` / `health --help` → exit 0 without env; `devmon bogus` → exit 2 with hint; `--version` exit 0
- [x] Daemon path unchanged: bare `devmon-agent` still reaches `config.Load` (exit 2 without env, serves with env); HEALTHCHECK untouched
- [x] `device list` / `audit list` table output byte-identical (e2e harness parser unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)