### PR TITLE
docs: document image_id in ContainerDetail spec and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ changes nothing about the agent's behaviour, but this is an open repository and
 a contributor reading the history should not have to reconstruct why the build
 moved.
 
+## [Unreleased]
+
+### Fixed
+
+- **`GET /v1/containers/{id}` now reports `image` and `image_id` consistently
+  with the container list.** The detail response previously returned the
+  Engine's digest-prefixed image ID in the `image` field. `image` now carries
+  the image reference the container was created from (as in the list route),
+  and a new `image_id` field carries the digest-prefixed ID. Clients reading
+  the digest out of `image` should switch to `image_id`. ([#120])
+
 ## [0.4.0] - 2026-08-26
 
 A feature release. The agent gains `GET /v1/events/stream`, a live feed of
@@ -421,6 +432,10 @@ First public release — the full surface.
   writing a `compose.yaml`, and waiting for the agent to answer.
 - **Multi-arch image.** `linux/amd64` and `linux/arm64`.
 
+[#120]: https://github.com/scnplt/devmon-agent/issues/120
+
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/scnplt/devmon-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scnplt/devmon-agent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scnplt/devmon-agent/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/scnplt/devmon-agent/compare/v0.1.1...v0.1.2

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1219,12 +1219,21 @@ components:
         The full projection of one container. No environment variables, at any
         level, and no raw Engine payload.
       required:
-        [id, name, image, created_at, state, running, paused, restarting, exit_code,
-         restart_count, platform, labels, command, args, mounts, networks, ports, protected]
+        [id, name, image, image_id, created_at, state, running, paused, restarting,
+         exit_code, restart_count, platform, labels, command, args, mounts, networks,
+         ports, protected]
       properties:
         id: { type: string }
         name: { type: string }
-        image: { type: string }
+        image:
+          type: string
+          description: The image reference the container was created from, as in ContainerSummary.
+        image_id:
+          type: string
+          description: |
+            The Engine's image ID, digest-prefixed (`sha256:…`), as in
+            ImageSummary. `GET /v1/images/{id}` rejects a `:`, so strip the
+            prefix before inspecting it.
         created_at: { type: string, format: date-time }
         state:
           type: string


### PR DESCRIPTION
## Summary

PR #121 (issue #120) added `image_id` to the container detail response and changed `image` to carry the reference from `Config.Image` instead of the digest-prefixed ID, but the docs did not follow:

- **docs/openapi.yaml** — the `ContainerDetail` schema now declares `image_id` (digest-prefixed, as in `ImageSummary`), adds it to the `required` list, and documents the new `image` semantics (the reference the container was created from, as in `ContainerSummary`).
- **CHANGELOG.md** — adds an `Unreleased` entry for the client-visible field change (commit dd33c8b is in no release tag yet), plus the previously missing `[Unreleased]` and `[0.4.0]` link definitions.

No code changes.

Refs #120

## Test plan

- [x] `docs/openapi.yaml` still parses as valid YAML
- [x] `ContainerDetail` spec now matches the 26-field struct in `internal/dockerx/types.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)