### PR TITLE
release: 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,74 @@ moved.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-29
+
+A feature release. The pairing-code lifetime, fixed at ten minutes since the
+pairing flow shipped, becomes a choice the operator makes — bounded by a
+ceiling only the operator can set, at startup.
+
+The configuration surface gains one variable, `DEVMON_PAIR_TTL_MAX_MIN`, and
+loses none. An agent started without it behaves exactly as 0.5.1 did: codes
+live ten minutes. No route changed, and no response field changed meaning.
+
+### Added
+
+- **A configurable pairing-code TTL, with an operator-set ceiling.**
+  `device pair-code` accepts `--ttl <minutes>`, choosing a lifetime from five
+  minutes up to `DEVMON_PAIR_TTL_MAX_MIN` — a startup variable bounded to
+  5–60 minutes, defaulting to 10. Omitting the flag mints at
+  `min(10 minutes, ceiling)`, so lowering the ceiling below the default never
+  becomes a startup error. A value outside the range is a hard error that
+  mints nothing: it is never silently clamped, so a script that sees no error
+  knows the code carries exactly the TTL it asked for, and `--ttl 0` fails
+  like any other below-floor value rather than being read as an omitted flag.
+  The ceiling lives in startup configuration for the reason every other bound
+  does — a longer-lived code is a longer window for a leaked, unredeemed code
+  to matter, and nothing a client can reach may widen it.
+  ([#130](https://github.com/scnplt/devmon-agent/pull/130), closes
+  [#129](https://github.com/scnplt/devmon-agent/issues/129))
+
+## [0.5.1] - 2026-08-28
+
+A security release. Revoking a device now also ends the live streams that
+device already holds open, instead of only rejecting its next request.
+
+The configuration surface is unchanged, no variable was added or removed, and
+no route changed its contract. Upgrading is a straight image-tag bump.
+
+### Security
+
+- **A revoked device's already-open log and event streams now terminate
+  within one tick.** Revocation was enforced once per request, at entry. The
+  two SSE routes — `GET /v1/containers/{id}/logs/stream` and
+  `GET /v1/events/stream` — are each a single long-lived request, so a stream
+  opened before `device revoke` kept delivering container output and
+  host-wide health events until the client disconnected or the agent
+  restarted. Both routes now re-check revocation on every keepalive or
+  heartbeat tick and close the stream with one terminal `event: error` frame
+  carrying `device revoked`, so the operator's kill switch takes at most one
+  tick interval (20s for logs, 25s for events) to reach a stream that is
+  already running. A revoked *or deleted* device ends the stream; a transient
+  lookup failure does not, so a database hiccup cannot kill a healthy stream.
+  ([GHSA-qrxm-qm54-xc44](https://github.com/scnplt/devmon-agent/security/advisories/GHSA-qrxm-qm54-xc44),
+  CWE-613, moderate)
+
+### Fixed
+
+- **At most one terminal error frame per stream.** Both stream routes could
+  write a second terminal frame when a revocation tick coincided with another
+  terminating condition — a superseding stream or a lagging subscriber on the
+  event route, an Engine fault on the log route — because `select` picks
+  pseudo-randomly among ready cases. The terminal frame is now single-shot per
+  request on both routes.
+
+### Changed
+
+- **The threat model and README state the real revocation guarantee.** Both
+  described revocation as immediate, which held only for request-scoped
+  traffic. They now say what the code does: the next request is rejected, and
+  an already-open stream ends within one tick interval.
+
 ## [0.5.0] - 2026-08-27
 
 A feature release. The agent binary gains an operator CLI surface: the image
@@ -472,7 +540,9 @@ First public release — the full surface.
 
 [#120]: https://github.com/scnplt/devmon-agent/issues/120
 
-[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/scnplt/devmon-agent/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/scnplt/devmon-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scnplt/devmon-agent/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go agent that exposes a narrow, mTLS-authenticated Docker control API, so a
 paired client can inspect and restart containers without SSH and without
 exposing the Docker socket to the internet.
 
-**Status: 0.5.0 — an operator CLI via `docker exec devmon`.** The agent is its own certificate
+**Status: 0.6.0 — a configurable pairing-code lifetime.** The agent is its own certificate
 authority. An operator mints a pairing code on the host, the device generates a
 keypair and exchanges a CSR for a client certificate, and every guarded request
 is authenticated against that certificate. Revocation takes effect on the next
@@ -75,7 +75,7 @@ docker run -d --name devmon-agent \
   --read-only --tmpfs /tmp \
   --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.5.0
+  ghcr.io/scnplt/devmon-agent:0.6.0
 ```
 
 The four hardening flags are not needed to run the agent and none of them
@@ -99,7 +99,7 @@ Verify it is up:
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.5.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.6.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ file, or signal that can widen what was granted here.
 | `DEVMON_RATE_STATUS_PER_MIN` | int | `30` | ≥1 |
 | `DEVMON_RATE_PAIR_PER_MIN` | int | `5` | ≥1 |
 | `DEVMON_RATE_GUARDED_PER_SEC` | int | `20` | ≥1 |
+| `DEVMON_PAIR_TTL_MAX_MIN` | int | `10` | 5–60; ceiling in minutes for `device pair-code --ttl` |
 
 `DEVMON_PUBLIC_ADDR` has no default on purpose: a server certificate with no
 subject alternative name matches nothing, and the failure would otherwise
@@ -721,9 +722,18 @@ docker exec devmon-agent devmon device pair-code --name "pixel-8"
 # Expires:      2026-08-07T20:12:00Z
 ```
 
-The code is single-use, valid for **10 minutes**, and printed to stdout only —
+The code is single-use, valid for **10 minutes** by default, and printed to
+stdout only —
 never to `agent.log`, which is persisted and rotated. Only its SHA-256 is
-stored. Nobody, including the operator, can read it back out of the database, so
+stored.
+
+`--ttl <minutes>` picks a different lifetime, from 5 minutes up to the
+`DEVMON_PAIR_TTL_MAX_MIN` ceiling the operator fixed at startup (itself capped
+at 60). A value outside that range is a hard error — never silently clamped —
+and when the flag is omitted the default is 10 minutes or the ceiling,
+whichever is lower. A longer-lived code is a longer exposure window if it
+leaks unused, which is why the ceiling is startup configuration: nothing
+reachable from a client can raise it. Nobody, including the operator, can read it back out of the database, so
 a lost code is minted again rather than recovered.
 
 ### 2. Redeem it
@@ -804,7 +814,7 @@ docker exec devmon-agent devmon device <subcommand>
 | Subcommand | Effect |
 |---|---|
 | `device list` | Every registered device: ID, name, paired, last seen, state |
-| `device pair-code --name <name>` | Mint a single-use code, valid 10 minutes |
+| `device pair-code --name <name> [--ttl <minutes>]` | Mint a single-use code; valid 10 minutes by default, `--ttl` picks 5 up to `DEVMON_PAIR_TTL_MAX_MIN` |
 | `device revoke <id>` | Withdraw a device's access, effective immediately |
 
 ```bash

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -235,7 +235,7 @@ func runDevicePairCode(ctx context.Context, st *state.Store, args []string) erro
 		return fmt.Errorf("device pair-code: --%s is required", pairCodeNameFlag)
 	}
 
-	code, expiresAt, err := st.MintPairingCode(ctx, *name)
+	code, expiresAt, err := st.MintPairingCode(ctx, *name, state.DefaultPairingCodeTTL)
 	if err != nil {
 		return fmt.Errorf("mint pairing code: %w", err)
 	}

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -239,7 +239,19 @@ func runDevicePairCode(ctx context.Context, st *state.Store, ttlMax time.Duratio
 		return fmt.Errorf("device pair-code: --%s is required", pairCodeNameFlag)
 	}
 
-	ttl, err := resolvePairCodeTTL(*ttlMinutes, ttlMax)
+	// fs.Visit reports only flags actually set on the command line, unlike
+	// inspecting *ttlMinutes itself — the latter cannot tell an explicit
+	// `--ttl 0` apart from an omitted flag, which would silently redirect a
+	// hard-fail case to the default TTL (the second security-review finding
+	// on issue #129).
+	ttlSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == pairCodeTTLFlag {
+			ttlSet = true
+		}
+	})
+
+	ttl, err := resolvePairCodeTTL(*ttlMinutes, ttlSet, ttlMax)
 	if err != nil {
 		return err
 	}

--- a/cmd/devmon-agent/cli.go
+++ b/cmd/devmon-agent/cli.go
@@ -102,7 +102,7 @@ func runDeviceCommand(ctx context.Context, cfg config.Config, args []string) err
 	case subcommandRevoke:
 		return runDeviceRevoke(ctx, st, args[1:])
 	case subcommandPairCode:
-		return runDevicePairCode(ctx, st, args[1:])
+		return runDevicePairCode(ctx, st, cfg.PairTTLMax, args[1:])
 	default:
 		// Unreachable: args[0] was already validated above.
 		return nil
@@ -219,11 +219,15 @@ func deviceNameByID(devices []state.Device, id string) string {
 // runDevicePairCode mints a single-use pairing code and prints it to stdout
 // ONLY. It must never reach the logger — the log file is persisted and
 // rotated, so a pairing code in agent.log would be a durable credential.
-func runDevicePairCode(ctx context.Context, st *state.Store, args []string) error {
+//
+// ttlMax is the loaded config's PairTTLMax — the ceiling --ttl is checked
+// against. See resolvePairCodeTTL for how the effective TTL is chosen.
+func runDevicePairCode(ctx context.Context, st *state.Store, ttlMax time.Duration, args []string) error {
 	fs := flag.NewFlagSet(subcommandPairCode, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {}
 	name := fs.String(pairCodeNameFlag, "", "name of the device to mint a pairing code for")
+	ttlMinutes := fs.Int(pairCodeTTLFlag, 0, "pairing code TTL in minutes (default: min(10, DEVMON_PAIR_TTL_MAX_MIN); range 5-ceiling)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printDeviceUsage(os.Stdout)
@@ -235,7 +239,12 @@ func runDevicePairCode(ctx context.Context, st *state.Store, args []string) erro
 		return fmt.Errorf("device pair-code: --%s is required", pairCodeNameFlag)
 	}
 
-	code, expiresAt, err := st.MintPairingCode(ctx, *name, state.DefaultPairingCodeTTL)
+	ttl, err := resolvePairCodeTTL(*ttlMinutes, ttlMax)
+	if err != nil {
+		return err
+	}
+
+	code, expiresAt, err := st.MintPairingCode(ctx, *name, ttl)
 	if err != nil {
 		return fmt.Errorf("mint pairing code: %w", err)
 	}

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -288,6 +288,55 @@ func TestRunDevicePairCodeTTLBelowMinimumMintsNothing(t *testing.T) {
 	}
 }
 
+// TestRunDevicePairCodeExplicitZeroTTLMintsNothing proves an explicit
+// `--ttl 0` is a hard error, not silently redirected to the default TTL —
+// the second security-review finding on issue #129. Before the fix, 0
+// doubled as flag.Int's own "not set" zero value, so this exact case was the
+// one exception to "out-of-range is a hard error, never silently
+// substituted".
+func TestRunDevicePairCodeExplicitZeroTTLMintsNothing(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "0"})
+		if err == nil {
+			t.Fatal("runDevicePairCode() = nil error, want one for an explicit --ttl 0")
+		}
+		if !strings.Contains(err.Error(), "0") || !strings.Contains(err.Error(), "5") {
+			t.Errorf("runDevicePairCode() error = %v, want it to name the value and the 5-minute minimum", err)
+		}
+	})
+
+	// Assert — nothing was minted, so nothing was printed either.
+	if got != "" {
+		t.Errorf("runDevicePairCode() wrote %q to stdout, want nothing when --ttl is rejected", got)
+	}
+}
+
+// TestRunDevicePairCodeExplicitNegativeTTLMintsNothing proves an explicit
+// negative --ttl is a hard error too, not just zero.
+func TestRunDevicePairCodeExplicitNegativeTTLMintsNothing(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "-1"})
+		if err == nil {
+			t.Fatal("runDevicePairCode() = nil error, want one for an explicit negative --ttl")
+		}
+	})
+
+	// Assert — nothing was minted, so nothing was printed either.
+	if got != "" {
+		t.Errorf("runDevicePairCode() wrote %q to stdout, want nothing when --ttl is rejected", got)
+	}
+}
+
 func TestRunDevicePairCodeNonIntegerTTLMintsNothing(t *testing.T) {
 	// Arrange
 	st := openTestStore(t)

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/scnplt/devmon-agent/internal/state"
 )
@@ -169,7 +170,7 @@ func TestRunDevicePairCodeRequiresName(t *testing.T) {
 	st := openTestStore(t)
 
 	// Act
-	err := runDevicePairCode(context.Background(), st, nil)
+	err := runDevicePairCode(context.Background(), st, testPairTTLMax, nil)
 
 	// Assert
 	if err == nil {
@@ -184,12 +185,145 @@ func TestRunDevicePairCodeMintsCode(t *testing.T) {
 	st := openTestStore(t)
 
 	// Act
-	err := runDevicePairCode(context.Background(), st, []string{"--" + pairCodeNameFlag, "Pixel 9"})
+	err := runDevicePairCode(context.Background(), st, testPairTTLMax, []string{"--" + pairCodeNameFlag, "Pixel 9"})
 
 	// Assert
 	if err != nil {
 		t.Fatalf("runDevicePairCode() unexpected error: %v", err)
 	}
+}
+
+// TestRunDevicePairCodeExplicitTTLSetsExpiry and the four TTL tests below it
+// deliberately do NOT call t.Parallel() — see captureStdout's comment on
+// TestRunAuditListCommandBadFlagErrorsWithoutStdoutOutput: redirecting the
+// package-level os.Stdout would race with any concurrently running parallel
+// test that also writes to stdout.
+func TestRunDevicePairCodeExplicitTTLSetsExpiry(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+	before := time.Now()
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "7"})
+		if err != nil {
+			t.Fatalf("runDevicePairCode() unexpected error: %v", err)
+		}
+	})
+
+	// Assert — the printed expiry reflects the requested 7-minute TTL, not
+	// the 10-minute default.
+	expires := parseExpiresLine(t, got)
+	wantAround := before.Add(7 * time.Minute)
+	if diff := expires.Sub(wantAround); diff < -time.Minute || diff > time.Minute {
+		t.Errorf("runDevicePairCode() expiry = %v, want close to %v (7m TTL)", expires, wantAround)
+	}
+}
+
+func TestRunDevicePairCodeTTLAboveCeilingMintsNothing(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "30"})
+		if err == nil {
+			t.Fatal("runDevicePairCode() = nil error, want one for --ttl above the ceiling")
+		}
+		if !strings.Contains(err.Error(), "30") || !strings.Contains(err.Error(), "DEVMON_PAIR_TTL_MAX_MIN") {
+			t.Errorf("runDevicePairCode() error = %v, want it to name the value and DEVMON_PAIR_TTL_MAX_MIN", err)
+		}
+	})
+
+	// Assert — nothing was minted, so nothing was printed either.
+	if got != "" {
+		t.Errorf("runDevicePairCode() wrote %q to stdout, want nothing when --ttl is rejected", got)
+	}
+}
+
+func TestRunDevicePairCodeTTLBelowMinimumMintsNothing(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "2"})
+		if err == nil {
+			t.Fatal("runDevicePairCode() = nil error, want one for --ttl below the 5-minute floor")
+		}
+	})
+
+	// Assert
+	if got != "" {
+		t.Errorf("runDevicePairCode() wrote %q to stdout, want nothing when --ttl is rejected", got)
+	}
+}
+
+func TestRunDevicePairCodeNonIntegerTTLMintsNothing(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "not-a-number"})
+		if err == nil {
+			t.Fatal("runDevicePairCode() = nil error, want one for a non-integer --ttl")
+		}
+	})
+
+	// Assert
+	if got != "" {
+		t.Errorf("runDevicePairCode() wrote %q to stdout, want nothing when --ttl fails to parse", got)
+	}
+}
+
+func TestRunDevicePairCodeOmittedTTLUsesLoweredCeiling(t *testing.T) {
+	// Arrange — the ceiling is below the 10-minute default, so the effective
+	// TTL must be the ceiling itself.
+	st := openTestStore(t)
+	before := time.Now()
+	ceiling := 6 * time.Minute
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, ceiling, []string{"--" + pairCodeNameFlag, "Pixel 9"})
+		if err != nil {
+			t.Fatalf("runDevicePairCode() unexpected error: %v", err)
+		}
+	})
+
+	// Assert
+	expires := parseExpiresLine(t, got)
+	wantAround := before.Add(ceiling)
+	if diff := expires.Sub(wantAround); diff < -time.Minute || diff > time.Minute {
+		t.Errorf("runDevicePairCode() expiry = %v, want close to %v (ceiling-clamped TTL)", expires, wantAround)
+	}
+}
+
+// parseExpiresLine extracts the timestamp from the "Expires:" line printed by
+// runDevicePairCode's stdout, so a test can assert on the actual TTL used
+// without re-parsing the pairing code line too.
+func parseExpiresLine(t *testing.T, stdout string) time.Time {
+	t.Helper()
+
+	for _, line := range strings.Split(stdout, "\n") {
+		const prefix = "Expires:"
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		expires, err := time.Parse(deviceTimeFormat, raw)
+		if err != nil {
+			t.Fatalf("parse expires line %q: %v", line, err)
+		}
+		return expires
+	}
+	t.Fatalf("no %q line found in stdout %q", "Expires:", stdout)
+	return time.Time{}
 }
 
 func TestRunDeviceCommandDispatchesToSubcommands(t *testing.T) {
@@ -609,7 +743,7 @@ func TestRunDevicePairCodeHelpReturnsNilWithoutWrappedError(t *testing.T) {
 	st := openTestStore(t)
 
 	// Act
-	err := runDevicePairCode(context.Background(), st, []string{"--help"})
+	err := runDevicePairCode(context.Background(), st, testPairTTLMax, []string{"--help"})
 
 	// Assert
 	if err != nil {
@@ -683,7 +817,7 @@ func TestRunDevicePairCodeBadFlagErrorsWithoutStdoutOutput(t *testing.T) {
 
 	// Act
 	got := captureStdout(t, func() {
-		err = runDevicePairCode(context.Background(), st, []string{"--bogus"})
+		err = runDevicePairCode(context.Background(), st, testPairTTLMax, []string{"--bogus"})
 	})
 
 	// Assert

--- a/cmd/devmon-agent/cli_test.go
+++ b/cmd/devmon-agent/cli_test.go
@@ -243,6 +243,32 @@ func TestRunDevicePairCodeTTLAboveCeilingMintsNothing(t *testing.T) {
 	}
 }
 
+// TestRunDevicePairCodeHugeTTLMintsNothing proves a --ttl large enough to
+// overflow int64 nanoseconds under naive Duration multiplication is still a
+// hard error at the CLI layer, not silently accepted — see
+// resolvePairCodeTTL's overflow-safety doc comment.
+func TestRunDevicePairCodeHugeTTLMintsNothing(t *testing.T) {
+	// Arrange
+	st := openTestStore(t)
+
+	// Act
+	got := captureStdout(t, func() {
+		err := runDevicePairCode(context.Background(), st, testPairTTLMax,
+			[]string{"--" + pairCodeNameFlag, "Pixel 9", "--" + pairCodeTTLFlag, "9007199254741022"})
+		if err == nil {
+			t.Fatal("runDevicePairCode() = nil error, want one for a --ttl that overflows under naive multiplication")
+		}
+		if !strings.Contains(err.Error(), "9007199254741022") || !strings.Contains(err.Error(), "DEVMON_PAIR_TTL_MAX_MIN") {
+			t.Errorf("runDevicePairCode() error = %v, want it to name the typed value and DEVMON_PAIR_TTL_MAX_MIN", err)
+		}
+	})
+
+	// Assert — nothing was minted, so nothing was printed either.
+	if got != "" {
+		t.Errorf("runDevicePairCode() wrote %q to stdout, want nothing when --ttl is rejected", got)
+	}
+}
+
 func TestRunDevicePairCodeTTLBelowMinimumMintsNothing(t *testing.T) {
 	// Arrange
 	st := openTestStore(t)

--- a/cmd/devmon-agent/main_test.go
+++ b/cmd/devmon-agent/main_test.go
@@ -14,9 +14,14 @@ import (
 	"github.com/scnplt/devmon-agent/internal/config"
 )
 
+// testPairTTLMax mirrors internal/config's default for DEVMON_PAIR_TTL_MAX_MIN
+// (defaultPairTTLMaxMin), so tests that never touch --ttl behave the same as
+// an agent started without that env var set.
+const testPairTTLMax = 10 * time.Minute
+
 func testStateConfig(t *testing.T) config.Config {
 	t.Helper()
-	return config.Config{StateDir: t.TempDir()}
+	return config.Config{StateDir: t.TempDir(), PairTTLMax: testPairTTLMax}
 }
 
 func statDir(path string) error {

--- a/cmd/devmon-agent/pair_code_ttl.go
+++ b/cmd/devmon-agent/pair_code_ttl.go
@@ -18,9 +18,6 @@ const pairCodeTTLFlag = "ttl"
 // would expire before an operator can plausibly read and enter one.
 const pairCodeMinTTLMinutes = 5
 
-// pairCodeMinTTL is pairCodeMinTTLMinutes expressed as a Duration.
-const pairCodeMinTTL = pairCodeMinTTLMinutes * time.Minute
-
 // pairTTLMaxEnvVar names the env var that sets the ceiling --ttl is checked
 // against, so a rejected --ttl points the operator at the knob that controls
 // it instead of just a bare number.
@@ -39,6 +36,14 @@ const pairTTLMaxEnvVar = "DEVMON_PAIR_TTL_MAX_MIN"
 // An explicit value outside [pairCodeMinTTLMinutes, ceiling] is a hard error;
 // it is never clamped, so an operator's script can trust that "no error"
 // means the code was minted with the exact TTL requested.
+//
+// The range check happens on the raw minute count, before ttlMinutes is ever
+// multiplied by time.Minute. time.Duration is int64 nanoseconds, so
+// multiplying an out-of-range minute count first can overflow and wrap
+// around to an innocent-looking Duration that would slip past a Duration
+// comparison against ceiling — mirrors internal/config's rangedInt, which
+// bounds-checks the raw integer before any Duration conversion for the same
+// reason.
 func resolvePairCodeTTL(ttlMinutes int, ceiling time.Duration) (time.Duration, error) {
 	if ttlMinutes == 0 {
 		def := state.DefaultPairingCodeTTL
@@ -48,14 +53,14 @@ func resolvePairCodeTTL(ttlMinutes int, ceiling time.Duration) (time.Duration, e
 		return def, nil
 	}
 
-	requested := time.Duration(ttlMinutes) * time.Minute
-	if requested < pairCodeMinTTL {
+	ceilingMinutes := int(ceiling / time.Minute)
+	if ttlMinutes < pairCodeMinTTLMinutes {
 		return 0, fmt.Errorf("device pair-code: --%s %d is below the %d-minute minimum",
 			pairCodeTTLFlag, ttlMinutes, pairCodeMinTTLMinutes)
 	}
-	if requested > ceiling {
+	if ttlMinutes > ceilingMinutes {
 		return 0, fmt.Errorf("device pair-code: --%s %d exceeds %s (%d)",
-			pairCodeTTLFlag, ttlMinutes, pairTTLMaxEnvVar, int(ceiling/time.Minute))
+			pairCodeTTLFlag, ttlMinutes, pairTTLMaxEnvVar, ceilingMinutes)
 	}
-	return requested, nil
+	return time.Duration(ttlMinutes) * time.Minute, nil
 }

--- a/cmd/devmon-agent/pair_code_ttl.go
+++ b/cmd/devmon-agent/pair_code_ttl.go
@@ -26,16 +26,21 @@ const pairTTLMaxEnvVar = "DEVMON_PAIR_TTL_MAX_MIN"
 // resolvePairCodeTTL turns the raw --ttl flag value into the Duration to mint
 // a pairing code with, or rejects it outright.
 //
-// ttlMinutes is 0 when --ttl was omitted — flag.Int's own zero value doubles
-// as the "not set" sentinel here, which is safe because 0 is never a valid
-// explicit value (it is below pairCodeMinTTLMinutes). In that case the
-// effective TTL is min(state.DefaultPairingCodeTTL, ceiling): never above the
-// ceiling, with no cross-field validation error for a default that happens to
-// exceed a lowered ceiling.
+// set reports whether --ttl was actually passed on the command line — the
+// caller determines this with flag.FlagSet.Visit, never by inspecting
+// ttlMinutes itself. flag.Int's zero value cannot double as a "not set"
+// sentinel here: doing so would make an explicit `--ttl 0` indistinguishable
+// from an omitted flag and silently redirect it to the default TTL instead
+// of hard-failing it like every other below-floor value (the second
+// security-review finding on issue #129). When set is false the effective
+// TTL is min(state.DefaultPairingCodeTTL, ceiling): never above the ceiling,
+// with no cross-field validation error for a default that happens to exceed
+// a lowered ceiling.
 //
-// An explicit value outside [pairCodeMinTTLMinutes, ceiling] is a hard error;
-// it is never clamped, so an operator's script can trust that "no error"
-// means the code was minted with the exact TTL requested.
+// When set is true, ttlMinutes outside [pairCodeMinTTLMinutes, ceiling] —
+// including 0 and negative values — is a hard error; it is never clamped, so
+// an operator's script can trust that "no error" means the code was minted
+// with the exact TTL requested.
 //
 // The range check happens on the raw minute count, before ttlMinutes is ever
 // multiplied by time.Minute. time.Duration is int64 nanoseconds, so
@@ -44,8 +49,8 @@ const pairTTLMaxEnvVar = "DEVMON_PAIR_TTL_MAX_MIN"
 // comparison against ceiling — mirrors internal/config's rangedInt, which
 // bounds-checks the raw integer before any Duration conversion for the same
 // reason.
-func resolvePairCodeTTL(ttlMinutes int, ceiling time.Duration) (time.Duration, error) {
-	if ttlMinutes == 0 {
+func resolvePairCodeTTL(ttlMinutes int, set bool, ceiling time.Duration) (time.Duration, error) {
+	if !set {
 		def := state.DefaultPairingCodeTTL
 		if def > ceiling {
 			def = ceiling

--- a/cmd/devmon-agent/pair_code_ttl.go
+++ b/cmd/devmon-agent/pair_code_ttl.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/scnplt/devmon-agent/internal/state"
+)
+
+// pairCodeTTLFlag is the --ttl flag on `device pair-code`.
+const pairCodeTTLFlag = "ttl"
+
+// pairCodeMinTTLMinutes is the floor for --ttl. It mirrors
+// internal/config's minPairTTLMaxMin: that package validates
+// DEVMON_PAIR_TTL_MAX_MIN against the same floor, so a code minted below it
+// would expire before an operator can plausibly read and enter one.
+const pairCodeMinTTLMinutes = 5
+
+// pairCodeMinTTL is pairCodeMinTTLMinutes expressed as a Duration.
+const pairCodeMinTTL = pairCodeMinTTLMinutes * time.Minute
+
+// pairTTLMaxEnvVar names the env var that sets the ceiling --ttl is checked
+// against, so a rejected --ttl points the operator at the knob that controls
+// it instead of just a bare number.
+const pairTTLMaxEnvVar = "DEVMON_PAIR_TTL_MAX_MIN"
+
+// resolvePairCodeTTL turns the raw --ttl flag value into the Duration to mint
+// a pairing code with, or rejects it outright.
+//
+// ttlMinutes is 0 when --ttl was omitted — flag.Int's own zero value doubles
+// as the "not set" sentinel here, which is safe because 0 is never a valid
+// explicit value (it is below pairCodeMinTTLMinutes). In that case the
+// effective TTL is min(state.DefaultPairingCodeTTL, ceiling): never above the
+// ceiling, with no cross-field validation error for a default that happens to
+// exceed a lowered ceiling.
+//
+// An explicit value outside [pairCodeMinTTLMinutes, ceiling] is a hard error;
+// it is never clamped, so an operator's script can trust that "no error"
+// means the code was minted with the exact TTL requested.
+func resolvePairCodeTTL(ttlMinutes int, ceiling time.Duration) (time.Duration, error) {
+	if ttlMinutes == 0 {
+		def := state.DefaultPairingCodeTTL
+		if def > ceiling {
+			def = ceiling
+		}
+		return def, nil
+	}
+
+	requested := time.Duration(ttlMinutes) * time.Minute
+	if requested < pairCodeMinTTL {
+		return 0, fmt.Errorf("device pair-code: --%s %d is below the %d-minute minimum",
+			pairCodeTTLFlag, ttlMinutes, pairCodeMinTTLMinutes)
+	}
+	if requested > ceiling {
+		return 0, fmt.Errorf("device pair-code: --%s %d exceeds %s (%d)",
+			pairCodeTTLFlag, ttlMinutes, pairTTLMaxEnvVar, int(ceiling/time.Minute))
+	}
+	return requested, nil
+}

--- a/cmd/devmon-agent/pair_code_ttl_test.go
+++ b/cmd/devmon-agent/pair_code_ttl_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolvePairCodeTTLOmittedUsesDefaultCeiling(t *testing.T) {
+	t.Parallel()
+
+	// Act — --ttl omitted (sentinel 0), ceiling is the config default (10m).
+	got, err := resolvePairCodeTTL(0, 10*time.Minute)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("resolvePairCodeTTL() unexpected error: %v", err)
+	}
+	if got != 10*time.Minute {
+		t.Errorf("resolvePairCodeTTL() = %v, want 10m", got)
+	}
+}
+
+func TestResolvePairCodeTTLOmittedClampsToLoweredCeiling(t *testing.T) {
+	t.Parallel()
+
+	// Act — the ceiling is lowered below the 10-minute default, so the
+	// effective TTL must never exceed it even with --ttl omitted.
+	got, err := resolvePairCodeTTL(0, 7*time.Minute)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("resolvePairCodeTTL() unexpected error: %v", err)
+	}
+	if got != 7*time.Minute {
+		t.Errorf("resolvePairCodeTTL() = %v, want 7m (the ceiling)", got)
+	}
+}
+
+func TestResolvePairCodeTTLExplicitValueWithinRange(t *testing.T) {
+	t.Parallel()
+
+	// Act
+	got, err := resolvePairCodeTTL(8, 15*time.Minute)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("resolvePairCodeTTL() unexpected error: %v", err)
+	}
+	if got != 8*time.Minute {
+		t.Errorf("resolvePairCodeTTL() = %v, want 8m", got)
+	}
+}
+
+func TestResolvePairCodeTTLAboveCeilingErrors(t *testing.T) {
+	t.Parallel()
+
+	// Act
+	_, err := resolvePairCodeTTL(30, 15*time.Minute)
+
+	// Assert
+	if err == nil {
+		t.Fatal("resolvePairCodeTTL() = nil error, want one for a TTL above the ceiling")
+	}
+	if !strings.Contains(err.Error(), "30") || !strings.Contains(err.Error(), "DEVMON_PAIR_TTL_MAX_MIN") || !strings.Contains(err.Error(), "15") {
+		t.Errorf("resolvePairCodeTTL() error = %v, want it to name the requested value, the env var, and the ceiling", err)
+	}
+}
+
+func TestResolvePairCodeTTLBelowMinimumErrors(t *testing.T) {
+	t.Parallel()
+
+	// Act
+	_, err := resolvePairCodeTTL(4, 15*time.Minute)
+
+	// Assert
+	if err == nil {
+		t.Fatal("resolvePairCodeTTL() = nil error, want one for a TTL below the 5-minute floor")
+	}
+	if !strings.Contains(err.Error(), "4") || !strings.Contains(err.Error(), "5") {
+		t.Errorf("resolvePairCodeTTL() error = %v, want it to name the requested value and the 5-minute minimum", err)
+	}
+}
+
+func TestResolvePairCodeTTLAtBoundsSucceeds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		minutes int
+		ceiling time.Duration
+	}{
+		{"exactly the floor", 5, 60 * time.Minute},
+		{"exactly the ceiling", 60, 60 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got, err := resolvePairCodeTTL(tt.minutes, tt.ceiling)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("resolvePairCodeTTL(%d, %v) unexpected error: %v", tt.minutes, tt.ceiling, err)
+			}
+			if want := time.Duration(tt.minutes) * time.Minute; got != want {
+				t.Errorf("resolvePairCodeTTL(%d, %v) = %v, want %v", tt.minutes, tt.ceiling, got, want)
+			}
+		})
+	}
+}

--- a/cmd/devmon-agent/pair_code_ttl_test.go
+++ b/cmd/devmon-agent/pair_code_ttl_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +82,68 @@ func TestResolvePairCodeTTLBelowMinimumErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "4") || !strings.Contains(err.Error(), "5") {
 		t.Errorf("resolvePairCodeTTL() error = %v, want it to name the requested value and the 5-minute minimum", err)
+	}
+}
+
+// TestResolvePairCodeTTLOverflowingValuesAreHardErrors proves resolvePairCodeTTL
+// range-checks the raw --ttl minute count before ever multiplying it by
+// time.Minute. time.Duration is int64 nanoseconds, so multiplying first lets
+// a huge minute count wrap via two's-complement overflow into an
+// innocent-looking Duration that would slip past the ceiling check — see the
+// security-review finding on issue #129. Every case here must be rejected
+// with an error that names the literal value the caller passed, never
+// silently accepted or clamped.
+func TestResolvePairCodeTTLOverflowingValuesAreHardErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		minutes int
+		ceiling time.Duration
+		wantIn  []string // substrings the error message must contain
+	}{
+		{
+			// 9007199254741022 minutes * time.Minute (60e9 ns) overflows
+			// int64 and wraps around to exactly 30m — historically accepted
+			// against a 60m ceiling despite being nowhere near it.
+			name:    "wraps to exactly 30m under naive multiplication",
+			minutes: 9007199254741022,
+			ceiling: 60 * time.Minute,
+			wantIn:  []string{"9007199254741022", pairTTLMaxEnvVar, "60"},
+		},
+		{
+			name:    "math.MaxInt64",
+			minutes: math.MaxInt64,
+			ceiling: 60 * time.Minute,
+			wantIn:  []string{"9223372036854775807", pairTTLMaxEnvVar, "60"},
+		},
+		{
+			name:    "large negative value",
+			minutes: -9007199254741022,
+			ceiling: 60 * time.Minute,
+			wantIn:  []string{"-9007199254741022", "5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got, err := resolvePairCodeTTL(tt.minutes, tt.ceiling)
+
+			// Assert
+			if err == nil {
+				t.Fatalf("resolvePairCodeTTL(%d, %v) = %v, nil error, want a hard error", tt.minutes, tt.ceiling, got)
+			}
+			if got != 0 {
+				t.Errorf("resolvePairCodeTTL(%d, %v) = %v, want 0 on error", tt.minutes, tt.ceiling, got)
+			}
+			for _, want := range tt.wantIn {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("resolvePairCodeTTL(%d, %v) error = %q, want it to contain %q", tt.minutes, tt.ceiling, err.Error(), want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/devmon-agent/pair_code_ttl_test.go
+++ b/cmd/devmon-agent/pair_code_ttl_test.go
@@ -12,8 +12,10 @@ import (
 func TestResolvePairCodeTTLOmittedUsesDefaultCeiling(t *testing.T) {
 	t.Parallel()
 
-	// Act — --ttl omitted (sentinel 0), ceiling is the config default (10m).
-	got, err := resolvePairCodeTTL(0, 10*time.Minute)
+	// Act — --ttl omitted (set=false), ceiling is the config default (10m).
+	// ttlMinutes is 0 here too, proving the omitted path is driven by set,
+	// never by the raw value.
+	got, err := resolvePairCodeTTL(0, false, 10*time.Minute)
 
 	// Assert
 	if err != nil {
@@ -29,7 +31,7 @@ func TestResolvePairCodeTTLOmittedClampsToLoweredCeiling(t *testing.T) {
 
 	// Act — the ceiling is lowered below the 10-minute default, so the
 	// effective TTL must never exceed it even with --ttl omitted.
-	got, err := resolvePairCodeTTL(0, 7*time.Minute)
+	got, err := resolvePairCodeTTL(0, false, 7*time.Minute)
 
 	// Assert
 	if err != nil {
@@ -44,7 +46,7 @@ func TestResolvePairCodeTTLExplicitValueWithinRange(t *testing.T) {
 	t.Parallel()
 
 	// Act
-	got, err := resolvePairCodeTTL(8, 15*time.Minute)
+	got, err := resolvePairCodeTTL(8, true, 15*time.Minute)
 
 	// Assert
 	if err != nil {
@@ -59,7 +61,7 @@ func TestResolvePairCodeTTLAboveCeilingErrors(t *testing.T) {
 	t.Parallel()
 
 	// Act
-	_, err := resolvePairCodeTTL(30, 15*time.Minute)
+	_, err := resolvePairCodeTTL(30, true, 15*time.Minute)
 
 	// Assert
 	if err == nil {
@@ -74,13 +76,56 @@ func TestResolvePairCodeTTLBelowMinimumErrors(t *testing.T) {
 	t.Parallel()
 
 	// Act
-	_, err := resolvePairCodeTTL(4, 15*time.Minute)
+	_, err := resolvePairCodeTTL(4, true, 15*time.Minute)
 
 	// Assert
 	if err == nil {
 		t.Fatal("resolvePairCodeTTL() = nil error, want one for a TTL below the 5-minute floor")
 	}
 	if !strings.Contains(err.Error(), "4") || !strings.Contains(err.Error(), "5") {
+		t.Errorf("resolvePairCodeTTL() error = %v, want it to name the requested value and the 5-minute minimum", err)
+	}
+}
+
+// TestResolvePairCodeTTLExplicitZeroErrors proves an explicit `--ttl 0` is a
+// hard error rather than being silently redirected to the default TTL — the
+// second security-review finding on issue #129. Only set=false (the flag
+// truly omitted) takes the default path; set=true with ttlMinutes==0 must
+// fail exactly like any other below-floor explicit value.
+func TestResolvePairCodeTTLExplicitZeroErrors(t *testing.T) {
+	t.Parallel()
+
+	// Act
+	got, err := resolvePairCodeTTL(0, true, 15*time.Minute)
+
+	// Assert
+	if err == nil {
+		t.Fatal("resolvePairCodeTTL() = nil error, want one for an explicit --ttl 0")
+	}
+	if got != 0 {
+		t.Errorf("resolvePairCodeTTL() = %v, want 0 on error", got)
+	}
+	if !strings.Contains(err.Error(), "0") || !strings.Contains(err.Error(), "5") {
+		t.Errorf("resolvePairCodeTTL() error = %v, want it to name the requested value and the 5-minute minimum", err)
+	}
+}
+
+// TestResolvePairCodeTTLExplicitNegativeErrors proves an explicit negative
+// --ttl is a hard error, not clamped or treated as omitted.
+func TestResolvePairCodeTTLExplicitNegativeErrors(t *testing.T) {
+	t.Parallel()
+
+	// Act
+	got, err := resolvePairCodeTTL(-1, true, 15*time.Minute)
+
+	// Assert
+	if err == nil {
+		t.Fatal("resolvePairCodeTTL() = nil error, want one for an explicit negative --ttl")
+	}
+	if got != 0 {
+		t.Errorf("resolvePairCodeTTL() = %v, want 0 on error", got)
+	}
+	if !strings.Contains(err.Error(), "-1") || !strings.Contains(err.Error(), "5") {
 		t.Errorf("resolvePairCodeTTL() error = %v, want it to name the requested value and the 5-minute minimum", err)
 	}
 }
@@ -129,7 +174,7 @@ func TestResolvePairCodeTTLOverflowingValuesAreHardErrors(t *testing.T) {
 			t.Parallel()
 
 			// Act
-			got, err := resolvePairCodeTTL(tt.minutes, tt.ceiling)
+			got, err := resolvePairCodeTTL(tt.minutes, true, tt.ceiling)
 
 			// Assert
 			if err == nil {
@@ -163,7 +208,7 @@ func TestResolvePairCodeTTLAtBoundsSucceeds(t *testing.T) {
 			t.Parallel()
 
 			// Act
-			got, err := resolvePairCodeTTL(tt.minutes, tt.ceiling)
+			got, err := resolvePairCodeTTL(tt.minutes, true, tt.ceiling)
 
 			// Assert
 			if err != nil {

--- a/cmd/devmon-agent/usage.go
+++ b/cmd/devmon-agent/usage.go
@@ -25,12 +25,12 @@ Usage:
   devmon-agent               run the agent daemon (container entrypoint)
 
 Commands:
-  device list                     list paired devices
-  device revoke <id>              revoke a device's access
-  device pair-code --name <name>  mint a single-use pairing code
-  audit list [--limit N]          print recent audit entries (default 100)
-  health                          probe the running agent's listener
-  help                            show this help
+  device list                                     list paired devices
+  device revoke <id>                              revoke a device's access
+  device pair-code --name <name> [--ttl minutes]  mint a single-use pairing code
+  audit list [--limit N]                          print recent audit entries (default 100)
+  health                                           probe the running agent's listener
+  help                                             show this help
 
 Flags:
   --version   print version information and exit
@@ -44,9 +44,12 @@ Run 'devmon <command> --help' for details on a command.
 const deviceUsage = `Usage: devmon device <subcommand> [flags]
 
 Subcommands:
-  list                     list paired devices
-  revoke <id>              revoke a device's access
-  pair-code --name <name>  mint a single-use pairing code
+  list                                            list paired devices
+  revoke <id>                                     revoke a device's access
+  pair-code --name <name> [--ttl minutes]         mint a single-use pairing code
+
+--ttl minutes   pairing code lifetime, 5 to DEVMON_PAIR_TTL_MAX_MIN
+                (default: 10, or the ceiling if it is lower)
 `
 
 // auditUsage is shown for `audit --help`.

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -141,3 +141,10 @@ services:
       # DEVMON_RATE_STATUS_PER_MIN: "30"
       # DEVMON_RATE_PAIR_PER_MIN: "5"
       # DEVMON_RATE_GUARDED_PER_SEC: "20"
+
+      # Ceiling, in minutes, for `device pair-code --ttl`; shown at its
+      # default. Valid range 5-60. A minted code that leaks before it is
+      # redeemed stays redeemable until it expires, so the ceiling is fixed
+      # here at startup — nothing a client can reach can raise it, and 60 is
+      # an absolute cap.
+      # DEVMON_PAIR_TTL_MAX_MIN: "10"

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -37,7 +37,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.5.0
+    image: ghcr.io/scnplt/devmon-agent:0.6.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.5.0
+  version: 0.6.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -123,7 +123,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.5.0
+                    agent_version: 0.6.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -975,7 +975,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.5.0"]
+          examples: ["0.6.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ set -eu
 # They must stay in step with README.md and compose.example.yaml, which name
 # the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.5.0'
+IMAGE_TAG='0.6.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,8 @@ const (
 	envRateStatusPerMin  = "DEVMON_RATE_STATUS_PER_MIN"
 	envRatePairPerMin    = "DEVMON_RATE_PAIR_PER_MIN"
 	envRateGuardedPerSec = "DEVMON_RATE_GUARDED_PER_SEC"
+
+	envPairTTLMax = "DEVMON_PAIR_TTL_MAX_MIN"
 )
 
 // Defaults. DEVMON_PUBLIC_ADDR deliberately has none — a server certificate with
@@ -58,6 +60,8 @@ const (
 	defaultRateStatusPerMin  = 30
 	defaultRatePairPerMin    = 5
 	defaultRateGuardedPerSec = 20
+
+	defaultPairTTLMaxMin = 10
 )
 
 // Validation bounds.
@@ -83,6 +87,14 @@ const (
 
 	maxDNSLabelLen = 63
 	maxDNSNameLen  = 253
+
+	// minPairTTLMaxMin and maxPairTTLMaxMin bound DEVMON_PAIR_TTL_MAX_MIN: a
+	// ceiling below the floor would make pairing codes expire before an
+	// operator can plausibly read and enter one, and a ceiling above the
+	// cap widens the window a leaked code stays usable well past what any
+	// legitimate pairing flow needs.
+	minPairTTLMaxMin = 5
+	maxPairTTLMaxMin = 60
 )
 
 const hoursPerDay = 24
@@ -111,6 +123,12 @@ type Config struct {
 	RateStatusPerMin  int
 	RatePairPerMin    int
 	RateGuardedPerSec int
+
+	// PairTTLMax is the ceiling for the pairing-code TTL: the CLI must reject
+	// any requested TTL longer than this. It is parsed from
+	// DEVMON_PAIR_TTL_MAX_MIN, an integer count of minutes, and stored as a
+	// Duration so callers never have to remember the source unit.
+	PairTTLMax time.Duration
 
 	// SelfContainer is an operator-supplied name-or-ID override for the
 	// agent's own container, used when the agent cannot detect it
@@ -174,6 +192,8 @@ func Load(getenv func(string) string) (Config, error) {
 		RateStatusPerMin:  l.boundedInt(envRateStatusPerMin, defaultRateStatusPerMin, minRatePerX),
 		RatePairPerMin:    l.boundedInt(envRatePairPerMin, defaultRatePairPerMin, minRatePerX),
 		RateGuardedPerSec: l.boundedInt(envRateGuardedPerSec, defaultRateGuardedPerSec, minRatePerX),
+
+		PairTTLMax: l.minutes(envPairTTLMax, defaultPairTTLMaxMin, minPairTTLMaxMin, maxPairTTLMaxMin),
 
 		SelfContainer: l.selfContainer(),
 	}
@@ -340,6 +360,33 @@ func (l *loader) boundedInt(key string, def, min int) int {
 		return def
 	}
 	return n
+}
+
+// rangedInt parses key as an integer within [min, max] inclusive. On any fault
+// it records the problem and returns def, so parsing continues and every
+// remaining variable is still checked. It is the range-checked counterpart of
+// boundedInt, which only enforces a floor.
+func (l *loader) rangedInt(key string, def, min, max int) int {
+	raw := l.raw(key, "")
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		l.fail(key, "%q is not an integer", raw)
+		return def
+	}
+	if n < min || n > max {
+		l.fail(key, "%d is not in %d-%d", n, min, max)
+		return def
+	}
+	return n
+}
+
+// minutes parses an integer minute count within [min, max] and returns it as
+// a Duration, so no caller has to remember which unit the variable was in.
+func (l *loader) minutes(key string, def, min, max int) time.Duration {
+	return time.Duration(l.rangedInt(key, def, min, max)) * time.Minute
 }
 
 // checkRetentionOrder enforces the separate-retention-budgets rule: the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,6 +56,7 @@ func TestLoadDefaults(t *testing.T) {
 		{"RateStatusPerMin", cfg.RateStatusPerMin, defaultRateStatusPerMin},
 		{"RatePairPerMin", cfg.RatePairPerMin, defaultRatePairPerMin},
 		{"RateGuardedPerSec", cfg.RateGuardedPerSec, defaultRateGuardedPerSec},
+		{"PairTTLMax", cfg.PairTTLMax, defaultPairTTLMaxMin * time.Minute},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -202,6 +203,33 @@ func TestLoadOverrides(t *testing.T) {
 			},
 		},
 		{
+			name: "pair TTL max empty string falls back to the default",
+			env:  map[string]string{envPairTTLMax: ""},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.PairTTLMax != defaultPairTTLMaxMin*time.Minute {
+					t.Errorf("PairTTLMax = %v, want %dm (default)", cfg.PairTTLMax, defaultPairTTLMaxMin)
+				}
+			},
+		},
+		{
+			name: "pair TTL max override, lower bound",
+			env:  map[string]string{envPairTTLMax: "5"},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.PairTTLMax != 5*time.Minute {
+					t.Errorf("PairTTLMax = %v, want 5m", cfg.PairTTLMax)
+				}
+			},
+		},
+		{
+			name: "pair TTL max override, upper bound",
+			env:  map[string]string{envPairTTLMax: "60"},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.PairTTLMax != 60*time.Minute {
+					t.Errorf("PairTTLMax = %v, want 60m", cfg.PairTTLMax)
+				}
+			},
+		},
+		{
 			name: "rate limit overrides",
 			env: map[string]string{
 				envRateStatusPerMin:  "60",
@@ -309,6 +337,9 @@ func TestLoadRejections(t *testing.T) {
 		{"non-integer guarded rate", map[string]string{envRateGuardedPerSec: "many"}, envRateGuardedPerSec},
 		{"zero guarded rate", map[string]string{envRateGuardedPerSec: "0"}, envRateGuardedPerSec},
 		{"negative guarded rate", map[string]string{envRateGuardedPerSec: "-1"}, envRateGuardedPerSec},
+		{"pair TTL max below the floor", map[string]string{envPairTTLMax: "4"}, envPairTTLMax},
+		{"pair TTL max above the ceiling", map[string]string{envPairTTLMax: "61"}, envPairTTLMax},
+		{"non-integer pair TTL max", map[string]string{envPairTTLMax: "many"}, envPairTTLMax},
 	}
 
 	for _, tt := range tests {

--- a/internal/httpapi/pair_test.go
+++ b/internal/httpapi/pair_test.go
@@ -95,7 +95,7 @@ func TestHandlePairSucceeds(t *testing.T) {
 
 	// Arrange
 	s, st, ca := testServerForPairing(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestHandlePairCodeReusedFails(t *testing.T) {
 
 	// Arrange
 	s, st, _ := testServerForPairing(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestHandlePairMalformedCSRFails(t *testing.T) {
 
 	// Arrange
 	s, st, _ := testServerForPairing(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestHandlePairIssueCertFailureIsInternalError(t *testing.T) {
 
 	// Arrange
 	s, st, _ := testServerForPairing(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestPairDeviceRollbackSurvivesCanceledContext(t *testing.T) {
 
 	// Arrange
 	s, st, _ := testServerForPairing(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestHandlePairSuccessWritesAuditRowWithNewDeviceID(t *testing.T) {
 
 	// Arrange
 	s, st, _ := testServerForPairing(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -523,7 +523,7 @@ func TestHandlePairWithoutCAFailsClosed(t *testing.T) {
 
 	// Arrange
 	s, st := testServerForPairingWithoutCA(t)
-	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9")
+	code, _, err := st.MintPairingCode(context.Background(), "Pixel 9", state.DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}

--- a/internal/state/errors_test.go
+++ b/internal/state/errors_test.go
@@ -106,7 +106,7 @@ func TestMethodsFailWhenStoreIsClosed(t *testing.T) {
 			return s.TouchDevice(ctx, "id")
 		}},
 		{"MintPairingCode", func(ctx context.Context, s *Store) error {
-			_, _, err := s.MintPairingCode(ctx, "device")
+			_, _, err := s.MintPairingCode(ctx, "device", DefaultPairingCodeTTL)
 			return err
 		}},
 		{"RedeemPairingCode", func(ctx context.Context, s *Store) error {

--- a/internal/state/pairing.go
+++ b/internal/state/pairing.go
@@ -13,24 +13,31 @@ import (
 	"time"
 )
 
-// pairingCodeTTL bounds how long a minted pairing code stays redeemable.
-// Ten minutes is long enough for an operator to read the code aloud or type
-// it on a phone, short enough that a leaked, unused code stops mattering
-// quickly — rate limiting is Phase 6, so the code's own lifetime is part of
-// what keeps it safe until then (D3).
-const pairingCodeTTL = 10 * time.Minute
+// DefaultPairingCodeTTL is the TTL callers should pass to MintPairingCode
+// absent an operator-configured override. Ten minutes is long enough for an
+// operator to read the code aloud or type it on a phone, short enough that a
+// leaked, unused code stops mattering quickly — rate limiting is Phase 6, so
+// the code's own lifetime is part of what keeps it safe until then (D3).
+const DefaultPairingCodeTTL = 10 * time.Minute
 
-// MintPairingCode generates a single-use pairing code for deviceName and
-// persists only its hex SHA-256 (D4) — the plaintext is never written to
-// disk and is unrecoverable once this call returns. The caller must show it
-// to the operator once and never log it.
-func (s *Store) MintPairingCode(ctx context.Context, deviceName string) (string, time.Time, error) {
+// MintPairingCode generates a single-use pairing code for deviceName, valid
+// for ttl, and persists only its hex SHA-256 (D4) — the plaintext is never
+// written to disk and is unrecoverable once this call returns. The caller
+// must show it to the operator once and never log it.
+//
+// ttl must be positive: a non-positive value is a programming error at this
+// layer, and MintPairingCode returns an error without minting anything.
+func (s *Store) MintPairingCode(ctx context.Context, deviceName string, ttl time.Duration) (string, time.Time, error) {
+	if ttl <= 0 {
+		return "", time.Time{}, fmt.Errorf("mint pairing code: ttl must be positive, got %s", ttl)
+	}
+
 	code := rand.Text()
 	hash := sha256.Sum256([]byte(code))
 	codeHash := hex.EncodeToString(hash[:])
 
 	now := time.Now()
-	expiresAt := now.Add(pairingCodeTTL)
+	expiresAt := now.Add(ttl)
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO pairing_codes (code_hash, device_name, created_at, expires_at)

--- a/internal/state/pairing_test.go
+++ b/internal/state/pairing_test.go
@@ -17,7 +17,7 @@ func TestMintPairingCodeThenRedeemSucceeds(t *testing.T) {
 	// Arrange
 	s := openStore(t, tempDBPath(t))
 	ctx := context.Background()
-	code, expiresAt, err := s.MintPairingCode(ctx, "Pixel 9")
+	code, expiresAt, err := s.MintPairingCode(ctx, "Pixel 9", DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -37,13 +37,76 @@ func TestMintPairingCodeThenRedeemSucceeds(t *testing.T) {
 	}
 }
 
+func TestMintPairingCodeUsesCallerSuppliedTTL(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	s := openStore(t, tempDBPath(t))
+	ctx := context.Background()
+	const ttl = 90 * time.Second
+
+	// Act
+	before := time.Now()
+	_, expiresAt, err := s.MintPairingCode(ctx, "Pixel 9", ttl)
+	after := time.Now()
+
+	// Assert
+	if err != nil {
+		t.Fatalf("MintPairingCode() unexpected error: %v", err)
+	}
+	wantMin := before.Add(ttl)
+	wantMax := after.Add(ttl)
+	if expiresAt.Before(wantMin) || expiresAt.After(wantMax) {
+		t.Fatalf("MintPairingCode() expiresAt = %v, want between %v and %v", expiresAt, wantMin, wantMax)
+	}
+}
+
+func TestMintPairingCodeRejectsNonPositiveTTL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			s := openStore(t, tempDBPath(t))
+			ctx := context.Background()
+
+			// Act
+			code, expiresAt, err := s.MintPairingCode(ctx, "Pixel 9", tc.ttl)
+
+			// Assert
+			if err == nil {
+				t.Fatalf("MintPairingCode() error = nil for ttl %s, want an error", tc.ttl)
+			}
+			if code != "" {
+				t.Errorf("MintPairingCode() code = %q, want empty on error", code)
+			}
+			if !expiresAt.IsZero() {
+				t.Errorf("MintPairingCode() expiresAt = %v, want zero on error", expiresAt)
+			}
+			if countPairingCodes(t, ctx, s) != 0 {
+				t.Error("MintPairingCode() persisted a row despite returning an error")
+			}
+		})
+	}
+}
+
 func TestRedeemPairingCodeTwiceFailsSecondTime(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
 	s := openStore(t, tempDBPath(t))
 	ctx := context.Background()
-	code, _, err := s.MintPairingCode(ctx, "Pixel 9")
+	code, _, err := s.MintPairingCode(ctx, "Pixel 9", DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -83,7 +146,7 @@ func TestRedeemPairingCodeExpiredFails(t *testing.T) {
 	// alone within a fast test.
 	s := openStore(t, tempDBPath(t))
 	ctx := context.Background()
-	code, _, err := s.MintPairingCode(ctx, "Pixel 9")
+	code, _, err := s.MintPairingCode(ctx, "Pixel 9", DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -110,7 +173,7 @@ func TestRedeemPairingCodeConcurrentProducesExactlyOneSuccess(t *testing.T) {
 	// would let more than one goroutine observe the code as unused.
 	s := openStore(t, tempDBPath(t))
 	ctx := context.Background()
-	code, _, err := s.MintPairingCode(ctx, "Pixel 9")
+	code, _, err := s.MintPairingCode(ctx, "Pixel 9", DefaultPairingCodeTTL)
 	if err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
@@ -154,10 +217,10 @@ func TestPrunePairingCodesRemovesExpiredRows(t *testing.T) {
 	// Arrange
 	s := openStore(t, tempDBPath(t))
 	ctx := context.Background()
-	if _, _, err := s.MintPairingCode(ctx, "Expired Phone"); err != nil {
+	if _, _, err := s.MintPairingCode(ctx, "Expired Phone", DefaultPairingCodeTTL); err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
-	if _, _, err := s.MintPairingCode(ctx, "Active Phone"); err != nil {
+	if _, _, err := s.MintPairingCode(ctx, "Active Phone", DefaultPairingCodeTTL); err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
 	if _, err := s.db.ExecContext(ctx,

--- a/internal/state/pruner_test.go
+++ b/internal/state/pruner_test.go
@@ -31,7 +31,7 @@ func newCapturingPruner(t *testing.T, maxAge time.Duration, maxRows int) (*Prune
 // alone within a fast test.
 func seedExpiredPairingCode(t *testing.T, ctx context.Context, s *Store, deviceName string) {
 	t.Helper()
-	if _, _, err := s.MintPairingCode(ctx, deviceName); err != nil {
+	if _, _, err := s.MintPairingCode(ctx, deviceName, DefaultPairingCodeTTL); err != nil {
 		t.Fatalf("MintPairingCode() unexpected error: %v", err)
 	}
 	if _, err := s.db.ExecContext(ctx,


### PR DESCRIPTION
Release **0.6.0**: a configurable pairing-code lifetime, bounded by a ceiling only the operator can set.

## What ships

**Configurable pairing-code TTL** ([#130](https://github.com/scnplt/devmon-agent/pull/130), closes [#129](https://github.com/scnplt/devmon-agent/issues/129))

`device pair-code` accepts `--ttl <minutes>`, choosing a lifetime from five minutes up to the new `DEVMON_PAIR_TTL_MAX_MIN` startup ceiling (bounded 5–60, default 10). Omitting the flag mints at `min(10 minutes, ceiling)`, so lowering the ceiling below the default never becomes a startup error. Out-of-range values are hard errors that mint nothing — never silently clamped — and `--ttl 0` fails like any other below-floor value rather than being read as an omitted flag. The ceiling is startup configuration because a longer-lived code is a longer window for a leaked, unredeemed code to matter, and nothing a client can reach may widen it.

**Release preparation** ([#132](https://github.com/scnplt/devmon-agent/pull/132))

Pinned version references bumped to `0.6.0` across the README, `install.sh`, `compose.example.yaml`, and the OpenAPI description; changelog entries added for `0.6.0` and for `0.5.1`, whose security release had shipped a tag, an image, and a published advisory without ever reaching the changelog.

## Compatibility

The configuration surface gains one variable and loses none. An agent started without `DEVMON_PAIR_TTL_MAX_MIN` behaves exactly as 0.5.1 did: pairing codes live ten minutes. No route changed, and no response field changed meaning. Upgrading is an image-tag bump.

## Already released from `main`

`0.5.1` (GHSA-qrxm-qm54-xc44) is in this history: a revoked device's already-open SSE streams now terminate within one keepalive/heartbeat tick. It was released from `main` directly as a hotfix and merged back into `dev`; this PR does not reintroduce it.

## Test plan

- [ ] Full release bar green on this PR into `main`: `test`, `lint`, `image`, `gosec`, `shellcheck`, `e2e`, `govulncheck`, `openapi`
- [ ] After merge: tag `v0.6.0` to trigger the multi-arch image build
- [ ] Confirm `ghcr.io/scnplt/devmon-agent:0.6.0` manifest published
- [ ] Create the GitHub Release, matching the convention of prior tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
