### PR TITLE
chore: prepare the 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,74 @@ moved.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-29
+
+A feature release. The pairing-code lifetime, fixed at ten minutes since the
+pairing flow shipped, becomes a choice the operator makes — bounded by a
+ceiling only the operator can set, at startup.
+
+The configuration surface gains one variable, `DEVMON_PAIR_TTL_MAX_MIN`, and
+loses none. An agent started without it behaves exactly as 0.5.1 did: codes
+live ten minutes. No route changed, and no response field changed meaning.
+
+### Added
+
+- **A configurable pairing-code TTL, with an operator-set ceiling.**
+  `device pair-code` accepts `--ttl <minutes>`, choosing a lifetime from five
+  minutes up to `DEVMON_PAIR_TTL_MAX_MIN` — a startup variable bounded to
+  5–60 minutes, defaulting to 10. Omitting the flag mints at
+  `min(10 minutes, ceiling)`, so lowering the ceiling below the default never
+  becomes a startup error. A value outside the range is a hard error that
+  mints nothing: it is never silently clamped, so a script that sees no error
+  knows the code carries exactly the TTL it asked for, and `--ttl 0` fails
+  like any other below-floor value rather than being read as an omitted flag.
+  The ceiling lives in startup configuration for the reason every other bound
+  does — a longer-lived code is a longer window for a leaked, unredeemed code
+  to matter, and nothing a client can reach may widen it.
+  ([#130](https://github.com/scnplt/devmon-agent/pull/130), closes
+  [#129](https://github.com/scnplt/devmon-agent/issues/129))
+
+## [0.5.1] - 2026-08-28
+
+A security release. Revoking a device now also ends the live streams that
+device already holds open, instead of only rejecting its next request.
+
+The configuration surface is unchanged, no variable was added or removed, and
+no route changed its contract. Upgrading is a straight image-tag bump.
+
+### Security
+
+- **A revoked device's already-open log and event streams now terminate
+  within one tick.** Revocation was enforced once per request, at entry. The
+  two SSE routes — `GET /v1/containers/{id}/logs/stream` and
+  `GET /v1/events/stream` — are each a single long-lived request, so a stream
+  opened before `device revoke` kept delivering container output and
+  host-wide health events until the client disconnected or the agent
+  restarted. Both routes now re-check revocation on every keepalive or
+  heartbeat tick and close the stream with one terminal `event: error` frame
+  carrying `device revoked`, so the operator's kill switch takes at most one
+  tick interval (20s for logs, 25s for events) to reach a stream that is
+  already running. A revoked *or deleted* device ends the stream; a transient
+  lookup failure does not, so a database hiccup cannot kill a healthy stream.
+  ([GHSA-qrxm-qm54-xc44](https://github.com/scnplt/devmon-agent/security/advisories/GHSA-qrxm-qm54-xc44),
+  CWE-613, moderate)
+
+### Fixed
+
+- **At most one terminal error frame per stream.** Both stream routes could
+  write a second terminal frame when a revocation tick coincided with another
+  terminating condition — a superseding stream or a lagging subscriber on the
+  event route, an Engine fault on the log route — because `select` picks
+  pseudo-randomly among ready cases. The terminal frame is now single-shot per
+  request on both routes.
+
+### Changed
+
+- **The threat model and README state the real revocation guarantee.** Both
+  described revocation as immediate, which held only for request-scoped
+  traffic. They now say what the code does: the next request is rejected, and
+  an already-open stream ends within one tick interval.
+
 ## [0.5.0] - 2026-08-27
 
 A feature release. The agent binary gains an operator CLI surface: the image
@@ -472,7 +540,9 @@ First public release — the full surface.
 
 [#120]: https://github.com/scnplt/devmon-agent/issues/120
 
-[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/scnplt/devmon-agent/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/scnplt/devmon-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scnplt/devmon-agent/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.5.0 — an operator CLI via `docker exec devmon`.** The agent is its own certificate
+**Status: 0.6.0 — a configurable pairing-code lifetime.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -75,7 +75,7 @@ docker run -d --name devmon-agent \
   --read-only --tmpfs /tmp \
   --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.5.0
+  ghcr.io/scnplt/devmon-agent:0.6.0
 ```
 
 The four hardening flags are not needed to run the agent and none of them
@@ -99,7 +99,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.5.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.6.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -37,7 +37,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.5.0
+    image: ghcr.io/scnplt/devmon-agent:0.6.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.5.0
+  version: 0.6.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -123,7 +123,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.5.0
+                    agent_version: 0.6.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -975,7 +975,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.5.0"]
+          examples: ["0.6.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.5.0'
+IMAGE_TAG='0.6.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
Release preparation for **0.6.0**. Documentation and pinned-version only — no Go code changes, so the shipped behaviour is exactly what is already on `dev`.

## Version bump

Every pinned reference moves `0.5.0` → `0.6.0`:

- `README.md` — status line, the `docker run` image tag, and the `/v1/status` example output
- `install.sh` — `IMAGE_TAG`
- `compose.example.yaml` — the service image
- `docs/openapi.yaml` — `info.version` and the two `agent_version` examples

`internal/version` needs no edit: the version is stamped at link time via `-ldflags`.

## Changelog

Two entries, not one:

- **`[0.6.0]`** — the configurable pairing-code TTL from #130 (closes #129): `--ttl <minutes>` on `device pair-code`, bounded by the new `DEVMON_PAIR_TTL_MAX_MIN` startup ceiling (5–60, default 10). Out-of-range values are hard errors that mint nothing, and an omitted flag resolves to `min(10 minutes, ceiling)`.
- **`[0.5.1]`** — **this was missing entirely.** The security release shipped a tag, an image, and a published advisory, but never reached the changelog. Recorded now under `Security` (a first use of the Keep a Changelog category this file already declares it follows), covering GHSA-qrxm-qm54-xc44: a revoked device's already-open SSE streams now terminate within one keepalive/heartbeat tick, plus the single-shot terminal frame fix and the threat-model wording correction.

Version link references at the foot of the file are updated for both.

## Why 0.6.0

`dev` carries a new user-facing flag and a new `DEVMON_*` variable, both backward compatible — a minor bump under semver. An agent started without `DEVMON_PAIR_TTL_MAX_MIN` behaves exactly as 0.5.1 did.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...` clean
- [x] `sh -n install.sh` — syntax valid (`shellcheck` itself is not installed locally; the CI `shellcheck` job covers it)
- [x] `npx @redocly/cli@2.46.2 lint docs/openapi.yaml` — valid, using the exact version the Makefile and CI pin
- [x] No `0.5.0` references remain outside the changelog's own history
- [ ] CI green on this PR

## Follow-up

After this merges, `dev` → `main` release PR, then tag `v0.6.0` to trigger the image build.

Refs #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
