### PR TITLE
test: document image_id in the container detail contract keys

### DIFF
--- a/internal/e2e/api/contract_reads_test.go
+++ b/internal/e2e/api/contract_reads_test.go
@@ -162,7 +162,7 @@ func TestContainerReadContractKeys(t *testing.T) {
 	}
 	assertKeySet(t, detail,
 		[]string{
-			"id", "name", "image", "created_at", "state", "running", "paused", "restarting",
+			"id", "name", "image", "image_id", "created_at", "state", "running", "paused", "restarting",
 			"exit_code", "restart_count", "platform", "labels", "command", "args",
 			"mounts", "networks", "ports", "protected",
 		},


### PR DESCRIPTION
The e2e contract test's detail-route allowlist was never updated when #121 added `image_id` — the list-route allowlist was. Since `e2e` only runs on PRs into `main`, this first surfaced on the 0.5.0 release PR (#127), where `TestContainerReadContractKeys` fails with an undocumented-key error for `image_id`.

One-token fix: add `image_id` to the required-keys list the detail assertion checks, matching the list route and the OpenAPI spec (#125).

Refs #120

## Test plan

- [x] `gofmt`, `go vet -tags e2e`, `go build` clean
- [ ] `test` green on this PR
- [ ] `e2e` green on #127 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)