### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ changes nothing about the agent's behaviour, but this is an open repository and
 a contributor reading the history should not have to reconstruct why the build
 moved.
 
+## [Unreleased]
+
+### Fixed
+
+- **`GET /v1/containers/{id}` now reports `image` and `image_id` consistently
+  with the container list.** The detail response previously returned the
+  Engine's digest-prefixed image ID in the `image` field. `image` now carries
+  the image reference the container was created from (as in the list route),
+  and a new `image_id` field carries the digest-prefixed ID. Clients reading
+  the digest out of `image` should switch to `image_id`. ([#120])
+
 ## [0.4.0] - 2026-08-26
 
 A feature release. The agent gains `GET /v1/events/stream`, a live feed of
@@ -421,6 +432,10 @@ First public release — the full surface.
   writing a `compose.yaml`, and waiting for the agent to answer.
 - **Multi-arch image.** `linux/amd64` and `linux/arm64`.
 
+[#120]: https://github.com/scnplt/devmon-agent/issues/120
+
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/scnplt/devmon-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scnplt/devmon-agent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scnplt/devmon-agent/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/scnplt/devmon-agent/compare/v0.1.1...v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,46 @@ moved.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-27
+
+A feature release. The agent binary gains an operator CLI surface: the image
+ships a `devmon` alias next to the binary, so `docker exec devmon-agent devmon
+help` (and `device`, `audit`, `health` with `--help`) work without a shell in
+the container, and unknown commands fail fast instead of starting a second
+daemon.
+
+The configuration surface is unchanged: every `DEVMON_*` variable means in
+0.5.0 exactly what it meant in 0.4.0, and no variable was added or removed.
+One response field changed meaning — `image` in the container detail route,
+see *Fixed* below.
+
+### Added
+
+- **A `devmon` alias in the image, for `docker exec`.** `/usr/local/bin`
+  carries a relative `devmon` symlink next to the binary, so
+  `docker exec devmon-agent devmon <command>` resolves on the distroless
+  PATH without a shell. `ENTRYPOINT` and `HEALTHCHECK` are unchanged.
+  ([#123](https://github.com/scnplt/devmon-agent/pull/123))
+- **Operator CLI help.** Running the binary under the `devmon` name with no
+  arguments, or with `help`/`-h`/`--help`, prints a one-screen usage listing
+  of all operator commands. `device`, `audit` and `health` accept
+  `-h`/`--help` without requiring any `DEVMON_*` variables and without
+  opening the store; subcommand help lands on stdout and exits 0. Unknown
+  commands now fail with exit 2 and a usage hint instead of silently starting
+  the daemon.
+  ([#124](https://github.com/scnplt/devmon-agent/pull/124))
+
 ### Fixed
 
+- **A graceful shutdown is no longer pinned for the full drain grace by a
+  connection that never sent a request.** A connection that completed its TLS
+  handshake but sent nothing sits in `http.StateNew`, carries no request
+  context for the lifecycle cancellation to reach, and kept
+  `http.Server.Shutdown` waiting for the whole 5-second grace window. Such
+  connections are now tracked and closed directly when shutdown begins.
+  Slowloris protection during normal serving is unchanged.
+  ([#122](https://github.com/scnplt/devmon-agent/pull/122), refs
+  [#117](https://github.com/scnplt/devmon-agent/issues/117))
 - **`GET /v1/containers/{id}` now reports `image` and `image_id` consistently
   with the container list.** The detail response previously returned the
   Engine's digest-prefixed image ID in the `image` field. `image` now carries
@@ -434,7 +472,8 @@ First public release — the full surface.
 
 [#120]: https://github.com/scnplt/devmon-agent/issues/120
 
-[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/scnplt/devmon-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scnplt/devmon-agent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scnplt/devmon-agent/compare/v0.1.2...v0.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,21 @@ ARG BUILD_TIME=unknown
 # it run on distroless/static. With cgo left on, the binary links against musl
 # and distroless reports "no such file or directory" for a file that plainly
 # exists, which is a genuinely confusing way to spend an afternoon.
+#
+# The `devmon` symlink is the operator-CLI alias: distroless has no shell and
+# no ln, so the link must be created here and carried over by a *directory*
+# COPY (a single-file COPY would dereference it into a second full copy of the
+# binary). The relative target keeps the link valid wherever the directory
+# lands. main.go dispatches on argv[0]: under the `devmon` name a bare
+# invocation prints help instead of starting the daemon.
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
     -ldflags "-s -w \
       -X github.com/scnplt/devmon-agent/internal/version.Version=${VERSION} \
       -X github.com/scnplt/devmon-agent/internal/version.Commit=${COMMIT} \
       -X github.com/scnplt/devmon-agent/internal/version.BuildTime=${BUILD_TIME}" \
-    -o /out/devmon-agent ./cmd/devmon-agent
+    -o /out/bin/devmon-agent ./cmd/devmon-agent \
+ && ln -s devmon-agent /out/bin/devmon
 
 # The default DEVMON_STATE_DIR (internal/config/config.go), staged here so the
 # final stage can COPY it in with the right owner. distroless has no shell, so
@@ -47,7 +55,11 @@ RUN mkdir -m 0700 -p /out/state
 # distroless/static already carries a bundle if a later phase needs one.
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
 
-COPY --from=build /out/devmon-agent /usr/local/bin/devmon-agent
+# Directory COPY, deliberately: it preserves the `devmon` symlink next to the
+# binary, so `docker exec devmon-agent devmon ...` resolves via the image PATH
+# (/usr/local/bin is on distroless's default PATH) at the cost of a symlink,
+# not a second copy of the binary.
+COPY --from=build /out/bin/ /usr/local/bin/
 
 # Pre-created and owned by the nonroot UID. UID 65532 cannot MkdirAll under a
 # root-owned /var, so without this a bare `docker run` with no bind mount dies

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
       -X github.com/scnplt/devmon-agent/internal/version.BuildTime=${BUILD_TIME}" \
     -o /out/devmon-agent ./cmd/devmon-agent
 
+# `devmon` is the documented short name for docker exec (`docker exec <name>
+# devmon device list`). It has to be staged as a symlink inside a directory:
+# COPY of a single symlink dereferences it, which would duplicate the whole
+# binary in the final layer, while symlinks inside a copied directory are
+# preserved. The link target is relative so it resolves at /usr/local/bin too.
+RUN mkdir -p /out/bin \
+    && cp /out/devmon-agent /out/bin/devmon-agent \
+    && ln -s devmon-agent /out/bin/devmon
+
 # The default DEVMON_STATE_DIR (internal/config/config.go), staged here so the
 # final stage can COPY it in with the right owner. distroless has no shell, so
 # `RUN mkdir` is not available there and this is the only way to put a directory
@@ -47,7 +56,7 @@ RUN mkdir -m 0700 -p /out/state
 # distroless/static already carries a bundle if a later phase needs one.
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
 
-COPY --from=build /out/devmon-agent /usr/local/bin/devmon-agent
+COPY --from=build /out/bin/ /usr/local/bin/
 
 # Pre-created and owned by the nonroot UID. UID 65532 cannot MkdirAll under a
 # root-owned /var, so without this a bare `docker run` with no bind mount dies

--- a/README.md
+++ b/README.md
@@ -716,8 +716,7 @@ in transit or at rest anywhere but on the device that owns it.
 ### 1. Mint a code on the host
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent \
-  device pair-code --name "pixel-8"
+docker exec devmon-agent devmon device pair-code --name "pixel-8"
 # Pairing code: B4HJFH3KEAZ2QMY546LLN3IDOW
 # Expires:      2026-08-07T20:12:00Z
 ```
@@ -791,11 +790,17 @@ cannot lock a device out.
 
 These run against the same state directory the agent is using. The image is
 `distroless/static:nonroot` — no shell, no second binary — so the host CLI is
-subcommands on the agent binary itself:
+subcommands on the agent binary itself, reachable through the `devmon` alias
+(a symlink the image ships next to the binary):
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
+docker exec devmon-agent devmon device <subcommand>
 ```
+
+`docker exec devmon-agent devmon` on its own (or `devmon help`, or
+`devmon <command> --help`) prints a usage screen listing every command. The
+long form `docker exec devmon-agent /usr/local/bin/devmon-agent …` still works
+— `devmon` is the same binary under a different name.
 
 | Subcommand | Effect |
 |---|---|
@@ -804,11 +809,11 @@ docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
 | `device revoke <id>` | Withdraw a device's access, effective immediately |
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device list
+$ docker exec devmon-agent devmon device list
 ID                NAME     PAIRED                LAST SEEN             STATE
 3f9a1c74b2e05d68  pixel-8  2026-08-07T20:02:00Z  2026-08-07T21:14:33Z  active
 
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device revoke 3f9a1c74b2e05d68
+$ docker exec devmon-agent devmon device revoke 3f9a1c74b2e05d68
 revoked 3f9a1c74b2e05d68 (pixel-8)
 ```
 
@@ -843,7 +848,7 @@ alone only reacts to the process exiting; this also catches a listener that is
 up but no longer answering.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent health
+$ docker exec devmon-agent devmon health
 healthy: GET /v1/status returned 200
 
 $ docker inspect -f '{{.State.Health.Status}}' devmon-agent
@@ -871,7 +876,7 @@ a row per list refresh would drown the record the log exists for and then push
 the destructive-operation history out under retention.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent audit list --limit 5
+$ docker exec devmon-agent devmon audit list --limit 5
 WHEN                  DEVICE            OPERATION  TARGET  OUTCOME        DETAIL
 2026-08-08T21:06:40Z  3f9a1c… (pixel-8) delete     devmon  denied_self
 2026-08-08T21:05:02Z  3f9a1c… (pixel-8) kill       api     denied_policy

--- a/README.md
+++ b/README.md
@@ -716,8 +716,7 @@ in transit or at rest anywhere but on the device that owns it.
 ### 1. Mint a code on the host
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent \
-  device pair-code --name "pixel-8"
+docker exec devmon-agent devmon device pair-code --name "pixel-8"
 # Pairing code: B4HJFH3KEAZ2QMY546LLN3IDOW
 # Expires:      2026-08-07T20:12:00Z
 ```
@@ -791,10 +790,12 @@ cannot lock a device out.
 
 These run against the same state directory the agent is using. The image is
 `distroless/static:nonroot` — no shell, no second binary — so the host CLI is
-subcommands on the agent binary itself:
+subcommands on the agent binary itself. `devmon` is a symlink to
+`/usr/local/bin/devmon-agent`, so the full path and the `devmon-agent` name
+work just as well:
 
 ```bash
-docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
+docker exec devmon-agent devmon device <subcommand>
 ```
 
 | Subcommand | Effect |
@@ -804,11 +805,11 @@ docker exec devmon-agent /usr/local/bin/devmon-agent device <subcommand>
 | `device revoke <id>` | Withdraw a device's access, effective immediately |
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device list
+$ docker exec devmon-agent devmon device list
 ID                NAME     PAIRED                LAST SEEN             STATE
 3f9a1c74b2e05d68  pixel-8  2026-08-07T20:02:00Z  2026-08-07T21:14:33Z  active
 
-$ docker exec devmon-agent /usr/local/bin/devmon-agent device revoke 3f9a1c74b2e05d68
+$ docker exec devmon-agent devmon device revoke 3f9a1c74b2e05d68
 revoked 3f9a1c74b2e05d68 (pixel-8)
 ```
 
@@ -843,7 +844,7 @@ alone only reacts to the process exiting; this also catches a listener that is
 up but no longer answering.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent health
+$ docker exec devmon-agent devmon health
 healthy: GET /v1/status returned 200
 
 $ docker inspect -f '{{.State.Health.Status}}' devmon-agent
@@ -871,7 +872,7 @@ a row per list refresh would drown the record the log exists for and then push
 the destructive-operation history out under retention.
 
 ```bash
-$ docker exec devmon-agent /usr/local/bin/devmon-agent audit list --limit 5
+$ docker exec devmon-agent devmon audit list --limit 5
 WHEN                  DEVICE            OPERATION  TARGET  OUTCOME        DETAIL
 2026-08-08T21:06:40Z  3f9a1c… (pixel-8) delete     devmon  denied_self
 2026-08-08T21:05:02Z  3f9a1c… (pixel-8) kill       api     denied_policy

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.4.0 — live container health events.** The agent is its own certificate
+**Status: 0.5.0 — an operator CLI via `docker exec devmon`.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -75,7 +75,7 @@ docker run -d --name devmon-agent \
   --read-only --tmpfs /tmp \
   --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.4.0
+  ghcr.io/scnplt/devmon-agent:0.5.0
 ```
 
 The four hardening flags are not needed to run the agent and none of them
@@ -99,7 +99,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.4.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.5.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -73,6 +74,20 @@ func runDeviceCommand(ctx context.Context, cfg config.Config, args []string) err
 		return fmt.Errorf("device: missing subcommand (want one of: %s, %s, %s)",
 			subcommandList, subcommandRevoke, subcommandPairCode)
 	}
+	if isHelpSubcommand(args[0]) {
+		printDeviceUsage(os.Stdout)
+		return nil
+	}
+
+	// Validated before openDeviceStore opens the SQLite file: an unknown
+	// subcommand (or a help request, handled above) must not pay for a store
+	// open it will never use.
+	switch args[0] {
+	case subcommandList, subcommandRevoke, subcommandPairCode:
+	default:
+		return fmt.Errorf("device: unknown subcommand %q (want one of: %s, %s, %s)",
+			args[0], subcommandList, subcommandRevoke, subcommandPairCode)
+	}
 
 	st, err := openDeviceStore(ctx, cfg)
 	if err != nil {
@@ -88,9 +103,20 @@ func runDeviceCommand(ctx context.Context, cfg config.Config, args []string) err
 	case subcommandPairCode:
 		return runDevicePairCode(ctx, st, args[1:])
 	default:
-		return fmt.Errorf("device: unknown subcommand %q (want one of: %s, %s, %s)",
-			args[0], subcommandList, subcommandRevoke, subcommandPairCode)
+		// Unreachable: args[0] was already validated above.
+		return nil
 	}
+}
+
+// isHelpSubcommand reports whether a would-be subcommand argument (args[0] to
+// runDeviceCommand or runAuditCommand) is actually a request for help rather
+// than a real subcommand name.
+func isHelpSubcommand(a string) bool {
+	switch a {
+	case "help", "-h", "-help", "--help":
+		return true
+	}
+	return false
 }
 
 // openDeviceStore opens the state store without constructing a logging.Sink.
@@ -152,7 +178,13 @@ func deviceStateOf(d state.Device) string {
 // no name, only an error.
 func runDeviceRevoke(ctx context.Context, st *state.Store, args []string) error {
 	fs := flag.NewFlagSet(subcommandRevoke, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeviceUsage(os.Stdout)
+			return nil
+		}
 		return fmt.Errorf("device revoke: %w", err)
 	}
 	if fs.NArg() != 1 {
@@ -188,8 +220,14 @@ func deviceNameByID(devices []state.Device, id string) string {
 // rotated, so a pairing code in agent.log would be a durable credential.
 func runDevicePairCode(ctx context.Context, st *state.Store, args []string) error {
 	fs := flag.NewFlagSet(subcommandPairCode, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 	name := fs.String(pairCodeNameFlag, "", "name of the device to mint a pairing code for")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeviceUsage(os.Stdout)
+			return nil
+		}
 		return fmt.Errorf("device pair-code: %w", err)
 	}
 	if strings.TrimSpace(*name) == "" {
@@ -218,6 +256,16 @@ func runAuditCommand(ctx context.Context, cfg config.Config, args []string) erro
 	if len(args) == 0 {
 		return fmt.Errorf("audit: missing subcommand (want one of: %s)", subcommandList)
 	}
+	if isHelpSubcommand(args[0]) {
+		printAuditUsage(os.Stdout)
+		return nil
+	}
+
+	// Validated before openDeviceStore opens the SQLite file — see
+	// runDeviceCommand's identical reordering and its comment.
+	if args[0] != subcommandList {
+		return fmt.Errorf("audit: unknown subcommand %q (want one of: %s)", args[0], subcommandList)
+	}
 
 	st, err := openDeviceStore(ctx, cfg)
 	if err != nil {
@@ -225,20 +273,21 @@ func runAuditCommand(ctx context.Context, cfg config.Config, args []string) erro
 	}
 	defer func() { _ = st.Close() }()
 
-	switch args[0] {
-	case subcommandList:
-		return runAuditListCommand(ctx, st, args[1:])
-	default:
-		return fmt.Errorf("audit: unknown subcommand %q (want one of: %s)", args[0], subcommandList)
-	}
+	return runAuditListCommand(ctx, st, args[1:])
 }
 
 // runAuditListCommand parses the `audit list` flags and prints the result to
 // stdout.
 func runAuditListCommand(ctx context.Context, st *state.Store, args []string) error {
 	fs := flag.NewFlagSet(subcommandList, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 	limit := fs.Int(auditLimitFlag, defaultAuditLimit, "maximum number of audit rows to print, most recent first")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printAuditUsage(os.Stdout)
+			return nil
+		}
 		return fmt.Errorf("audit list: %w", err)
 	}
 	return runAuditList(ctx, st, os.Stdout, *limit)

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -2,8 +2,9 @@
 
 // Host-side `device` subcommands (D8 in the Phase 2 plan). The image is
 // distroless/static:nonroot — there is no shell and no second binary — so
-// `docker exec devmon-agent /usr/local/bin/devmon-agent device ...` is the
-// only shape that works for an operator managing paired devices.
+// `docker exec devmon-agent devmon device ...` (with `devmon` a symlink to
+// /usr/local/bin/devmon-agent) is the only shape that works for an operator
+// managing paired devices.
 package main
 
 import (

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -6,11 +6,39 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/scnplt/devmon-agent/internal/state"
 )
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// whatever fn wrote to it. Used to prove a parse error never reaches
+// stdout — only requested help does (see runAuditListCommand's ErrHelp
+// branch and the plan note it implements).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() unexpected error: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return buf.String()
+}
 
 func openTestStore(t *testing.T) *state.Store {
 	t.Helper()
@@ -501,6 +529,222 @@ func TestAuditDeviceColumnReturnsBareIDWhenUnknown(t *testing.T) {
 	// Assert
 	if got != "deadbeefcafefeed" {
 		t.Errorf("auditDeviceColumn() = %q, want the bare id when no device matches", got)
+	}
+}
+
+func TestRunDeviceCommandHelpPrintsUsageWithoutOpeningStore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{"help", "help"},
+		{"-h", "-h"},
+		{"-help", "-help"},
+		{"--help", "--help"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — StateDir is never prepared: a store open would fail
+			// noisily if the help path tried to touch it.
+			cfg := testStateConfig(t)
+
+			// Act
+			err := runDeviceCommand(context.Background(), cfg, []string{tt.arg})
+
+			// Assert
+			if err != nil {
+				t.Fatalf("runDeviceCommand(%q) unexpected error: %v", tt.arg, err)
+			}
+			if _, statErr := os.Stat(cfg.DBPath()); !os.IsNotExist(statErr) {
+				t.Errorf("runDeviceCommand(%q) created a store file at %s, want none for help", tt.arg, cfg.DBPath())
+			}
+			if entries, readErr := os.ReadDir(cfg.StateDir); readErr == nil && len(entries) != 0 {
+				t.Errorf("runDeviceCommand(%q) left %d entries under %s, want an untouched state dir", tt.arg, len(entries), cfg.StateDir)
+			}
+		})
+	}
+}
+
+func TestRunAuditCommandHelpPrintsUsageWithoutOpeningStore(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+
+	// Act
+	err := runAuditCommand(context.Background(), cfg, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runAuditCommand(--help) unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(cfg.DBPath()); !os.IsNotExist(statErr) {
+		t.Errorf("runAuditCommand(--help) created a store file at %s, want none for help", cfg.DBPath())
+	}
+}
+
+func TestRunDeviceRevokeHelpReturnsNilWithoutWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDeviceRevoke(context.Background(), st, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDeviceRevoke(--help) = %v, want nil", err)
+	}
+}
+
+func TestRunDevicePairCodeHelpReturnsNilWithoutWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runDevicePairCode(context.Background(), st, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runDevicePairCode(--help) = %v, want nil", err)
+	}
+}
+
+func TestRunAuditListCommandHelpReturnsNilWithoutWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	err := runAuditListCommand(context.Background(), st, []string{"--help"})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("runAuditListCommand(--help) = %v, want nil", err)
+	}
+}
+
+// TestRunAuditListCommandBadFlagErrorsWithoutStdoutOutput and its two
+// siblings below deliberately do NOT call t.Parallel(): they redirect the
+// package-level os.Stdout for the duration of the call, which would race
+// with any concurrently running parallel test that also writes to stdout.
+func TestRunAuditListCommandBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+	var err error
+
+	// Act — capture stdout around the call: a genuine parse error must print
+	// nothing there, only the wrapped error (which main sends to stderr).
+	got := captureStdout(t, func() {
+		err = runAuditListCommand(context.Background(), st, []string{"--bogus"})
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runAuditListCommand(--bogus) = nil error, want one for an unknown flag")
+	}
+	if got != "" {
+		t.Errorf("runAuditListCommand(--bogus) wrote %q to stdout, want nothing", got)
+	}
+}
+
+func TestRunDeviceRevokeBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+	var err error
+
+	// Act
+	got := captureStdout(t, func() {
+		err = runDeviceRevoke(context.Background(), st, []string{"--bogus"})
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDeviceRevoke(--bogus) = nil error, want one for an unknown flag")
+	}
+	if got != "" {
+		t.Errorf("runDeviceRevoke(--bogus) wrote %q to stdout, want nothing", got)
+	}
+}
+
+func TestRunDevicePairCodeBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
+	// Arrange — the bad-flag case matters most here: pair-code's stdout is a
+	// pairing code a script may parse, so a flag error must never pollute it.
+	st := openTestStore(t)
+	var err error
+
+	// Act
+	got := captureStdout(t, func() {
+		err = runDevicePairCode(context.Background(), st, []string{"--bogus"})
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("runDevicePairCode(--bogus) = nil error, want one for an unknown flag")
+	}
+	if got != "" {
+		t.Errorf("runDevicePairCode(--bogus) wrote %q to stdout, want nothing", got)
+	}
+}
+
+func TestIsHelpSubcommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"help literal", "help", true},
+		{"short flag", "-h", true},
+		{"single-dash long flag", "-help", true},
+		{"double-dash long flag", "--help", true},
+		{"real subcommand", subcommandList, false},
+		{"empty string", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := isHelpSubcommand(tt.in)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("isHelpSubcommand(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunDeviceCommandUnknownSubcommandDoesNotOpenStore proves the reordered
+// check pays no SQLite open for a typo'd subcommand: the state dir is left
+// untouched by prepareStateDir's own directories only, no devmon.db appears.
+func TestRunDeviceCommandUnknownSubcommandDoesNotOpenStore(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	cfg := testStateConfig(t)
+	if err := prepareStateDir(cfg); err != nil {
+		t.Fatalf("prepareStateDir() unexpected error: %v", err)
+	}
+
+	// Act
+	if err := runDeviceCommand(context.Background(), cfg, []string{"bogus"}); err == nil {
+		t.Fatal("runDeviceCommand() = nil, want an error for an unknown subcommand")
+	}
+
+	// Assert
+	if _, statErr := os.Stat(cfg.DBPath()); !os.IsNotExist(statErr) {
+		t.Errorf("runDeviceCommand(bogus) created a store file at %s, want none for an unknown subcommand", cfg.DBPath())
 	}
 }
 

--- a/cmd/devmon-agent/health.go
+++ b/cmd/devmon-agent/health.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/scnplt/devmon-agent/internal/config"
@@ -52,6 +53,10 @@ const loopbackHost = "127.0.0.1"
 // second process touching certs/ could race the running agent's own startup
 // exactly as cli.go's comment on runDeviceCommand explains.
 func runHealthCommand(ctx context.Context, cfg config.Config, args []string) error {
+	if helpRequested(args) {
+		printHealthUsage(os.Stdout)
+		return nil
+	}
 	if len(args) != 0 {
 		return fmt.Errorf("health: unexpected argument %q (health takes no arguments)", args[0])
 	}

--- a/cmd/devmon-agent/health_test.go
+++ b/cmd/devmon-agent/health_test.go
@@ -123,3 +123,33 @@ func TestRunHealthCommandRejectsTrailingArgument(t *testing.T) {
 		t.Fatal("runHealthCommand() = nil error, want one for an unexpected trailing argument")
 	}
 }
+
+func TestRunHealthCommandHelpReturnsNilWithoutProbing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{"-h", "-h"},
+		{"-help", "-help"},
+		{"--help", "--help"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — an unresolvable listen address proves probeStatus was
+			// never reached: a real probe attempt would return an error.
+			cfg := config.Config{ListenAddr: "not-a-host-port"}
+
+			// Act
+			err := runHealthCommand(context.Background(), cfg, []string{tt.arg})
+
+			// Assert
+			if err != nil {
+				t.Fatalf("runHealthCommand(%q) = %v, want nil", tt.arg, err)
+			}
+		})
+	}
+}

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -24,8 +25,9 @@ import (
 	"github.com/scnplt/devmon-agent/internal/version"
 )
 
-// Exit codes. 2 is reserved for configuration faults so an operator (or an
-// installer script) can tell "you typed something wrong" apart from "it broke".
+// Exit codes. 2 is reserved for configuration faults and CLI usage mistakes
+// so an operator (or an installer script) can tell "you typed something
+// wrong" apart from "it broke".
 const (
 	exitOK      = 0
 	exitFailure = 1
@@ -35,14 +37,35 @@ const (
 // stateDirMode keeps the state directory owner-only; it holds the key material.
 const stateDirMode = 0o700
 
+// usageError is returned for a CLI mistake that a config.ValidationError
+// cannot represent — an unknown command or a bad global flag. main() maps it
+// to exitConfig, the same code as a configuration fault, since both mean
+// "you typed something wrong" rather than "the agent broke".
+type usageError struct {
+	msg string
+}
+
+func (e *usageError) Error() string { return e.msg }
+
+// unknownCommandHint is appended to the unknown-command error so it is
+// visible on stderr even though the full root usage screen is not — an
+// unknown command is a mistake, not a help request, and only requested help
+// goes to stdout.
+const unknownCommandHint = "Run 'devmon help' for usage."
+
 // main does nothing but map run's error to an exit code. os.Exit skips deferred
 // calls, so any defer placed here would silently never run — including the log
 // flush.
 func main() {
-	if err := run(); err != nil {
+	if err := run(os.Args, os.Getenv, os.Stdout, os.Stderr); err != nil {
 		var vErr *config.ValidationError
 		if errors.As(err, &vErr) {
 			fmt.Fprintln(os.Stderr, vErr.Error())
+			os.Exit(exitConfig)
+		}
+		var uErr *usageError
+		if errors.As(err, &uErr) {
+			fmt.Fprintln(os.Stderr, uErr.Error())
 			os.Exit(exitConfig)
 		}
 		fmt.Fprintf(os.Stderr, "devmon-agent: %v\n", err)
@@ -51,19 +74,60 @@ func main() {
 	os.Exit(exitOK)
 }
 
-func run() error {
-	showVersion := flag.Bool("version", false, "print version information and exit")
-	flag.Parse()
+// run holds every path through the binary: the operator CLI (device, audit,
+// health, help) and the daemon path (container ENTRYPOINT). argv, getenv,
+// stdout, and stderr are injected so tests can exercise it without touching
+// the process's real os.Args, environment, or standard streams.
+//
+// Every help path below returns before config.Load is reached — a `--help`
+// invocation must not require DEVMON_PUBLIC_ADDR or any other env var, and
+// must never open the SQLite state store.
+func run(argv []string, getenv func(string) string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("devmon-agent", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { printRootUsage(stderr) }
+	showVersion := fs.Bool("version", false, "print version information and exit")
+
+	if err := fs.Parse(argv[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRootUsage(stdout)
+			return nil
+		}
+		return &usageError{msg: err.Error()}
+	}
+
 	if *showVersion {
-		fmt.Printf("devmon-agent %s (commit %s, built %s)\n",
+		_, _ = fmt.Fprintf(stdout, "devmon-agent %s (commit %s, built %s)\n",
 			version.Version, version.Commit, version.BuildTime)
 		return nil
+	}
+
+	cmd := fs.Arg(0)
+	rest := fs.Args()[min(1, fs.NArg()):]
+
+	switch {
+	case cmd == "help":
+		printRootUsage(stdout)
+		return nil
+	case cmd == "" && isDevmonAlias(argv[0]):
+		printRootUsage(stdout)
+		return nil
+	case cmd == "":
+		// No subcommand under the devmon-agent name: this is the container
+		// ENTRYPOINT starting the daemon, unchanged.
+	case (cmd == "device" || cmd == "audit" || cmd == "health") && helpRequested(rest):
+		printCommandUsage(stdout, cmd)
+		return nil
+	case cmd == "device" || cmd == "audit" || cmd == "health":
+		// Handled below, after config.Load.
+	default:
+		return &usageError{msg: fmt.Sprintf("unknown command %q\n%s", cmd, unknownCommandHint)}
 	}
 
 	// Configuration is read and validated before the log sink exists, so a bad
 	// docker run line lands on stderr as plain readable text rather than as
 	// structured slog lines an operator has to squint at.
-	cfg, err := config.Load(os.Getenv)
+	cfg, err := config.Load(getenv)
 	if err != nil {
 		return err
 	}
@@ -73,8 +137,8 @@ func run() error {
 	// or touch certs/ — see cli.go for why. It is dispatched before the
 	// server path so it never triggers state-dir prep, log-sink construction,
 	// or certificate loading meant only for the long-running agent.
-	if flag.Arg(0) == "device" {
-		return runDeviceCommand(context.Background(), cfg, flag.Args()[1:])
+	if cmd == "device" {
+		return runDeviceCommand(context.Background(), cfg, rest)
 	}
 
 	// The `audit list` CLI (D19) is the audit trail's only reader — it is
@@ -82,8 +146,8 @@ func run() error {
 	// for the same reason as `device`: it must never trigger state-dir prep,
 	// log-sink construction, or certificate loading meant only for the
 	// long-running agent.
-	if flag.Arg(0) == "audit" {
-		return runAuditCommand(context.Background(), cfg, flag.Args()[1:])
+	if cmd == "audit" {
+		return runAuditCommand(context.Background(), cfg, rest)
 	}
 
 	// `health` (issue #56) backs the Dockerfile's HEALTHCHECK. It is
@@ -91,8 +155,8 @@ func run() error {
 	// never trigger state-dir prep, log-sink construction, or certificate
 	// loading meant only for the long-running agent — and doubly so here,
 	// since Docker invokes it every 30 seconds for the life of the container.
-	if flag.Arg(0) == "health" {
-		return runHealthCommand(context.Background(), cfg, flag.Args()[1:])
+	if cmd == "health" {
+		return runHealthCommand(context.Background(), cfg, rest)
 	}
 
 	if err := prepareStateDir(cfg); err != nil {
@@ -112,6 +176,20 @@ func run() error {
 	defer stop()
 
 	return serve(ctx, cfg, sink, log)
+}
+
+// printCommandUsage prints the per-command usage screen for one of
+// "device", "audit", or "health". It is only ever called with those three
+// values, guarded by the switch in run.
+func printCommandUsage(w io.Writer, cmd string) {
+	switch cmd {
+	case "device":
+		printDeviceUsage(w)
+	case "audit":
+		printAuditUsage(w)
+	case "health":
+		printHealthUsage(w)
+	}
 }
 
 // prepareStateDir creates the bind-mounted layout. A failure here is almost

--- a/cmd/devmon-agent/run_test.go
+++ b/cmd/devmon-agent/run_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestRunPrintsRootUsage(t *testing.T) {
 		argv []string
 	}{
 		{name: "devmon with no args", argv: []string{"devmon"}},
-		{name: "devmon.exe path with no args", argv: []string{`C:\x\devmon.exe`}},
+		{name: "devmon.exe with no args", argv: []string{filepath.Join("x", "devmon.exe")}},
 		{name: "devmon-agent help", argv: []string{"devmon-agent", "help"}},
 		{name: "devmon-agent -h", argv: []string{"devmon-agent", "-h"}},
 		{name: "devmon-agent -help", argv: []string{"devmon-agent", "-help"}},
@@ -161,7 +162,7 @@ func TestIsDevmonAlias(t *testing.T) {
 	}{
 		{name: "bare name", argv0: "devmon", want: true},
 		{name: "unix path", argv0: "/usr/local/bin/devmon", want: true},
-		{name: "windows path with .exe", argv0: `C:\x\devmon.exe`, want: true},
+		{name: "path with .exe", argv0: filepath.Join("x", "devmon.exe"), want: true},
 		{name: "mixed case", argv0: "DevMon", want: true},
 		{name: "devmon-agent is not the alias", argv0: "devmon-agent", want: false},
 		{name: "unrelated name", argv0: "bash", want: false},

--- a/cmd/devmon-agent/run_test.go
+++ b/cmd/devmon-agent/run_test.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/scnplt/devmon-agent/internal/config"
+)
+
+// emptyEnv is a getenv that answers every lookup with "". Passing it into
+// run() proves a help path never reaches config.Load — if it did, the
+// missing required variables would surface as a *config.ValidationError
+// instead of the expected nil.
+func emptyEnv(string) string { return "" }
+
+func TestRunPrintsRootUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		argv []string
+	}{
+		{name: "devmon with no args", argv: []string{"devmon"}},
+		{name: "devmon.exe path with no args", argv: []string{`C:\x\devmon.exe`}},
+		{name: "devmon-agent help", argv: []string{"devmon-agent", "help"}},
+		{name: "devmon-agent -h", argv: []string{"devmon-agent", "-h"}},
+		{name: "devmon-agent -help", argv: []string{"devmon-agent", "-help"}},
+		{name: "devmon-agent --help", argv: []string{"devmon-agent", "--help"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			var stdout, stderr bytes.Buffer
+
+			// Act
+			err := run(tt.argv, emptyEnv, &stdout, &stderr)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("run() = %v, want nil", err)
+			}
+			if stdout.String() != rootUsage {
+				t.Errorf("stdout = %q, want root usage", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunPrintsPerCommandUsageWithoutLoadingConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{name: "device --help", argv: []string{"devmon-agent", "device", "--help"}, want: deviceUsage},
+		{name: "device pair-code --help", argv: []string{"devmon-agent", "device", "pair-code", "--help"}, want: deviceUsage},
+		{name: "audit --help", argv: []string{"devmon-agent", "audit", "--help"}, want: auditUsage},
+		{name: "health --help", argv: []string{"devmon-agent", "health", "--help"}, want: healthUsage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — empty env: if run() reached config.Load, this would
+			// fail validation and return a *config.ValidationError instead
+			// of nil, so a nil result here is itself proof config was never
+			// loaded.
+			var stdout, stderr bytes.Buffer
+
+			// Act
+			err := run(tt.argv, emptyEnv, &stdout, &stderr)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("run() = %v, want nil", err)
+			}
+			if stdout.String() != tt.want {
+				t.Errorf("stdout = %q, want %q", stdout.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRunVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	var stdout, stderr bytes.Buffer
+
+	// Act
+	err := run([]string{"devmon-agent", "--version"}, emptyEnv, &stdout, &stderr)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("run() = %v, want nil", err)
+	}
+	if !strings.HasPrefix(stdout.String(), "devmon-agent ") {
+		t.Errorf("stdout = %q, want it to start with the version string", stdout.String())
+	}
+}
+
+func TestRunUnknownCommandIsAUsageError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	var stdout, stderr bytes.Buffer
+
+	// Act
+	err := run([]string{"devmon-agent", "bogus"}, emptyEnv, &stdout, &stderr)
+
+	// Assert
+	var uErr *usageError
+	if !errors.As(err, &uErr) {
+		t.Fatalf("run() error = %v (%T), want *usageError", err, err)
+	}
+	if !strings.Contains(uErr.Error(), `unknown command "bogus"`) {
+		t.Errorf("usageError message = %q, want it to name the unknown command", uErr.Error())
+	}
+	if !strings.Contains(uErr.Error(), unknownCommandHint) {
+		t.Errorf("usageError message = %q, want the %q hint", uErr.Error(), unknownCommandHint)
+	}
+}
+
+func TestRunWithNoArgsUnderDevmonAgentNameReachesDaemonPath(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — devmon-agent with no subcommand and no args is the daemon
+	// path (container ENTRYPOINT). With an empty environment, config.Load
+	// fails validation before anything is constructed, which is exactly the
+	// proof this test wants: the daemon path was reached, not skipped as a
+	// help screen would skip it, and nothing beyond config.Load ran.
+	var stdout, stderr bytes.Buffer
+
+	// Act
+	err := run([]string{"devmon-agent"}, emptyEnv, &stdout, &stderr)
+
+	// Assert
+	var vErr *config.ValidationError
+	if !errors.As(err, &vErr) {
+		t.Fatalf("run() error = %v (%T), want *config.ValidationError", err, err)
+	}
+}
+
+func TestIsDevmonAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		argv0 string
+		want  bool
+	}{
+		{name: "bare name", argv0: "devmon", want: true},
+		{name: "unix path", argv0: "/usr/local/bin/devmon", want: true},
+		{name: "windows path with .exe", argv0: `C:\x\devmon.exe`, want: true},
+		{name: "mixed case", argv0: "DevMon", want: true},
+		{name: "devmon-agent is not the alias", argv0: "devmon-agent", want: false},
+		{name: "unrelated name", argv0: "bash", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isDevmonAlias(tt.argv0); got != tt.want {
+				t.Errorf("isDevmonAlias(%q) = %v, want %v", tt.argv0, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelpRequested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty", args: nil, want: false},
+		{name: "no help flag", args: []string{"list"}, want: false},
+		{name: "-h", args: []string{"-h"}, want: true},
+		{name: "-help", args: []string{"-help"}, want: true},
+		{name: "--help", args: []string{"--help"}, want: true},
+		{name: "help flag not first", args: []string{"revoke", "some-id", "--help"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := helpRequested(tt.args); got != tt.want {
+				t.Errorf("helpRequested(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/devmon-agent/usage.go
+++ b/cmd/devmon-agent/usage.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// devmonAliasName is the symlink name the Dockerfile installs alongside the
+// real binary (`ln -s devmon-agent devmon`), so an operator can run
+// `docker exec devmon-agent devmon` instead of the full binary path.
+const devmonAliasName = "devmon"
+
+// rootUsage is shown for `devmon` with no args, `devmon help`,
+// `-h`/`-help`/`--help`, and any invocation under the `devmon` alias name. It
+// must stay verbatim in sync with the plan's help screen — operators run this
+// via `docker exec` and it is the only discovery mechanism the image offers.
+const rootUsage = `DevMon agent — mTLS-authenticated Docker control agent.
+
+Usage:
+  devmon <command> [flags]   operator CLI (docker exec devmon-agent devmon ...)
+  devmon-agent               run the agent daemon (container entrypoint)
+
+Commands:
+  device list                     list paired devices
+  device revoke <id>              revoke a device's access
+  device pair-code --name <name>  mint a single-use pairing code
+  audit list [--limit N]          print recent audit entries (default 100)
+  health                          probe the running agent's listener
+  help                            show this help
+
+Flags:
+  --version   print version information and exit
+
+Run 'devmon <command> --help' for details on a command.
+`
+
+// deviceUsage is shown for `device --help` and for `--help` on any of its
+// three subcommands — a single screen instead of six near-identical ones,
+// since `--help` is detected before the subcommand itself is dispatched.
+const deviceUsage = `Usage: devmon device <subcommand> [flags]
+
+Subcommands:
+  list                     list paired devices
+  revoke <id>              revoke a device's access
+  pair-code --name <name>  mint a single-use pairing code
+`
+
+// auditUsage is shown for `audit --help`.
+const auditUsage = `Usage: devmon audit list [--limit N]
+
+--limit N   maximum number of audit rows to print, most recent first (default 100)
+`
+
+// healthUsage is shown for `health --help`. health takes no arguments — it
+// backs the Dockerfile's HEALTHCHECK, which invokes it on a fixed 30-second
+// interval for the life of the container.
+const healthUsage = `Usage: devmon health
+
+Probes the running agent's own listener and exits 0 if healthy, 1 otherwise.
+Takes no arguments. This is what the image's HEALTHCHECK runs.
+`
+
+// printRootUsage writes rootUsage to w. A write failure here is not
+// actionable — w is stdout or stderr — so it is intentionally ignored, as
+// the other usage printers below also do.
+func printRootUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, rootUsage)
+}
+
+// printDeviceUsage writes deviceUsage to w.
+func printDeviceUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, deviceUsage)
+}
+
+// printAuditUsage writes auditUsage to w.
+func printAuditUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, auditUsage)
+}
+
+// printHealthUsage writes healthUsage to w.
+func printHealthUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, healthUsage)
+}
+
+// isDevmonAlias reports whether argv0 — typically os.Args[0] — is an
+// invocation of the `devmon` symlink the Dockerfile installs next to the real
+// binary, rather than devmon-agent itself. A no-args run under that name
+// shows help instead of starting the daemon, since `devmon` (unlike
+// `devmon-agent`) is never the container's ENTRYPOINT.
+func isDevmonAlias(argv0 string) bool {
+	base := strings.ToLower(filepath.Base(argv0))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == devmonAliasName
+}
+
+// helpRequested reports whether any of args asks for help. It scans every
+// remaining argument rather than only args[0], so `device revoke --help`
+// shows the device usage screen instead of treating "--help" as a device id
+// — "--help" was never a valid id.
+func helpRequested(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "-h", "-help", "--help":
+			return true
+		}
+	}
+	return false
+}

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -37,7 +37,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.4.0
+    image: ghcr.io/scnplt/devmon-agent:0.5.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.4.0
+  version: 0.5.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -123,7 +123,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.4.0
+                    agent_version: 0.5.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -975,7 +975,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.4.0"]
+          examples: ["0.5.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1219,12 +1219,21 @@ components:
         The full projection of one container. No environment variables, at any
         level, and no raw Engine payload.
       required:
-        [id, name, image, created_at, state, running, paused, restarting, exit_code,
-         restart_count, platform, labels, command, args, mounts, networks, ports, protected]
+        [id, name, image, image_id, created_at, state, running, paused, restarting,
+         exit_code, restart_count, platform, labels, command, args, mounts, networks,
+         ports, protected]
       properties:
         id: { type: string }
         name: { type: string }
-        image: { type: string }
+        image:
+          type: string
+          description: The image reference the container was created from, as in ContainerSummary.
+        image_id:
+          type: string
+          description: |
+            The Engine's image ID, digest-prefixed (`sha256:…`), as in
+            ImageSummary. `GET /v1/images/{id}` rejects a `:`, so strip the
+            prefix before inspecting it.
         created_at: { type: string, format: date-time }
         state:
           type: string

--- a/install.sh
+++ b/install.sh
@@ -35,11 +35,13 @@ NONROOT_GID='65532'
 # Docker host is outside what this installer sets up.
 SOCKET_PATH='/var/run/docker.sock'
 
-# CONTAINER_BINARY is the absolute path of the agent binary inside the image.
-# The image is distroless/static:nonroot — there is no shell in it — so every
-# in-container command must name the binary directly. `docker compose exec sh
-# -c ...` does not work and never will.
-CONTAINER_BINARY='/usr/local/bin/devmon-agent'
+# CONTAINER_BINARY is the agent CLI name inside the image: a symlink to
+# /usr/local/bin/devmon-agent, resolved through the container's default PATH
+# (docker exec does the lookup, no absolute path needed). The image is
+# distroless/static:nonroot — there is no shell in it — so every in-container
+# command must name the binary directly. `docker compose exec sh -c ...` does
+# not work and never will.
+CONTAINER_BINARY='devmon'
 
 # SERVICE_NAME is the compose service the exec and log commands address.
 SERVICE_NAME='devmon-agent'

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.4.0'
+IMAGE_TAG='0.5.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission

--- a/internal/dockerx/containers.go
+++ b/internal/dockerx/containers.go
@@ -104,7 +104,7 @@ func toContainerDetail(r container.InspectResponse, selfID string) ContainerDeta
 	d := ContainerDetail{
 		ID:           r.ID,
 		Name:         r.Name,
-		Image:        r.Image,
+		ImageID:      r.Image,
 		CreatedAt:    r.Created,
 		Command:      r.Path,
 		Platform:     r.Platform,
@@ -131,6 +131,7 @@ func toContainerDetail(r container.InspectResponse, selfID string) ContainerDeta
 	}
 
 	if r.Config != nil {
+		d.Image = r.Config.Image
 		d.Labels = r.Config.Labels
 		d.WorkingDir = r.Config.WorkingDir
 		d.User = r.Config.User

--- a/internal/dockerx/containers_test.go
+++ b/internal/dockerx/containers_test.go
@@ -52,6 +52,7 @@ func TestToContainerDetailNilState(t *testing.T) {
 	// Arrange
 	r := container.InspectResponse{
 		ID:         "abc123",
+		Image:      "sha256:abcdef",
 		State:      nil,
 		Config:     nil,
 		HostConfig: nil,
@@ -61,6 +62,12 @@ func TestToContainerDetailNilState(t *testing.T) {
 	got := toContainerDetail(r, "")
 
 	// Assert
+	if got.Image != "" {
+		t.Errorf("got.Image = %q, want empty when Config is nil", got.Image)
+	}
+	if got.ImageID != "sha256:abcdef" {
+		t.Errorf("got.ImageID = %q, want sha256:abcdef", got.ImageID)
+	}
 	if got.State != "" {
 		t.Errorf("got.State = %q, want empty", got.State)
 	}
@@ -229,7 +236,7 @@ func TestToContainerDetailFullState(t *testing.T) {
 	r := container.InspectResponse{
 		ID:      "abc123",
 		Name:    "/api",
-		Image:   "myapp:1.4",
+		Image:   "sha256:abcdef",
 		Created: "2023-11-14T22:13:20Z",
 		Path:    "/app/server",
 		Args:    []string{"--port", "8080"},
@@ -243,6 +250,7 @@ func TestToContainerDetailFullState(t *testing.T) {
 		},
 		Config: &container.Config{
 			Env:        []string{"DB_PASSWORD=hunter2"},
+			Image:      "myapp:1.4",
 			WorkingDir: "/app",
 			User:       "nobody",
 			Labels:     map[string]string{"app": "myapp"},
@@ -272,6 +280,12 @@ func TestToContainerDetailFullState(t *testing.T) {
 	got := toContainerDetail(r, "")
 
 	// Assert
+	if got.Image != "myapp:1.4" {
+		t.Errorf("got.Image = %q, want myapp:1.4 (from Config.Image)", got.Image)
+	}
+	if got.ImageID != "sha256:abcdef" {
+		t.Errorf("got.ImageID = %q, want sha256:abcdef (from the top-level Image digest)", got.ImageID)
+	}
 	if got.FinishedAt != "" {
 		t.Errorf("got.FinishedAt = %q, want empty for the zero timestamp", got.FinishedAt)
 	}

--- a/internal/dockerx/types.go
+++ b/internal/dockerx/types.go
@@ -72,12 +72,13 @@ type ContainerSummary struct {
 	Protected bool `json:"protected"`
 }
 
-// ContainerDetail is the full projection of a single container. 25 fields.
+// ContainerDetail is the full projection of a single container. 26 fields.
 // NO env. NO raw Engine payload.
 type ContainerDetail struct {
 	ID            string            `json:"id"`
 	Name          string            `json:"name"`
 	Image         string            `json:"image"`
+	ImageID       string            `json:"image_id"`
 	CreatedAt     string            `json:"created_at"` // RFC3339 UTC
 	State         string            `json:"state"`
 	Running       bool              `json:"running"`

--- a/internal/dockerx/types_test.go
+++ b/internal/dockerx/types_test.go
@@ -79,6 +79,7 @@ func TestContainerDetailFieldCount(t *testing.T) {
 		ID:            "abc123",
 		Name:          "/api",
 		Image:         "myapp:1.4",
+		ImageID:       "sha256:abcdef",
 		CreatedAt:     "2023-11-14T22:13:20Z",
 		State:         "running",
 		Running:       true,
@@ -107,8 +108,8 @@ func TestContainerDetailFieldCount(t *testing.T) {
 	body := marshalToMap(t, cd)
 
 	// Assert
-	if len(body) != 25 {
-		t.Fatalf("ContainerDetail payload has %d keys (%v), want exactly 25", len(body), keysOf(body))
+	if len(body) != 26 {
+		t.Fatalf("ContainerDetail payload has %d keys (%v), want exactly 26", len(body), keysOf(body))
 	}
 }
 

--- a/internal/e2e/api/contract_reads_test.go
+++ b/internal/e2e/api/contract_reads_test.go
@@ -162,7 +162,7 @@ func TestContainerReadContractKeys(t *testing.T) {
 	}
 	assertKeySet(t, detail,
 		[]string{
-			"id", "name", "image", "created_at", "state", "running", "paused", "restarting",
+			"id", "name", "image", "image_id", "created_at", "state", "running", "paused", "restarting",
 			"exit_code", "restart_count", "platform", "labels", "command", "args",
 			"mounts", "networks", "ports", "protected",
 		},

--- a/internal/e2e/api/contract_startup_test.go
+++ b/internal/e2e/api/contract_startup_test.go
@@ -135,8 +135,10 @@ func TestGracefulShutdown(t *testing.T) {
 	a := harness.StartAgent(t, harness.AgentOptions{})
 
 	// Agent.Stop already asserts a clean (0) exit within its own
-	// shutdownTimeout (5s, matching server.go's own drain budget) — a
-	// timeout or a non-zero exit fails the test right here.
+	// shutdownTimeout (7s — it deliberately exceeds server.go's 5s drain
+	// budget by design, so SIGKILL only fires on a genuine hang, never on a
+	// correct full-grace drain; issue #117) — a timeout or a non-zero exit
+	// fails the test right here.
 	exitCode := a.Stop(t)
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", exitCode)

--- a/internal/e2e/harness/agent.go
+++ b/internal/e2e/harness/agent.go
@@ -26,10 +26,17 @@ import (
 // Timing budgets for the agent subprocess. readinessTimeout is generous: the
 // state store and CA are built on first start, which is slower than a warm
 // restart.
+//
+// shutdownTimeout must strictly exceed the agent's own drain grace
+// (shutdownGrace in internal/httpapi/server.go, currently 5s — unexported, so
+// it can't be imported here and the two values are kept aligned by this
+// comment) plus roughly 2s of scheduling margin. Setting it equal to the
+// drain grace put SIGTERM-to-SIGKILL on a knife edge where even a correct
+// full-grace drain got killed as if it were a hang (issue #117).
 const (
 	readinessTimeout = 15 * time.Second
 	readinessPoll    = 100 * time.Millisecond
-	shutdownTimeout  = 5 * time.Second
+	shutdownTimeout  = 7 * time.Second
 	killTimeout      = 10 * time.Second
 )
 

--- a/internal/e2e/incontainer/main_test.go
+++ b/internal/e2e/incontainer/main_test.go
@@ -20,6 +20,7 @@ package incontainer
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,4 +91,49 @@ func TestContainerSmoke(t *testing.T) {
 	if restartCount != 0 {
 		t.Fatalf("agent container %s restart count = %d, want 0", c.ID, restartCount)
 	}
+
+	// `devmon` is the documented short alias `docker exec <name> devmon ...`
+	// depends on (Dockerfile): a symlink to devmon-agent, staged into a
+	// directory that is on the container's default PATH. Resolving the BARE
+	// name — never the absolute path — must produce the exact same `device
+	// list` table header as the canonical binary does.
+	canonicalOut, canonicalExit := c.Exec(t, "/usr/local/bin/devmon-agent", "device", "list")
+	if canonicalExit != 0 {
+		t.Fatalf("device list (canonical path): exit code %d", canonicalExit)
+	}
+	aliasOut, aliasExit := c.Exec(t, "devmon", "device", "list")
+	if aliasExit != 0 {
+		t.Fatalf("device list (via `devmon` PATH alias): exit code %d", aliasExit)
+	}
+
+	const wantHeaderFields = "ID NAME PAIRED LAST SEEN STATE"
+	canonicalHeader := normalizeHeader(firstLine(t, canonicalOut))
+	aliasHeader := normalizeHeader(firstLine(t, aliasOut))
+	if canonicalHeader != wantHeaderFields {
+		t.Fatalf("device list (canonical path) header = %q, want %q", canonicalHeader, wantHeaderFields)
+	}
+	if aliasHeader != canonicalHeader {
+		t.Fatalf("device list (via `devmon` PATH alias) header = %q, want the canonical path's header %q", aliasHeader, canonicalHeader)
+	}
+}
+
+// normalizeHeader collapses a tabwriter table's inter-column padding down to
+// single spaces, so the header's field text can be compared against a fixed
+// literal regardless of the terminal-driven column widths TTY: true exec
+// produces.
+func normalizeHeader(line string) string {
+	return strings.Join(strings.Fields(line), " ")
+}
+
+// firstLine returns the first non-empty line of a tabwriter table's output —
+// the header row `device list` prints as its first line.
+func firstLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			return strings.TrimSpace(line)
+		}
+	}
+	t.Fatalf("output has no non-empty lines: %q", out)
+	return ""
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -131,6 +132,23 @@ type Server struct {
 	// with a sleep. It is per-instance rather than a package-level var so
 	// setting it on one test's Server can never race a different test's.
 	afterCreateHook func()
+
+	// newConnMu guards newConns and draining below (issue #117). A
+	// connection that completed its TLS handshake but never sent a request
+	// sits in http.StateNew for the rest of its life; http.Server.Shutdown
+	// only treats such a connection as closable-idle once its state stamp
+	// is more than shutdownGrace old, with one-second stamp granularity, so
+	// it can pin Shutdown for the entire grace window. Tracking every
+	// StateNew connection here lets shutdown close them itself instead of
+	// waiting on that stamp.
+	newConnMu sync.Mutex
+	newConns  map[net.Conn]struct{}
+	// draining is set by shutdown before it closes the tracked connections
+	// above. The ConnState hook checks it so a connection that reaches
+	// StateNew after draining started — in the window between shutdown
+	// beginning and http.Server.Shutdown closing the listener — is closed
+	// immediately too, rather than surviving to pin the grace window.
+	draining bool
 }
 
 // NewServer wires the API. tlsCfg carries the server certificate, so the
@@ -144,7 +162,11 @@ type Server struct {
 // likewise be nil in tests that do not exercise the Docker read routes; every
 // read handler tolerates that by serving 502 instead of panicking.
 func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader, tlsCfg *tls.Config, log *slog.Logger) *Server {
-	s := &Server{cfg: cfg, st: st, ca: ca, dc: dc, log: log, streams: newStreamBudget(maxConcurrentStreams, maxStreamsPerDevice)}
+	s := &Server{
+		cfg: cfg, st: st, ca: ca, dc: dc, log: log,
+		streams:  newStreamBudget(maxConcurrentStreams, maxStreamsPerDevice),
+		newConns: make(map[net.Conn]struct{}),
+	}
 	s.lifecycleCtx, s.cancelLifecycle = context.WithCancel(context.Background())
 	s.events = newEventHub(dc, log)
 	s.eventStreams = newEventRegistry()
@@ -194,8 +216,70 @@ func NewServer(cfg config.Config, st *state.Store, ca *certs.CA, dc DockerReader
 		// in one step, which is how a live SSE stream (issue #41) learns to
 		// stop without Shutdown having to wait out the client.
 		BaseContext: func(net.Listener) context.Context { return s.lifecycleCtx },
+		// ConnState tracks every connection whose current state is
+		// http.StateNew (issue #117): shutdown closes them directly instead
+		// of waiting on Shutdown's own idle-since-state-stamp check, which a
+		// handshake-only, request-less connection can outlive for the whole
+		// shutdownGrace window. See trackConnState's doc comment.
+		ConnState: s.trackConnState,
 	}
 	return s
+}
+
+// trackConnState is the http.Server ConnState hook (issue #117). It keeps
+// newConns as the current set of connections in http.StateNew — added on
+// StateNew, removed the moment a connection leaves it for StateActive,
+// StateIdle, StateHijacked, or StateClosed — so shutdown can close every
+// still-StateNew connection itself rather than rely on Shutdown's own
+// idle-since-state-stamp check, which treats a StateNew connection as
+// closable-idle only once that stamp is more than shutdownGrace old.
+//
+// If draining is already true when a connection reaches StateNew, shutdown
+// has already swept the connections it knew about; this one arrived in the
+// gap between that sweep and http.Server.Shutdown closing the listener, so
+// it is closed here immediately instead of being left to pin the grace
+// window on its own.
+//
+// There is an acknowledged, accepted race: a connection can transition
+// StateNew -> StateActive concurrently with shutdown closing it here. That
+// is fine during shutdown — the lifecycle context is already cancelled by
+// the time shutdown reaches this path, so any handler that connection's
+// request might have reached is already unwinding.
+func (s *Server) trackConnState(conn net.Conn, state http.ConnState) {
+	switch state {
+	case http.StateNew:
+		s.newConnMu.Lock()
+		draining := s.draining
+		if !draining {
+			s.newConns[conn] = struct{}{}
+		}
+		s.newConnMu.Unlock()
+		if draining {
+			_ = conn.Close()
+		}
+	case http.StateActive, http.StateIdle, http.StateHijacked, http.StateClosed:
+		s.newConnMu.Lock()
+		delete(s.newConns, conn)
+		s.newConnMu.Unlock()
+	}
+}
+
+// closeNewConns marks the server as draining and closes every connection
+// currently tracked as http.StateNew (issue #117). Called from shutdown
+// before http.Server.Shutdown, so a handshake-only, request-less connection
+// — which carries no request context for lifecycleCtx cancellation to reach
+// — is closed directly instead of pinning Shutdown for the whole
+// shutdownGrace window waiting on its state stamp to age out.
+func (s *Server) closeNewConns() {
+	s.newConnMu.Lock()
+	s.draining = true
+	conns := s.newConns
+	s.newConns = make(map[net.Conn]struct{})
+	s.newConnMu.Unlock()
+
+	for conn := range conns {
+		_ = conn.Close()
+	}
 }
 
 // routes builds the mux and wraps it in the middleware chain.
@@ -336,6 +420,18 @@ func (s *Server) shutdown() error {
 	// so a goroutine-leak test can assert it right after shutdown returns
 	// instead of racing the hub's own teardown.
 	s.events.stop()
+
+	// Close every connection still in http.StateNew (issue #117) before
+	// asking http.Server to drain. A connection that completed its TLS
+	// handshake but never sent a request has no request context for
+	// cancelLifecycle above to reach, and Shutdown itself only treats a
+	// StateNew connection as closable-idle once its state stamp is more
+	// than shutdownGrace old — with one-second stamp granularity, that can
+	// pin Shutdown for the entire grace window on a connection that was
+	// never going to send anything. See trackConnState's doc comment for
+	// why closing it here, mid-transition, is an accepted race rather than
+	// a bug.
+	s.closeNewConns()
 
 	// A fresh context: ctx is already cancelled, and Shutdown needs a live
 	// deadline to drain against.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -590,3 +590,62 @@ func TestShutdownEndsLiveStreamPromptlyAndReturnsNil(t *testing.T) {
 		t.Fatal("the client's stream read did not end after shutdown")
 	}
 }
+
+// TestShutdownNotPinnedByRequestlessConnection is issue #117's regression: a
+// connection that completed its TLS handshake but never sent a request sits
+// in http.StateNew for the server's whole life. That state has no request
+// context for shutdown to cancel — TestShutdownEndsLiveStreamPromptlyAndReturnsNil's
+// fix does not reach it — and http.Server.Shutdown only treats a StateNew
+// connection as closable-idle once its state stamp is more than five seconds
+// old, with one-second stamp granularity (issue #72). shutdownGrace is
+// exactly five seconds, so such a connection pins Shutdown for the entire
+// grace window rather than returning promptly. This is not a synthetic case:
+// Go's own http.Transport sometimes dials an extra connection during pool
+// contention that never carries a request and sits in the client's idle pool
+// while the server still sees it as StateNew.
+func TestShutdownNotPinnedByRequestlessConnection(t *testing.T) {
+	// Not t.Parallel(), for the same reason TestRunReturnsShutdownError is
+	// not: this test's assertion window overlaps shutdownGrace closely
+	// enough that running alongside other goroutine-heavy tests could skew
+	// TestStreamGoroutineDoesNotLeak's before/after count.
+
+	// Arrange — a known port, since this test dials the server itself.
+	addr := freeTCPAddr(t)
+	s := runnableServer(t, addr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() { done <- s.Run(ctx) }()
+	waitForListening(t, addr, 2*time.Second)
+
+	// A real TLS handshake, then deliberately no request: this is the
+	// server-side http.StateNew, request-less keep-alive connection the fix
+	// targets.
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec // test-only, talks to our own ephemeral server
+	if err != nil {
+		t.Fatalf("dial server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+
+	// Act
+	shutdownStart := time.Now()
+	cancel()
+
+	// Assert — Shutdown completes well under shutdownGrace: a request-less
+	// handshake-only connection must not pin it for the full grace window.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run() = %v, want nil with only a request-less connection open", err)
+		}
+		if elapsed := time.Since(shutdownStart); elapsed >= 2*time.Second {
+			t.Errorf("shutdown took %v, want well under the %v grace period", elapsed, shutdownGrace)
+		}
+	case <-time.After(shutdownGrace + 5*time.Second):
+		t.Fatal("Run() did not return after shutdown with only a request-less connection open")
+	}
+}


### PR DESCRIPTION
Releases `dev` into `main` as **0.5.0**. Merging this makes the code releasable; tagging `v0.5.0` on `main` afterwards is what publishes `ghcr.io/scnplt/devmon-agent:0.5.0`.

Full notes: [`CHANGELOG.md` § 0.5.0](https://github.com/scnplt/devmon-agent/blob/dev/CHANGELOG.md).

## What this release is

A feature release. The agent binary gains an operator CLI surface: the image ships a `devmon` alias next to the binary, so `docker exec devmon-agent devmon help` works without a shell in the container, and unknown commands fail fast instead of starting a second daemon. It also fixes two things: the container detail route's `image`/`image_id` contract, and a shutdown stall caused by request-less connections.

### Added

- A `devmon` symlink in the image on the distroless PATH, so `docker exec devmon-agent devmon <command>` resolves without a shell; `ENTRYPOINT` and `HEALTHCHECK` unchanged (#123)
- Operator CLI help — `devmon` with no args or `help`/`-h`/`--help` prints a one-screen usage listing; `device`, `audit` and `health` accept `--help` without any `DEVMON_*` variables and without opening the store; unknown commands exit 2 with a usage hint instead of silently starting the daemon (#124)

### Fixed

- `GET /v1/containers/{id}` now reports `image` consistently with the list route (the image reference, not the digest ID); a new `image_id` field carries the digest-prefixed ID (#121, docs #125, closes-adjacent issue #120)
- A graceful shutdown is no longer pinned for the full 5-second drain grace by a TLS connection that never sent a request — `StateNew` connections are tracked and closed directly when shutdown begins; Slowloris protection during normal serving unchanged (#122, refs #117)

### Internal

- `devmon` alias covered by container e2e; alias fixtures made platform-independent (#122–#124)
- Release prep — changelog entry and version pins (#126); the e2e contract allowlist gained the `image_id` detail key it was missing from #121, caught by this PR's first e2e run (#128)

## Compatibility

No `DEVMON_*` variable was added, removed, or given a new meaning since 0.4.0 — an existing compose file runs unchanged.

Two caller-visible behaviour changes:

- **`image` in the container detail response changed meaning.** It previously carried the Engine's digest-prefixed image ID; it now carries the image reference, matching the list route. Clients reading the digest out of `image` must switch to the new `image_id` field.
- **Unknown CLI commands exit 2** instead of silently starting the daemon. Anything invoking the binary with a mistyped subcommand and relying on it daemonising will now fail loudly — which is the point.

## Test plan

- [x] CI green on this PR — the full release bar (`e2e`, `e2e-health`, `image`, `gosec`, `govulncheck`, `lint`, `openapi`, `shellcheck`) runs on PRs into `main`
- [x] `test` green on every constituent PR; #122–#124 additionally ran the container e2e covering the `devmon` exec alias
- [x] `make openapi-lint` — valid; `make doc-citations` — all citations resolve
- [x] Version pins consistent across README, `install.sh`, `compose.example.yaml`, `docs/openapi.yaml`
- [ ] After merge: tag `v0.5.0` on `main` to publish the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
