### PR TITLE
chore: prepare the 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,46 @@ moved.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-27
+
+A feature release. The agent binary gains an operator CLI surface: the image
+ships a `devmon` alias next to the binary, so `docker exec devmon-agent devmon
+help` (and `device`, `audit`, `health` with `--help`) work without a shell in
+the container, and unknown commands fail fast instead of starting a second
+daemon.
+
+The configuration surface is unchanged: every `DEVMON_*` variable means in
+0.5.0 exactly what it meant in 0.4.0, and no variable was added or removed.
+One response field changed meaning — `image` in the container detail route,
+see *Fixed* below.
+
+### Added
+
+- **A `devmon` alias in the image, for `docker exec`.** `/usr/local/bin`
+  carries a relative `devmon` symlink next to the binary, so
+  `docker exec devmon-agent devmon <command>` resolves on the distroless
+  PATH without a shell. `ENTRYPOINT` and `HEALTHCHECK` are unchanged.
+  ([#123](https://github.com/scnplt/devmon-agent/pull/123))
+- **Operator CLI help.** Running the binary under the `devmon` name with no
+  arguments, or with `help`/`-h`/`--help`, prints a one-screen usage listing
+  of all operator commands. `device`, `audit` and `health` accept
+  `-h`/`--help` without requiring any `DEVMON_*` variables and without
+  opening the store; subcommand help lands on stdout and exits 0. Unknown
+  commands now fail with exit 2 and a usage hint instead of silently starting
+  the daemon.
+  ([#124](https://github.com/scnplt/devmon-agent/pull/124))
+
 ### Fixed
 
+- **A graceful shutdown is no longer pinned for the full drain grace by a
+  connection that never sent a request.** A connection that completed its TLS
+  handshake but sent nothing sits in `http.StateNew`, carries no request
+  context for the lifecycle cancellation to reach, and kept
+  `http.Server.Shutdown` waiting for the whole 5-second grace window. Such
+  connections are now tracked and closed directly when shutdown begins.
+  Slowloris protection during normal serving is unchanged.
+  ([#122](https://github.com/scnplt/devmon-agent/pull/122), refs
+  [#117](https://github.com/scnplt/devmon-agent/issues/117))
 - **`GET /v1/containers/{id}` now reports `image` and `image_id` consistently
   with the container list.** The detail response previously returned the
   Engine's digest-prefixed image ID in the `image` field. `image` now carries
@@ -434,7 +472,8 @@ First public release — the full surface.
 
 [#120]: https://github.com/scnplt/devmon-agent/issues/120
 
-[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/scnplt/devmon-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scnplt/devmon-agent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scnplt/devmon-agent/compare/v0.1.2...v0.2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.4.0 — live container health events.** The agent is its own certificate
+**Status: 0.5.0 — an operator CLI via `docker exec devmon`.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -75,7 +75,7 @@ docker run -d --name devmon-agent \
   --read-only --tmpfs /tmp \
   --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.4.0
+  ghcr.io/scnplt/devmon-agent:0.5.0
 ```
 
 The four hardening flags are not needed to run the agent and none of them
@@ -99,7 +99,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.4.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.5.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -37,7 +37,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.4.0
+    image: ghcr.io/scnplt/devmon-agent:0.5.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.4.0
+  version: 0.5.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -123,7 +123,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.4.0
+                    agent_version: 0.5.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -975,7 +975,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.4.0"]
+          examples: ["0.5.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.4.0'
+IMAGE_TAG='0.5.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
Release prep for **0.5.0**, mirroring #118: changelog entry and version pins. After this merges, the `dev` -> `main` release PR follows.

## What's in here

- **CHANGELOG.md** — rolls Unreleased into `## [0.5.0] - 2026-08-27`, and adds the entries the feature PRs did not record:
  - *Added*: the `devmon` exec alias in the image (#123) and the operator CLI help surface, including the unknown-command exit-2 behaviour change (#124)
  - *Fixed*: shutdown no longer pinned by request-less `StateNew` connections (#122, refs #117) — alongside the already-recorded `image_id` detail fix (#121)
- **Version pins 0.4.0 -> 0.5.0** — README status line and examples, `install.sh` `IMAGE_TAG`, `compose.example.yaml`, and the OpenAPI info block with its two `agent_version` examples.

0.5.0 rather than 0.4.1: the operator CLI is a new caller-visible capability. No `DEVMON_*` variable changed.

## Test plan

- [x] `make openapi-lint` — valid
- [x] `make doc-citations` — all citations resolve
- [x] No `0.4.0` pin remains outside the changelog history
- [ ] CI green (shellcheck runs there; not installed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)