### PR TITLE
feat: operator-protected containers via DEVMON_PROTECTED_CONTAINERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ moved.
 
 ## [Unreleased]
 
+The configuration surface gains one optional variable,
+`DEVMON_PROTECTED_CONTAINERS`, and loses none. An agent started without it
+behaves exactly as 0.6.0 did. No route changed, and the one response field
+involved, `protected`, widened its meaning without changing its shape.
+
+### Added
+
+- **Operator-protected containers.** `DEVMON_PROTECTED_CONTAINERS` is a
+  comma-separated list of container names or IDs that every lifecycle route
+  refuses with 403 `container is protected by host configuration`, in every
+  policy mode. Self-exclusion covers exactly one container — the agent's own —
+  so on a host running two agents a device paired to one could stop or delete
+  the other; this closes that gap, and covers anything else an operator wants
+  out of remote reach, such as a reverse proxy. Matching rows in
+  `GET /v1/containers` and `GET /v1/containers/{id}` carry `protected: true`,
+  the same field the agent's own row already uses, so a client that greys out
+  the agent's controls greys these out with no change. Reads, inspect, logs,
+  and the event stream are unaffected. An entry matches a container name
+  exactly, or — when it is 12 or 64 lowercase hex characters — a container ID
+  by short-ID prefix or in full; no other prefix length is honoured. The list
+  is read once at startup, never verified against the Engine (an absent name
+  protects the container whenever it appears), logged once at INFO, and
+  enforced in the same layer as self-exclusion, which takes precedence when
+  both apply. Refusals are audited as `denied_protected`. `install.sh` gains
+  `--protected-containers` and a matching prompt that Enter skips.
+
 ## [0.6.0] - 2026-08-29
 
 A feature release. The pairing-code lifetime, fixed at ten minutes since the

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ the file and run `docker compose up -d` to apply a change.
 | `DEVMON_STATE_DIR` | `/var/lib/devmon` | Identity, device registry, audit log, and operational logs |
 | `DEVMON_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker Engine endpoint (`unix://` or `tcp://`) |
 | `DEVMON_SELF_CONTAINER` | *(auto-detected)* | The agent's own container name, so it can refuse to act on itself |
+| `DEVMON_PROTECTED_CONTAINERS` | *(none)* | Comma-separated container names or IDs that no device may start, stop, restart, kill, or delete — for example another agent on the same host |
 | `DEVMON_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, or `error` |
 | `DEVMON_LOG_MAX_AGE_DAYS` | `1` | Operational log retention (days) |
 | `DEVMON_LOG_MAX_TOTAL_MB` | `64` | Operational log size budget (MB, at least 8) |

--- a/cmd/devmon-agent/main.go
+++ b/cmd/devmon-agent/main.go
@@ -250,7 +250,11 @@ func serve(ctx context.Context, cfg config.Config, sink *logging.Sink, log *slog
 		return err
 	}
 
-	dc, err := dockerx.New(ctx, cfg.DockerHost, cfg.SelfContainer, log)
+	dc, err := dockerx.New(ctx, dockerx.Options{
+		Host:                cfg.DockerHost,
+		SelfContainer:       cfg.SelfContainer,
+		ProtectedContainers: cfg.ProtectedContainers,
+	}, log)
 	if err != nil {
 		return err
 	}

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -116,6 +116,14 @@ services:
       # `docker compose up -d` does after any edit to this file.
       DEVMON_SELF_CONTAINER: devmon-agent
 
+      # Containers no paired device may start, stop, restart, kill, or delete
+      # through this agent, in any policy mode. Self-exclusion protects only
+      # this agent's own container; list here whatever else is off-limits to
+      # remote hands — typically another devmon-agent on the same host, or a
+      # reverse proxy. Comma-separated; names preferred over IDs for the same
+      # recreate reason as above. Reads and logs are unaffected.
+      # DEVMON_PROTECTED_CONTAINERS: devmon-agent-other,traefik
+
       DEVMON_LOG_MAX_AGE_DAYS: "1"
       DEVMON_LOG_MAX_TOTAL_MB: "64"
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -72,11 +72,12 @@ Shared by every read route:
 | Calling device already holds its own stream cap (stream route only) | 503 | `{"error":"too many concurrent log streams for this device"}` |
 | Every stream slot on the host is in use (stream route only) | 503 | `{"error":"too many concurrent log streams"}` |
 
-The mutating routes add three of their own:
+The mutating routes add four of their own:
 
 | Condition | Status | Body |
 |---|---|---|
 | The target is the agent's own container | 403 | `{"error":"the agent cannot act on itself"}` |
+| The target is listed in `DEVMON_PROTECTED_CONTAINERS` | 403 | `{"error":"container is protected by host configuration"}` |
 | Delete of a running container | 409 | `{"error":"container is running"}` |
 | The agent is containerised but cannot identify itself | 503 | `{"error":"agent cannot identify its own container"}` |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,6 +16,7 @@ file, or signal that can widen what was granted here.
 | `DEVMON_POLICY_MODE` | enum | `default` | One of `read-only`, `default`, `full` |
 | `DEVMON_DOCKER_HOST` | URL | `unix:///var/run/docker.sock` | Scheme `unix` or `tcp` |
 | `DEVMON_SELF_CONTAINER` | name or ID | *(auto-detected)* | Docker's own name grammar: `[a-zA-Z0-9][a-zA-Z0-9_.-]+` (two characters or more). Hex container IDs satisfy it too |
+| `DEVMON_PROTECTED_CONTAINERS` | comma list | *(none)* | Each entry a container name or ID under the same grammar as `DEVMON_SELF_CONTAINER`; blank entries ignored; duplicates dropped |
 | `DEVMON_LOG_LEVEL` | enum | `info` | One of `debug`, `info`, `warn`, `error` |
 | `DEVMON_LOG_MAX_AGE_DAYS` | int | `1` | ≥1 |
 | `DEVMON_LOG_MAX_TOTAL_MB` | int | `64` | ≥8 |
@@ -127,6 +128,61 @@ once at INFO.
 
 Before 0.2.0 this variable was called `DEVMON_SELF_CONTAINER_ID`; see
 [Upgrading](INSTALL.md#upgrading).
+
+## Protecting other containers
+
+Self-exclusion covers exactly one container: the agent's own. Everything else
+the policy mode permits is fair game for every paired device. That is the wrong
+boundary as soon as a host runs **more than one agent** — one per team, per
+tenant, or per policy tier — because a device paired to agent A cannot touch A,
+but it can stop, kill, or delete agent B, and B's devices can do the same to A.
+The same gap covers any container an operator considers off-limits to remote
+hands: a reverse proxy, a database, a backup job.
+
+`DEVMON_PROTECTED_CONTAINERS` closes it. It is a comma-separated list of
+container names or IDs; a container matching any entry is refused by every
+lifecycle route with 403 `container is protected by host configuration`, in
+every policy mode, and its rows in `GET /v1/containers` and
+`GET /v1/containers/{id}` carry `"protected": true` — the same field the agent's
+own row uses, so an app that already greys out the agent's controls greys these
+out too without knowing why. Reads, inspect, logs, and the event stream are not
+affected: protection stops a device from *changing* a container, not from
+*seeing* it.
+
+```yaml
+services:
+  devmon-agent-team-a:
+    container_name: devmon-agent-team-a
+    environment:
+      DEVMON_SELF_CONTAINER: devmon-agent-team-a
+      DEVMON_PROTECTED_CONTAINERS: devmon-agent-team-b,traefik
+```
+
+How an entry matches:
+
+- An entry matches a container whose **name** equals it exactly. Names are
+  case-sensitive and compared without Docker's leading `/`.
+- An entry that is 12 or 64 lowercase hex characters *also* matches a container
+  whose **ID** starts with (12) or equals (64) it. No other prefix length is
+  honoured: a name such as `cafe` must not quietly protect every container whose
+  ID happens to begin with it. An entry that is both a real name and someone
+  else's short ID matches both; over-protection is the safe direction.
+- **Prefer names**, for the reason given under `DEVMON_SELF_CONTAINER` above: an
+  ID is stale the next time the container is recreated, a name survives.
+
+Entries are not checked against the Engine at startup. A name that matches
+nothing today is legitimate — it protects that container whenever it appears,
+which is what a compose stack that recreates containers needs. The list is
+logged once at INFO at startup so an operator can confirm what was protected.
+
+When a target is both the agent itself and listed here, the self rule answers
+first, with its own body; the list never weakens self-exclusion and cannot be
+used to opt out of it. Like every other variable on this page the list is read
+once at startup: no device can read it back, shorten it, or extend it.
+
+A malformed entry is a startup configuration error (exit 2), reported with the
+offending value, in the same way as `DEVMON_SELF_CONTAINER`. Blank entries and
+exact duplicates are ignored.
 
 ## Retention
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -151,16 +151,18 @@ request log line every 30 seconds — about 2900 a day. Raise
 ## Audit log
 
 Every mutating request writes exactly **one** row — successes, refusals by
-policy, refusals by self-exclusion, and failures alike. Reads are not recorded:
-a row per list refresh would drown the record the log exists for and then push
-the destructive-operation history out under retention.
+policy, refusals by self-exclusion or by `DEVMON_PROTECTED_CONTAINERS`, and
+failures alike. Reads are not recorded: a row per list refresh would drown the
+record the log exists for and then push the destructive-operation history out
+under retention.
 
 ```bash
 $ docker exec devmon-agent devmon audit list --limit 5
-WHEN                  DEVICE            OPERATION  TARGET  OUTCOME        DETAIL
-2026-08-08T21:06:40Z  3f9a1c… (pixel-8) delete     devmon  denied_self
-2026-08-08T21:05:02Z  3f9a1c… (pixel-8) kill       api     denied_policy
-2026-08-08T21:04:11Z  3f9a1c… (pixel-8) restart    api     success        9c2e…
+WHEN                  DEVICE            OPERATION  TARGET   OUTCOME           DETAIL
+2026-08-08T21:07:15Z  3f9a1c… (pixel-8) stop       traefik  denied_protected
+2026-08-08T21:06:40Z  3f9a1c… (pixel-8) delete     devmon   denied_self
+2026-08-08T21:05:02Z  3f9a1c… (pixel-8) kill       api      denied_policy
+2026-08-08T21:04:11Z  3f9a1c… (pixel-8) restart    api      success           9c2e…
 ```
 
 `--limit` defaults to 100 rows, most recent first.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -117,7 +117,7 @@ documented deployment.
   ([`install.sh`, `compose_file_contents`](../install.sh)).
 - The agent talks to it through `github.com/moby/moby/client`, constructed
   once at startup from `DEVMON_DOCKER_HOST`:
-  [`internal/dockerx/client.go:42-46`](../internal/dockerx/client.go).
+  [`internal/dockerx/client.go:57-64`](../internal/dockerx/client.go).
 - The socket's GID is resolved from the host, not assumed, because it varies
   per distribution: [`install.sh`, `resolve_socket_gid`](../install.sh).
 
@@ -266,6 +266,18 @@ fixed rule, not a policy setting:
 the host's Docker socket, which is outside this agent's control — see "Not
 defended" below.
 
+**A device paired to a sibling agent on the same host.** Self-exclusion
+protects only the agent's own container, so with two agents on one host a
+device paired to agent A can, within A's policy mode, stop or delete agent B.
+The operator closes that with `DEVMON_PROTECTED_CONTAINERS`
+([Protecting other containers](CONFIGURATION.md#protecting-other-containers)):
+a startup list of names or IDs that every lifecycle route refuses in every
+policy mode, enforced in the same layer as self-exclusion
+([`internal/dockerx/lifecycle.go`](../internal/dockerx/lifecycle.go),
+`resolveTarget`). It is startup configuration, so a device cannot read it back
+or shorten it, and it never weakens self-exclusion: a target that is both the
+agent itself and listed is refused by the self rule first.
+
 ---
 
 ## What is explicitly NOT defended
@@ -294,7 +306,7 @@ substance, because the two documents describe the same boundary:
   30/min `/v1/status` default, a 5/min `/v1/pair` default, a 20/s guarded
   default — are a bound on request rate, not a guarantee against every form of
   resource exhaustion: [`internal/httpapi/ratelimit.go:20-65`](../internal/httpapi/ratelimit.go),
-  [`internal/config/config.go:58-65`](../internal/config/config.go) (defaults).
+  [`internal/config/config.go:59-66`](../internal/config/config.go) (defaults).
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -920,7 +920,7 @@ components:
 
     LifecycleForbidden:
       description: |
-        Refused, for one of two unrelated reasons the body distinguishes.
+        Refused, for one of three unrelated reasons the body distinguishes.
 
         Either the host's policy mode does not permit the operation — `kill` and
         `delete` need `full`, the rest need `default` — which no client can
@@ -929,15 +929,21 @@ components:
 
         Or the target is the agent's own container. That is a fixed rule rather
         than a policy tier: stopping or deleting the agent from a client would
-        destroy the operator's only remote access. The agent stays visible in
-        listings with `protected: true`, so a client can grey the control out
-        rather than discovering this through a failure.
+        destroy the operator's only remote access.
+
+        Or the target is one the operator listed in
+        `DEVMON_PROTECTED_CONTAINERS` at startup — typically another agent on
+        the same host. Both protected kinds stay visible in listings with
+        `protected: true`, so a client can grey the control out rather than
+        discovering this through a failure. When a target is both the agent
+        itself and listed, the self body is served.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
           examples:
             policy: { value: { error: operation not permitted by host policy } }
             self: { value: { error: the agent cannot act on itself } }
+            protected: { value: { error: container is protected by host configuration } }
 
     SelfUnknown:
       description: |
@@ -1207,11 +1213,13 @@ components:
         protected:
           type: boolean
           description: |
-            This is the agent's own container, and every mutating route will
-            refuse it in every policy mode. Always present, never omitted on
-            `false`: a client that could not tell "not protected" from "this
-            agent version does not report protection" would quietly offer a
-            delete button on the agent itself.
+            Every mutating route will refuse this container in every policy
+            mode: it is either the agent's own container, or one the operator
+            listed in `DEVMON_PROTECTED_CONTAINERS` at startup. Reads and logs
+            are unaffected. Always present, never omitted on `false`: a client
+            that could not tell "not protected" from "this agent version does
+            not report protection" would quietly offer a delete button on the
+            agent itself.
 
     ContainerDetail:
       type: object

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,7 @@ ASSUME_YES='no'
 # initial value; a flag overrides it; an empty value falls through to a prompt.
 PUBLIC_ADDR="${DEVMON_PUBLIC_ADDR:-}"
 POLICY_MODE="${DEVMON_POLICY_MODE:-}"
+PROTECTED_CONTAINERS="${DEVMON_PROTECTED_CONTAINERS:-}"
 PORT="${DEVMON_INSTALL_PORT:-}"
 STATE_DIR="${DEVMON_STATE_DIR:-}"
 LOG_MAX_AGE_DAYS="${DEVMON_LOG_MAX_AGE_DAYS:-}"
@@ -150,6 +151,12 @@ Options (each also settable by the environment variable in brackets):
   --policy-mode MODE      read-only | default | full. Fixed at startup and
                           immutable thereafter; a client can never widen it.
                           Default: default. [DEVMON_POLICY_MODE]
+  --protected-containers LIST
+                          Containers no paired device may start, stop, restart,
+                          kill, or delete through this agent, in any policy
+                          mode — typically another devmon-agent on this host.
+                          Comma-separated names (or IDs), no spaces. Optional;
+                          default: none. [DEVMON_PROTECTED_CONTAINERS]
   --port PORT             Host port to publish. Default: 8443.
                           [DEVMON_INSTALL_PORT]
   --state-dir DIR         Host directory holding the agent's identity and
@@ -194,6 +201,11 @@ while [ "$#" -gt 0 ]; do
 	--policy-mode)
 		require_value "$@"
 		POLICY_MODE="$2"
+		shift 2
+		;;
+	--protected-containers)
+		require_value "$@"
+		PROTECTED_CONTAINERS="$2"
 		shift 2
 		;;
 	--port)
@@ -358,6 +370,45 @@ is_valid_public_addr() {
 	return 0
 }
 
+# is_valid_container_ref mirrors the agent's own rule for a container name or
+# ID: an alphanumeric first character followed by one or more of
+# [A-Za-z0-9_.-]. Two characters minimum, no spaces, no slashes, and nothing
+# that could close the YAML scalar it is written into.
+is_valid_container_ref() {
+	case "$1" in
+	[A-Za-z0-9][A-Za-z0-9_.-]*) ;;
+	*) return 1 ;;
+	esac
+	case "$1" in
+	*[!A-Za-z0-9_.-]*) return 1 ;;
+	esac
+	return 0
+}
+
+# is_valid_container_list accepts an empty value (nothing extra is protected)
+# or a comma-separated list where every non-blank entry passes
+# is_valid_container_ref, matching how the agent parses
+# DEVMON_PROTECTED_CONTAINERS. It splits before checking characters because
+# has_unsafe_chars rejects the comma itself.
+is_valid_container_list() {
+	rest="$1"
+	while [ -n "$rest" ]; do
+		case "$rest" in
+		*,*)
+			entry="${rest%%,*}"
+			rest="${rest#*,}"
+			;;
+		*)
+			entry="$rest"
+			rest=''
+			;;
+		esac
+		[ -n "$entry" ] || continue
+		is_valid_container_ref "$entry" || return 1
+	done
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Prompts
 # ---------------------------------------------------------------------------
@@ -396,6 +447,40 @@ prompt() {
 		fi
 		read -r answer || die 'no more input; pass every value as a flag for unattended use.'
 		[ -n "$answer" ] || answer="$default_value"
+		if "$validator" "$answer"; then
+			eval "$var_name=\$answer"
+			return 0
+		fi
+		info '  that value is not accepted; see --help for the rule.'
+	done
+}
+
+# prompt_optional is prompt for a knob whose empty value is a legitimate
+# answer. A value already supplied by a flag or the environment is validated
+# but never re-asked; under --yes, or with no terminal on stdin, it stays
+# empty rather than dying for want of a default; interactively, Enter keeps it
+# empty.
+prompt_optional() {
+	var_name="$1"
+	question="$2"
+	validator="$3"
+
+	eval "current=\${$var_name}"
+
+	if [ -n "$current" ]; then
+		if ! "$validator" "$current"; then
+			die "$var_name is set to '$current', which is not accepted. See --help for the rule."
+		fi
+		return 0
+	fi
+
+	if [ "$ASSUME_YES" = 'yes' ] || [ ! -t 0 ]; then
+		return 0
+	fi
+
+	while :; do
+		printf '%s [none]: ' "$question"
+		read -r answer || die 'no more input; pass every value as a flag for unattended use.'
 		if "$validator" "$answer"; then
 			eval "$var_name=\$answer"
 			return 0
@@ -553,6 +638,16 @@ prepare_state_dir() {
 }
 
 compose_file_contents() {
+	# Written as a live key only when the operator listed something; otherwise
+	# as a commented example, so the knob is discoverable in the file it would
+	# be edited into. The value passed is_valid_container_list, so it cannot
+	# contain a quote or anything else that would close the YAML scalar.
+	if [ -n "$PROTECTED_CONTAINERS" ]; then
+		protected_containers_line="DEVMON_PROTECTED_CONTAINERS: \"$PROTECTED_CONTAINERS\""
+	else
+		protected_containers_line="# DEVMON_PROTECTED_CONTAINERS: devmon-agent-other,traefik"
+	fi
+
 	cat <<EOF
 # Written by devmon-agent's install.sh. Safe to edit and re-apply with
 # \`$COMPOSE_CMD up -d\`.
@@ -624,6 +719,13 @@ services:
       # pinned above is the one form that stays true across a recreate — an ID
       # would be stale the next time this file changes.
       DEVMON_SELF_CONTAINER: "$SERVICE_NAME"
+
+      # Containers no paired device may start, stop, restart, kill, or delete
+      # through this agent, in any policy mode — self-exclusion covers only
+      # this agent's own container, so list another devmon-agent on this host,
+      # a reverse proxy, or anything else that must stay out of remote reach.
+      # Comma-separated; names, not IDs, for the same recreate reason as above.
+      $protected_containers_line
 
       DEVMON_LOG_MAX_AGE_DAYS: "$LOG_MAX_AGE_DAYS"
       DEVMON_LOG_MAX_TOTAL_MB: "$LOG_MAX_TOTAL_MB"
@@ -824,6 +926,9 @@ prompt PUBLIC_ADDR \
 	'Hostname or IP the phone will reach this host at (no scheme, no port)' \
 	'' is_valid_public_addr
 prompt POLICY_MODE 'Policy mode (read-only | default | full)' "$DEFAULT_POLICY_MODE" is_valid_policy_mode
+prompt_optional PROTECTED_CONTAINERS \
+	'Containers no device may stop or delete, comma-separated (Enter for none)' \
+	is_valid_container_list
 prompt PORT 'Host port to publish' "$DEFAULT_PORT" is_valid_port
 prompt STATE_DIR 'State directory' "$DEFAULT_STATE_DIR" is_absolute_path
 prompt LOG_MAX_AGE_DAYS 'Operational log retention (days)' "$DEFAULT_LOG_MAX_AGE_DAYS" is_positive_int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,17 +25,18 @@ import (
 // Environment variable keys. Declared as constants so a typo is a compile error
 // and so error messages can name the exact variable the operator must fix.
 const (
-	envStateDir        = "DEVMON_STATE_DIR"
-	envListenAddr      = "DEVMON_LISTEN_ADDR"
-	envPublicAddr      = "DEVMON_PUBLIC_ADDR"
-	envPolicyMode      = "DEVMON_POLICY_MODE"
-	envDockerHost      = "DEVMON_DOCKER_HOST"
-	envLogLevel        = "DEVMON_LOG_LEVEL"
-	envLogMaxAgeDays   = "DEVMON_LOG_MAX_AGE_DAYS"
-	envLogMaxTotalMB   = "DEVMON_LOG_MAX_TOTAL_MB"
-	envAuditMaxAgeDays = "DEVMON_AUDIT_MAX_AGE_DAYS"
-	envAuditMaxRows    = "DEVMON_AUDIT_MAX_ROWS"
-	envSelfContainer   = "DEVMON_SELF_CONTAINER"
+	envStateDir            = "DEVMON_STATE_DIR"
+	envListenAddr          = "DEVMON_LISTEN_ADDR"
+	envPublicAddr          = "DEVMON_PUBLIC_ADDR"
+	envPolicyMode          = "DEVMON_POLICY_MODE"
+	envDockerHost          = "DEVMON_DOCKER_HOST"
+	envLogLevel            = "DEVMON_LOG_LEVEL"
+	envLogMaxAgeDays       = "DEVMON_LOG_MAX_AGE_DAYS"
+	envLogMaxTotalMB       = "DEVMON_LOG_MAX_TOTAL_MB"
+	envAuditMaxAgeDays     = "DEVMON_AUDIT_MAX_AGE_DAYS"
+	envAuditMaxRows        = "DEVMON_AUDIT_MAX_ROWS"
+	envSelfContainer       = "DEVMON_SELF_CONTAINER"
+	envProtectedContainers = "DEVMON_PROTECTED_CONTAINERS"
 
 	envRateStatusPerMin  = "DEVMON_RATE_STATUS_PER_MIN"
 	envRatePairPerMin    = "DEVMON_RATE_PAIR_PER_MIN"
@@ -138,6 +139,16 @@ type Config struct {
 	// ps is stale on the very next boot, while a name survives recreation.
 	// Empty is the normal case; it has no default.
 	SelfContainer string
+
+	// ProtectedContainers is an optional comma list of container names or IDs
+	// that every lifecycle route refuses in every policy mode, regardless of
+	// self-identification. The name form is preferred over an ID for the same
+	// reason as SelfContainer: docker compose up -d recreates a container and
+	// mints a new ID whenever the compose file changes, so an ID copied out of
+	// docker ps is stale on the very next boot, while a name survives
+	// recreation. Empty means nothing beyond the agent's own container (if any)
+	// is protected.
+	ProtectedContainers []string
 }
 
 // Derived paths live here as methods so no other package ever concatenates a
@@ -196,6 +207,8 @@ func Load(getenv func(string) string) (Config, error) {
 		PairTTLMax: l.minutes(envPairTTLMax, defaultPairTTLMaxMin, minPairTTLMaxMin, maxPairTTLMaxMin),
 
 		SelfContainer: l.selfContainer(),
+
+		ProtectedContainers: l.protectedContainers(),
 	}
 
 	l.checkRetentionOrder(cfg)
@@ -317,6 +330,40 @@ func (l *loader) selfContainer() string {
 		l.fail(envSelfContainer, "%q is not a valid container name or ID (want two or more characters matching [a-zA-Z0-9][a-zA-Z0-9_.-])", ref)
 	}
 	return ref
+}
+
+// protectedContainers parses the optional list of container names or IDs that
+// every lifecycle route must refuse in every policy mode. Unlike publicAddrs,
+// an unset or all-blank value is not an error: the knob is optional, and
+// nothing beyond self-exclusion (if any) is protected in that case. Each
+// entry is validated with the same grammar and wording as selfContainer, and
+// is never lower-cased — Docker container names are case-sensitive. Exact
+// duplicates are dropped, keeping the first occurrence's position, so the
+// resulting order matches what the operator wrote.
+func (l *loader) protectedContainers() []string {
+	raw := l.raw(envProtectedContainers, "")
+	if raw == "" {
+		return nil
+	}
+
+	entries := make([]string, 0, strings.Count(raw, ",")+1)
+	seen := make(map[string]struct{}, strings.Count(raw, ",")+1)
+	for _, part := range strings.Split(raw, ",") {
+		e := strings.TrimSpace(part)
+		if e == "" {
+			continue
+		}
+		if !containerRefPattern.MatchString(e) {
+			l.fail(envProtectedContainers, "%q is not a valid container name or ID (want two or more characters matching [a-zA-Z0-9][a-zA-Z0-9_.-])", e)
+			continue
+		}
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		entries = append(entries, e)
+	}
+	return entries
 }
 
 func (l *loader) logLevel() slog.Level {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,6 +66,9 @@ func TestLoadDefaults(t *testing.T) {
 	if len(cfg.PublicAddrs) != 1 || cfg.PublicAddrs[0] != "vps.example.com" {
 		t.Errorf("PublicAddrs = %v, want [vps.example.com]", cfg.PublicAddrs)
 	}
+	if len(cfg.ProtectedContainers) != 0 {
+		t.Errorf("ProtectedContainers = %v, want empty", cfg.ProtectedContainers)
+	}
 }
 
 func TestLoadOverrides(t *testing.T) {
@@ -230,6 +233,61 @@ func TestLoadOverrides(t *testing.T) {
 			},
 		},
 		{
+			name: "protected containers, single name",
+			env:  map[string]string{envProtectedContainers: "reverse-proxy"},
+			check: func(t *testing.T, cfg Config) {
+				want := []string{"reverse-proxy"}
+				if strings.Join(cfg.ProtectedContainers, ",") != strings.Join(want, ",") {
+					t.Errorf("ProtectedContainers = %v, want %v", cfg.ProtectedContainers, want)
+				}
+			},
+		},
+		{
+			name: "protected containers, mixed name and IDs with ragged spaces",
+			env: map[string]string{
+				envProtectedContainers: "proxy, 0123456789ab ,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+			check: func(t *testing.T, cfg Config) {
+				want := []string{
+					"proxy",
+					"0123456789ab",
+					"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				}
+				if strings.Join(cfg.ProtectedContainers, ",") != strings.Join(want, ",") {
+					t.Errorf("ProtectedContainers = %v, want %v", cfg.ProtectedContainers, want)
+				}
+			},
+		},
+		{
+			name: "protected containers, duplicates deduped preserving order",
+			env:  map[string]string{envProtectedContainers: "a1,b2,a1"},
+			check: func(t *testing.T, cfg Config) {
+				want := []string{"a1", "b2"}
+				if strings.Join(cfg.ProtectedContainers, ",") != strings.Join(want, ",") {
+					t.Errorf("ProtectedContainers = %v, want %v", cfg.ProtectedContainers, want)
+				}
+			},
+		},
+		{
+			name: "protected containers, all commas yields empty with no error",
+			env:  map[string]string{envProtectedContainers: " , ,"},
+			check: func(t *testing.T, cfg Config) {
+				if len(cfg.ProtectedContainers) != 0 {
+					t.Errorf("ProtectedContainers = %v, want empty", cfg.ProtectedContainers)
+				}
+			},
+		},
+		{
+			name: "protected containers, case preserved",
+			env:  map[string]string{envProtectedContainers: "MyDb"},
+			check: func(t *testing.T, cfg Config) {
+				want := []string{"MyDb"}
+				if strings.Join(cfg.ProtectedContainers, ",") != strings.Join(want, ",") {
+					t.Errorf("ProtectedContainers = %v, want %v", cfg.ProtectedContainers, want)
+				}
+			},
+		},
+		{
 			name: "rate limit overrides",
 			env: map[string]string{
 				envRateStatusPerMin:  "60",
@@ -327,6 +385,26 @@ func TestLoadRejections(t *testing.T) {
 			name:    "self container single character",
 			env:     map[string]string{envSelfContainer: "a"},
 			wantKey: envSelfContainer,
+		},
+		{
+			name:    "protected containers leading hyphen",
+			env:     map[string]string{envProtectedContainers: "-bad"},
+			wantKey: envProtectedContainers,
+		},
+		{
+			name:    "protected containers embedded slash",
+			env:     map[string]string{envProtectedContainers: "a/b"},
+			wantKey: envProtectedContainers,
+		},
+		{
+			name:    "protected containers inner space",
+			env:     map[string]string{envProtectedContainers: "bad name"},
+			wantKey: envProtectedContainers,
+		},
+		{
+			name:    "protected containers single character",
+			env:     map[string]string{envProtectedContainers: "x"},
+			wantKey: envProtectedContainers,
 		},
 		{"non-integer status rate", map[string]string{envRateStatusPerMin: "many"}, envRateStatusPerMin},
 		{"zero status rate", map[string]string{envRateStatusPerMin: "0"}, envRateStatusPerMin},
@@ -473,6 +551,32 @@ func TestLoadAggregatesRateLimitProblems(t *testing.T) {
 		if !strings.Contains(vErr.Error(), key) {
 			t.Errorf("aggregated error does not name %s:\n%s", key, vErr.Error())
 		}
+	}
+}
+
+func TestLoadProtectedContainersGoodEntrySurvivesAlongsideABadOne(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — one well-formed entry and one malformed entry in the same list,
+	// as an operator would produce by fat-fingering a single name in a longer
+	// comma list rather than typing the whole thing wrong.
+	env := minimalEnv()
+	env[envProtectedContainers] = "good, bad name"
+
+	// Act
+	_, err := Load(fakeEnv(env))
+
+	// Assert — the malformed entry is the only problem; the well-formed entry
+	// beside it does not itself produce a fault.
+	var vErr *ValidationError
+	if !errors.As(err, &vErr) {
+		t.Fatalf("Load() error = %v, want *ValidationError", err)
+	}
+	if len(vErr.Problems) != 1 {
+		t.Fatalf("Problems = %#v, want exactly 1", vErr.Problems)
+	}
+	if !strings.Contains(vErr.Problems[0], envProtectedContainers) {
+		t.Errorf("problem %q does not name %s", vErr.Problems[0], envProtectedContainers)
 	}
 }
 

--- a/internal/dockerx/client.go
+++ b/internal/dockerx/client.go
@@ -2,10 +2,11 @@
 
 // Package dockerx wraps the Docker Engine client.
 //
-// Phase 1 exposes only New and Close. No container, image, network, or volume
-// operation belongs here yet — reads are Phase 3 and lifecycle control is
-// Phase 5. Keeping the surface this narrow is what makes the policy tier
-// enforceable later: every capability arrives with the phase that audits it.
+// It exposes the narrow set of read and lifecycle operations the agent's HTTP
+// API needs, projected onto an explicit allowlist of DTOs (D1) so nothing
+// forwards an Engine struct verbatim. Every mutating call is enforced through
+// one chokepoint, resolveTarget, which refuses the agent's own container and
+// any container matching the operator's DEVMON_PROTECTED_CONTAINERS list.
 package dockerx
 
 import (
@@ -25,30 +26,44 @@ const pingTimeout = 5 * time.Second
 
 // Client is the agent's handle on the Docker Engine.
 type Client struct {
-	api  *client.Client
-	log  *slog.Logger
-	self selfInfo
+	api       *client.Client
+	log       *slog.Logger
+	self      selfInfo
+	protected protectedSet
 }
 
-// New dials the Docker Engine at host and verifies it responds.
+// Options configures New. Every field is startup configuration, read once and
+// never changed afterward (D5): a client can never widen what the operator
+// granted at process start.
+type Options struct {
+	// Host is DEVMON_DOCKER_HOST, the Engine endpoint to dial.
+	Host string
+	// SelfContainer is the operator's DEVMON_SELF_CONTAINER override, or ""
+	// when unset. It is the escape hatch for the rare host where every
+	// filesystem-derived candidate is wrong (D2).
+	SelfContainer string
+	// ProtectedContainers is the operator's DEVMON_PROTECTED_CONTAINERS
+	// entries (names or IDs), or nil when unset. A container matching any
+	// entry is refused by every lifecycle route and reported as protected in
+	// list and inspect responses, exactly like the agent's own container.
+	ProtectedContainers []string
+}
+
+// New dials the Docker Engine at opts.Host and verifies it responds.
 //
 // A host whose Engine is unreachable cannot serve any agent operation, so this
 // is a fatal startup error rather than a degraded mode: an agent that starts and
 // then fails every request is harder to diagnose than one that refuses to start.
-//
-// selfOverride is the operator's DEVMON_SELF_CONTAINER, or "" when unset.
-// It is the escape hatch for the rare host where every filesystem-derived
-// candidate is wrong (D2).
-func New(ctx context.Context, host string, selfOverride string, log *slog.Logger) (*Client, error) {
+func New(ctx context.Context, opts Options, log *slog.Logger) (*Client, error) {
 	// WithHost, not client.FromEnv: the socket path comes from the agent's own
 	// validated configuration and must not be redirectable by an unrelated
 	// DOCKER_HOST in the process environment.
 	api, err := client.New(
-		client.WithHost(host),
+		client.WithHost(opts.Host),
 		client.WithUserAgent("devmon-agent/"+version.Version),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("create docker client for %s: %w", host, err)
+		return nil, fmt.Errorf("create docker client for %s: %w", opts.Host, err)
 	}
 
 	pctx, cancel := context.WithTimeout(ctx, pingTimeout)
@@ -59,7 +74,7 @@ func New(ctx context.Context, host string, selfOverride string, log *slog.Logger
 	res, err := api.Ping(pctx, client.PingOptions{NegotiateAPIVersion: true})
 	if err != nil {
 		_ = api.Close()
-		return nil, fmt.Errorf("ping docker engine at %s: %w", host, err)
+		return nil, fmt.Errorf("ping docker engine at %s: %w", opts.Host, err)
 	}
 
 	log.Info("docker engine reachable",
@@ -70,7 +85,13 @@ func New(ctx context.Context, host string, selfOverride string, log *slog.Logger
 	c := &Client{api: api, log: log}
 	// Resolved once here, right after Ping, so Client stays immutable for
 	// its whole life (D5) — no later write for concurrent handlers to race.
-	c.self = c.resolveSelf(ctx, selfOverride)
+	c.self = c.resolveSelf(ctx, opts.SelfContainer)
+	c.protected = newProtectedSet(opts.ProtectedContainers)
+	if !c.protected.empty() {
+		// Names are not secrets; this is the operator's own confirmation of
+		// what it configured, worth one INFO line at startup.
+		log.Info("protected containers configured", slog.Any("entries", opts.ProtectedContainers))
+	}
 	return c, nil
 }
 

--- a/internal/dockerx/client_test.go
+++ b/internal/dockerx/client_test.go
@@ -33,7 +33,7 @@ func TestNewUnreachableEngine(t *testing.T) {
 			t.Parallel()
 
 			// Act
-			c, err := New(context.Background(), tt.host, "", testLogger())
+			c, err := New(context.Background(), Options{Host: tt.host}, testLogger())
 
 			// Assert
 			if err == nil {
@@ -70,7 +70,7 @@ func TestNewRejectsMalformedHost(t *testing.T) {
 	t.Parallel()
 
 	// Act
-	c, err := New(context.Background(), "://not a host", "", testLogger())
+	c, err := New(context.Background(), Options{Host: "://not a host"}, testLogger())
 
 	// Assert
 	if err == nil {

--- a/internal/dockerx/containers.go
+++ b/internal/dockerx/containers.go
@@ -31,7 +31,7 @@ func (c *Client) ListContainers(ctx context.Context, all bool) (ListResult[Conta
 
 	items := make([]ContainerSummary, 0, len(res.Items))
 	for _, s := range res.Items {
-		items = append(items, toContainerSummary(s, c.self.id))
+		items = append(items, toContainerSummary(s, c.self.id, c.protected))
 	}
 
 	items, truncated := truncate(items)
@@ -56,15 +56,19 @@ func (c *Client) InspectContainer(ctx context.Context, ref string) (ContainerDet
 		return ContainerDetail{}, classify("inspect container", err)
 	}
 
-	return toContainerDetail(res.Container, c.self.id), nil
+	return toContainerDetail(res.Container, c.self.id, c.protected), nil
 }
 
 // toContainerSummary projects a container.Summary onto the allowlisted DTO.
 // s.Health and s.NetworkSettings are nil for ordinary containers (no
 // healthcheck, no attached network) and must be guarded. selfID is the
 // agent's own resolved container ID (D18); "" means self-resolution never
-// succeeded, so nothing can ever be marked protected.
-func toContainerSummary(s container.Summary, selfID string) ContainerSummary {
+// succeeded, so self-identity can never mark anything protected, though the
+// operator's protected list still can. protected is the operator's
+// DEVMON_PROTECTED_CONTAINERS set (D1 extension for multi-agent hosts); every
+// one of s.Names is checked, since a container can carry a link alias
+// alongside its real name.
+func toContainerSummary(s container.Summary, selfID string, protected protectedSet) ContainerSummary {
 	var health string
 	if s.Health != nil {
 		health = string(s.Health.Status)
@@ -90,7 +94,7 @@ func toContainerSummary(s container.Summary, selfID string) ContainerSummary {
 		Health:    health,
 		Labels:    defaultLabels(s.Labels),
 		Ports:     ports,
-		Protected: s.ID == selfID && selfID != "",
+		Protected: (s.ID == selfID && selfID != "") || protected.matches(s.ID, s.Names...),
 	}
 }
 
@@ -99,8 +103,10 @@ func toContainerSummary(s container.Summary, selfID string) ContainerSummary {
 // (a container mid-creation, an image with no config, a restore of an old
 // record) and must be guarded individually. selfID is the agent's own
 // resolved container ID (D18); "" means self-resolution never succeeded, so
-// nothing can ever be marked protected.
-func toContainerDetail(r container.InspectResponse, selfID string) ContainerDetail {
+// self-identity can never mark this protected, though the operator's
+// protected list still can. protected is the operator's
+// DEVMON_PROTECTED_CONTAINERS set.
+func toContainerDetail(r container.InspectResponse, selfID string, protected protectedSet) ContainerDetail {
 	d := ContainerDetail{
 		ID:           r.ID,
 		Name:         r.Name,
@@ -110,7 +116,7 @@ func toContainerDetail(r container.InspectResponse, selfID string) ContainerDeta
 		Platform:     r.Platform,
 		RestartCount: r.RestartCount,
 		Mounts:       toMounts(r.Mounts),
-		Protected:    r.ID == selfID && selfID != "",
+		Protected:    (r.ID == selfID && selfID != "") || protected.matches(r.ID, r.Name),
 	}
 
 	args := make([]string, 0, len(r.Args))

--- a/internal/dockerx/containers_test.go
+++ b/internal/dockerx/containers_test.go
@@ -23,7 +23,7 @@ func TestToContainerSummaryZeroValue(t *testing.T) {
 	s := container.Summary{}
 
 	// Act
-	got := toContainerSummary(s, "")
+	got := toContainerSummary(s, "", protectedSet{})
 
 	// Assert
 	if got.Health != "" {
@@ -59,7 +59,7 @@ func TestToContainerDetailNilState(t *testing.T) {
 	}
 
 	// Act
-	got := toContainerDetail(r, "")
+	got := toContainerDetail(r, "", protectedSet{})
 
 	// Assert
 	if got.Image != "" {
@@ -103,7 +103,7 @@ func TestToContainerSummaryCreatedAt(t *testing.T) {
 	s := container.Summary{Created: 1700000000}
 
 	// Act
-	got := toContainerSummary(s, "")
+	got := toContainerSummary(s, "", protectedSet{})
 
 	// Assert
 	want := "2023-11-14T22:13:20Z"
@@ -122,7 +122,7 @@ func TestToContainerSummaryCreatedAtZero(t *testing.T) {
 	s := container.Summary{Created: 0}
 
 	// Act
-	got := toContainerSummary(s, "")
+	got := toContainerSummary(s, "", protectedSet{})
 
 	// Assert
 	if got.CreatedAt != "" {
@@ -139,7 +139,7 @@ func TestToContainerDetailCreatedAtPassthrough(t *testing.T) {
 	r := container.InspectResponse{Created: "2023-11-14T22:13:20.123456789Z"}
 
 	// Act
-	got := toContainerDetail(r, "")
+	got := toContainerDetail(r, "", protectedSet{})
 
 	// Assert
 	want := "2023-11-14T22:13:20.123456789Z"
@@ -218,7 +218,7 @@ func TestToContainerSummaryHealthAndNetworkSettings(t *testing.T) {
 	}
 
 	// Act
-	got := toContainerSummary(s, "")
+	got := toContainerSummary(s, "", protectedSet{})
 
 	// Assert
 	if got.Health != string(container.Unhealthy) {
@@ -277,7 +277,7 @@ func TestToContainerDetailFullState(t *testing.T) {
 	}
 
 	// Act
-	got := toContainerDetail(r, "")
+	got := toContainerDetail(r, "", protectedSet{})
 
 	// Assert
 	if got.Image != "myapp:1.4" {
@@ -335,21 +335,65 @@ func TestToContainerDetailFullState(t *testing.T) {
 	}
 }
 
-// TestToContainerSummaryProtected covers the D18 self-exclusion flag: it is
-// true only when the container's ID equals a non-empty selfID, and false for
-// every other container, including when selfID is unresolved ("").
+// TestToContainerSummaryProtected covers the D18 flag now that it combines
+// self-identity with the operator's DEVMON_PROTECTED_CONTAINERS set: true
+// when the container's ID equals a non-empty selfID OR the container matches
+// the protected set by name or ID, false otherwise.
 func TestToContainerSummaryProtected(t *testing.T) {
 	t.Parallel()
 
+	const shortID = "aaaaaaaaaaaa"
+	const fullID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 	tests := []struct {
-		name   string
-		id     string
-		selfID string
-		want   bool
+		name           string
+		id             string
+		names          []string
+		selfID         string
+		protectedEntry []string
+		want           bool
 	}{
-		{name: "matches self ID", id: "abc123", selfID: "abc123", want: true},
+		{name: "matches self ID, no protected entries", id: "abc123", selfID: "abc123", want: true},
 		{name: "does not match self ID", id: "abc123", selfID: "def456", want: false},
 		{name: "self ID unresolved", id: "abc123", selfID: "", want: false},
+		{
+			name:           "protected by name",
+			id:             "abc123",
+			names:          []string{"/proxy"},
+			selfID:         "",
+			protectedEntry: []string{"proxy"},
+			want:           true,
+		},
+		{
+			name:           "protected by short ID",
+			id:             fullID,
+			selfID:         "",
+			protectedEntry: []string{shortID},
+			want:           true,
+		},
+		{
+			name:           "self false and protected set true",
+			id:             "abc123",
+			names:          []string{"/database"},
+			selfID:         "not-this-one",
+			protectedEntry: []string{"database"},
+			want:           true,
+		},
+		{
+			name:           "both self and protected set false",
+			id:             "abc123",
+			names:          []string{"/database"},
+			selfID:         "not-this-one",
+			protectedEntry: []string{"proxy"},
+			want:           false,
+		},
+		{
+			name:           "self true and protected set empty",
+			id:             "abc123",
+			selfID:         "abc123",
+			protectedEntry: nil,
+			want:           true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -357,10 +401,11 @@ func TestToContainerSummaryProtected(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
-			s := container.Summary{ID: tt.id}
+			s := container.Summary{ID: tt.id, Names: tt.names}
+			protected := newProtectedSet(tt.protectedEntry)
 
 			// Act
-			got := toContainerSummary(s, tt.selfID)
+			got := toContainerSummary(s, tt.selfID, protected)
 
 			// Assert
 			if got.Protected != tt.want {
@@ -375,15 +420,58 @@ func TestToContainerSummaryProtected(t *testing.T) {
 func TestToContainerDetailProtected(t *testing.T) {
 	t.Parallel()
 
+	const shortID = "aaaaaaaaaaaa"
+	const fullID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 	tests := []struct {
-		name   string
-		id     string
-		selfID string
-		want   bool
+		name           string
+		id             string
+		containerName  string
+		selfID         string
+		protectedEntry []string
+		want           bool
 	}{
-		{name: "matches self ID", id: "abc123", selfID: "abc123", want: true},
+		{name: "matches self ID, no protected entries", id: "abc123", selfID: "abc123", want: true},
 		{name: "does not match self ID", id: "abc123", selfID: "def456", want: false},
 		{name: "self ID unresolved", id: "abc123", selfID: "", want: false},
+		{
+			name:           "protected by name",
+			id:             "abc123",
+			containerName:  "/proxy",
+			selfID:         "",
+			protectedEntry: []string{"proxy"},
+			want:           true,
+		},
+		{
+			name:           "protected by short ID",
+			id:             fullID,
+			selfID:         "",
+			protectedEntry: []string{shortID},
+			want:           true,
+		},
+		{
+			name:           "self false and protected set true",
+			id:             "abc123",
+			containerName:  "/database",
+			selfID:         "not-this-one",
+			protectedEntry: []string{"database"},
+			want:           true,
+		},
+		{
+			name:           "both self and protected set false",
+			id:             "abc123",
+			containerName:  "/database",
+			selfID:         "not-this-one",
+			protectedEntry: []string{"proxy"},
+			want:           false,
+		},
+		{
+			name:           "self true and protected set empty",
+			id:             "abc123",
+			selfID:         "abc123",
+			protectedEntry: nil,
+			want:           true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -391,10 +479,11 @@ func TestToContainerDetailProtected(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
-			r := container.InspectResponse{ID: tt.id}
+			r := container.InspectResponse{ID: tt.id, Name: tt.containerName}
+			protected := newProtectedSet(tt.protectedEntry)
 
 			// Act
-			got := toContainerDetail(r, tt.selfID)
+			got := toContainerDetail(r, tt.selfID, protected)
 
 			// Assert
 			if got.Protected != tt.want {

--- a/internal/dockerx/errors.go
+++ b/internal/dockerx/errors.go
@@ -31,6 +31,13 @@ var ErrInvalidSince = errors.New("invalid since timestamp")
 // no configuration may opt into that (D1).
 var ErrSelfProtected = errors.New("the agent cannot act on its own container")
 
+// ErrProtectedContainer is returned when a lifecycle operation targets a
+// container matching an entry of the operator's DEVMON_PROTECTED_CONTAINERS
+// list. Like self-exclusion it is enforced in every policy mode, but unlike
+// self-exclusion it is operator configuration rather than a fixed rule; when
+// a target matches both, the self rule takes precedence.
+var ErrProtectedContainer = errors.New("container is protected by host configuration")
+
 // ErrSelfUnknown is returned when the agent is running in a container but
 // could not determine which one. Lifecycle operations fail closed rather than
 // proceed with the self-exclusion rule unenforceable (D3).

--- a/internal/dockerx/lifecycle.go
+++ b/internal/dockerx/lifecycle.go
@@ -25,9 +25,15 @@ const (
 )
 
 // resolveTarget validates ref, resolves it to a full container ID, and
-// enforces the agent's permanent self-exclusion. Every lifecycle method goes
-// through it — that is what makes "the agent can never act on itself" a
-// property of this layer rather than of five route registrations (D1).
+// enforces the agent's permanent self-exclusion together with the operator's
+// DEVMON_PROTECTED_CONTAINERS list. Every lifecycle method goes through it —
+// that is what makes "the agent can never act on itself, or on a container
+// the operator protected" a property of this layer rather than of five route
+// registrations (D1).
+//
+// The self check runs first: an agent whose own name or ID is also listed in
+// DEVMON_PROTECTED_CONTAINERS still answers with ErrSelfProtected, the fixed
+// rule, rather than ErrProtectedContainer, the configurable one.
 func (c *Client) resolveTarget(ctx context.Context, ref string) (string, error) {
 	if err := ValidateRef(ref); err != nil {
 		return "", err
@@ -41,6 +47,9 @@ func (c *Client) resolveTarget(ctx context.Context, ref string) (string, error) 
 	}
 	if detail.ID == c.self.id && c.self.id != "" {
 		return "", ErrSelfProtected
+	}
+	if c.protected.matches(detail.ID, detail.Name) {
+		return "", ErrProtectedContainer
 	}
 	return detail.ID, nil
 }

--- a/internal/dockerx/lifecycle_test.go
+++ b/internal/dockerx/lifecycle_test.go
@@ -59,6 +59,13 @@ func withSelf(c *Client, containerized bool, id string) *Client {
 	return c
 }
 
+// withProtected returns a copy of c whose protected set is built from
+// entries, for the DEVMON_PROTECTED_CONTAINERS enforcement tests below.
+func withProtected(c *Client, entries ...string) *Client {
+	c.protected = newProtectedSet(entries)
+	return c
+}
+
 func inspectRoute(ref string) string {
 	return "GET /containers/" + ref + "/json"
 }
@@ -370,6 +377,152 @@ func TestLifecycleMutatingCallFailure(t *testing.T) {
 				t.Errorf("err = %v, want NOT errors.Is(err, ErrNotFound)", err)
 			}
 		})
+	}
+}
+
+// protectedFixtureName, protectedFixtureFullID, and protectedFixtureShortID
+// name a fixture container used by the DEVMON_PROTECTED_CONTAINERS
+// enforcement tests below; protectedFixtureShortID is protectedFixtureFullID's
+// 12-hex prefix.
+const protectedFixtureName = "protected-container"
+const protectedFixtureFullID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+const protectedFixtureShortID = "bbbbbbbbbbbb"
+
+// TestLifecycleRejectsProtectedAllFive proves every one of the five lifecycle
+// methods refuses a protected-set member before any mutating Engine call,
+// regardless of which of the three ref forms (name, short ID, full ID) the
+// device used to name it and which of those same forms the operator listed
+// in DEVMON_PROTECTED_CONTAINERS.
+func TestLifecycleRejectsProtectedAllFive(t *testing.T) {
+	t.Parallel()
+
+	refForms := []struct {
+		name    string
+		ref     string
+		entries []string
+	}{
+		{name: "by name", ref: protectedFixtureName, entries: []string{protectedFixtureName}},
+		{name: "by short ID", ref: protectedFixtureShortID, entries: []string{protectedFixtureShortID}},
+		{name: "by full ID", ref: protectedFixtureFullID, entries: []string{protectedFixtureFullID}},
+	}
+
+	for _, form := range refForms {
+		for _, op := range lifecycleOps() {
+			t.Run(form.name+"/"+op.name, func(t *testing.T) {
+				t.Parallel()
+
+				// Arrange
+				spy := &mutatingCallSpy{}
+				c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+					inspectRoute(form.ref): jsonHandler(http.StatusOK, container.InspectResponse{
+						ID:   protectedFixtureFullID,
+						Name: "/" + protectedFixtureName,
+					}),
+					op.actionRoute(protectedFixtureFullID): spy.handler,
+				})
+				c = withSelf(c, false, "")
+				c = withProtected(c, form.entries...)
+
+				// Act
+				err := op.call(c, context.Background(), form.ref)
+
+				// Assert
+				if !errors.Is(err, ErrProtectedContainer) {
+					t.Fatalf("err = %v, want errors.Is(err, ErrProtectedContainer)", err)
+				}
+				if spy.hit {
+					t.Error("mutating Engine endpoint was reached, want it never contacted")
+				}
+			})
+		}
+	}
+}
+
+// TestLifecycleSelfWinsOverProtected proves that when a target matches both
+// the agent's own identity and the operator's protected list, the fixed
+// self rule is reported, not the configurable one: an agent whose own name
+// is also listed must still answer with the self-specific error.
+func TestLifecycleSelfWinsOverProtected(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	spy := &mutatingCallSpy{}
+	c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+		inspectRoute(selfFullID):                    jsonHandler(http.StatusOK, container.InspectResponse{ID: selfFullID}),
+		"POST /containers/" + selfFullID + "/start": spy.handler,
+	})
+	c = withSelf(c, true, selfFullID)
+	c = withProtected(c, selfFullID)
+
+	// Act
+	err := c.StartContainer(context.Background(), selfFullID)
+
+	// Assert
+	if !errors.Is(err, ErrSelfProtected) {
+		t.Fatalf("err = %v, want errors.Is(err, ErrSelfProtected)", err)
+	}
+	if errors.Is(err, ErrProtectedContainer) {
+		t.Errorf("err = %v, want NOT errors.Is(err, ErrProtectedContainer)", err)
+	}
+	if spy.hit {
+		t.Error("mutating Engine endpoint was reached, want it never contacted")
+	}
+}
+
+// TestLifecycleProtectedNotContainerized proves the protected list is
+// enforced even when the agent itself is not running in a container at all
+// (so self-exclusion is inapplicable): protection is independent of
+// self-identification.
+func TestLifecycleProtectedNotContainerized(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	spy := &mutatingCallSpy{}
+	c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+		inspectRoute(protectedFixtureName): jsonHandler(http.StatusOK, container.InspectResponse{
+			ID:   protectedFixtureFullID,
+			Name: "/" + protectedFixtureName,
+		}),
+		"POST /containers/" + protectedFixtureFullID + "/stop": spy.handler,
+	})
+	c = withSelf(c, false, "")
+	c = withProtected(c, protectedFixtureName)
+
+	// Act
+	err := c.StopContainer(context.Background(), protectedFixtureName)
+
+	// Assert
+	if !errors.Is(err, ErrProtectedContainer) {
+		t.Fatalf("err = %v, want errors.Is(err, ErrProtectedContainer)", err)
+	}
+	if spy.hit {
+		t.Error("mutating Engine endpoint was reached, want it never contacted")
+	}
+}
+
+// TestLifecycleUnprotectedProceeds proves a target that does not match the
+// protected set proceeds to the Engine normally, even when the set is
+// non-empty: DEVMON_PROTECTED_CONTAINERS narrows what can be touched, it does
+// not fail closed for everything else.
+func TestLifecycleUnprotectedProceeds(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	const ref = "other-container"
+	const resolvedID = "other0000000000000000000000000000000000000000000000000000000"
+	c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+		inspectRoute(ref): jsonHandler(http.StatusOK, container.InspectResponse{ID: resolvedID, Name: "/" + ref}),
+		"POST /containers/" + resolvedID + "/start": jsonHandler(http.StatusOK, nil),
+	})
+	c = withSelf(c, false, "")
+	c = withProtected(c, protectedFixtureName)
+
+	// Act
+	err := c.StartContainer(context.Background(), ref)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("StartContainer() error = %v, want nil", err)
 	}
 }
 

--- a/internal/dockerx/protected.go
+++ b/internal/dockerx/protected.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dockerx
+
+import "regexp"
+
+// protectedIDPattern matches the two shapes the Docker Engine ever assigns a
+// container ID: a 12-hex short ID or a full 64-hex ID. An entry that matches
+// this pattern is treated as a possible ID as well as a name; an entry of any
+// other length or character set is a name only.
+//
+// This is deliberately not "hex characters, any length": a short operator
+// entry like "cafe" is a perfectly legal container NAME, and if it were also
+// tried as an ID prefix it would protect every container on the host whose ID
+// happens to start with those four hex digits — an accidental, host-wide
+// match the operator never asked for. Fixing the length to exactly 12 or 64
+// removes that failure mode entirely.
+var protectedIDPattern = regexp.MustCompile(`^(?:[0-9a-f]{12}|[0-9a-f]{64})$`)
+
+// shortIDLength is the length of the Engine's short-ID form. resolveTarget
+// always has the full ID by the time it calls matches, but matches also
+// accepts a caller that only knows the short form, mirroring the Engine's own
+// name-or-ID resolution.
+const shortIDLength = 12
+
+// protectedSet is the operator's DEVMON_PROTECTED_CONTAINERS entries, split
+// into names and IDs once at startup and never written again. The zero value
+// (no maps allocated) matches nothing: nil maps are safe to read, so a
+// &Client{} built without going through New — as every pre-existing test in
+// this package does — keeps behaving exactly as before this feature.
+type protectedSet struct {
+	names map[string]struct{}
+	ids   map[string]struct{}
+}
+
+// newProtectedSet builds a protectedSet from the operator's raw entries.
+// Every entry is a name candidate; an entry that also matches
+// protectedIDPattern is an ID candidate too. Uppercase hex never matches
+// protectedIDPattern (the pattern is lowercase-only, matching how the Engine
+// itself always reports IDs), so an uppercase 12-hex entry is name-only by
+// construction — Docker would never ask this agent to compare it against a
+// real ID.
+func newProtectedSet(entries []string) protectedSet {
+	names := make(map[string]struct{}, len(entries))
+	ids := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		names[e] = struct{}{}
+		if protectedIDPattern.MatchString(e) {
+			ids[e] = struct{}{}
+		}
+	}
+	return protectedSet{names: names, ids: ids}
+}
+
+// matches reports whether id or any of names is in the protected set.
+//
+// A name matches when trimContainerName(n) equals a configured entry exactly,
+// for any n in names — a container can carry a link alias alongside its real
+// name, and only one of them needs to match. An ID matches the configured
+// entries either as a full ID or, when id is at least shortIDLength characters
+// long, by its first shortIDLength characters — never by any other prefix
+// length, for the reason protectedIDPattern's doc comment gives.
+//
+// A 12-hex entry that happens to also be a real container's name matches
+// through both routes for two different containers; that is intentional.
+// Over-protecting a container the operator did not mean to name is the safe
+// direction for a security boundary, and it mirrors Docker's own CLI, which
+// resolves a short reference against names before IDs with the same
+// ambiguity.
+func (p protectedSet) matches(id string, names ...string) bool {
+	for _, n := range names {
+		if _, ok := p.names[trimContainerName(n)]; ok {
+			return true
+		}
+	}
+	if _, ok := p.ids[id]; ok {
+		return true
+	}
+	if len(id) >= shortIDLength {
+		if _, ok := p.ids[id[:shortIDLength]]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// empty reports whether the set carries no entries, used only to decide
+// whether New logs its one-line startup confirmation.
+func (p protectedSet) empty() bool {
+	return len(p.names) == 0
+}

--- a/internal/dockerx/protected_test.go
+++ b/internal/dockerx/protected_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dockerx
+
+import "testing"
+
+// TestProtectedSetMatches exercises newProtectedSet/matches together, covering
+// the design's name-vs-ID matching rules: name matching is exact after
+// trimming the leading "/", ID matching is only ever a 12-hex short ID or a
+// full 64-hex ID (never an arbitrary-length prefix), and a 12-hex entry that
+// is also a real container name matches by both routes.
+func TestProtectedSetMatches(t *testing.T) {
+	t.Parallel()
+
+	const fullID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const shortID = "aaaaaaaaaaaa" // fullID's 12-hex prefix
+	const otherFullID = "aaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	tests := []struct {
+		name    string
+		entries []string
+		id      string
+		names   []string
+		want    bool
+	}{
+		{
+			name:    "zero value matches nothing",
+			entries: nil,
+			id:      fullID,
+			names:   []string{"/anything"},
+			want:    false,
+		},
+		{
+			name:    "name entry matches a slash-prefixed name",
+			entries: []string{"proxy"},
+			id:      "irrelevant0000000000",
+			names:   []string{"/proxy"},
+			want:    true,
+		},
+		{
+			name:    "a different name does not match",
+			entries: []string{"proxy"},
+			id:      "irrelevant0000000000",
+			names:   []string{"/database"},
+			want:    false,
+		},
+		{
+			name:    "12-hex entry matches an ID prefix",
+			entries: []string{shortID},
+			id:      fullID,
+			names:   []string{"/unrelated-name"},
+			want:    true,
+		},
+		{
+			name:    "12-hex entry also matches a container named that string",
+			entries: []string{shortID},
+			id:      "totally-different-id-0000000000000000000000000000000000000000",
+			names:   []string{"/" + shortID},
+			want:    true,
+		},
+		{
+			name:    "64-hex entry is exact only, not a prefix match for another ID",
+			entries: []string{fullID},
+			id:      otherFullID,
+			names:   []string{"/unrelated-name"},
+			want:    false,
+		},
+		{
+			name:    "64-hex entry matches the exact full ID",
+			entries: []string{fullID},
+			id:      fullID,
+			names:   []string{"/unrelated-name"},
+			want:    true,
+		},
+		{
+			name:    "11-char hex is name-only, does not match an ID prefix",
+			entries: []string{shortID[:11]},
+			id:      fullID,
+			names:   []string{"/unrelated-name"},
+			want:    false,
+		},
+		{
+			name:    "13-char hex is name-only, does not match an ID prefix",
+			entries: []string{shortID + "a"},
+			id:      fullID,
+			names:   []string{"/unrelated-name"},
+			want:    false,
+		},
+		{
+			name:    "uppercase 12-hex entry is name-only",
+			entries: []string{"AAAAAAAAAAAA"},
+			id:      fullID,
+			names:   []string{"/unrelated-name"},
+			want:    false,
+		},
+		{
+			name:    "uppercase 12-hex entry still matches an equally-cased name",
+			entries: []string{"AAAAAAAAAAAA"},
+			id:      "irrelevant0000000000",
+			names:   []string{"/AAAAAAAAAAAA"},
+			want:    true,
+		},
+		{
+			name:    "a Names slice with a link alias plus the real name matches on the real name",
+			entries: []string{"proxy"},
+			id:      "irrelevant0000000000",
+			names:   []string{"/linker/alias", "/proxy"},
+			want:    true,
+		},
+		{
+			name:    "an ID shorter than 12 chars never panics and does not match",
+			entries: []string{shortID},
+			id:      "abc",
+			names:   []string{"/unrelated-name"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			p := newProtectedSet(tt.entries)
+
+			// Act
+			got := p.matches(tt.id, tt.names...)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("matches(%q, %v) = %v, want %v", tt.id, tt.names, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProtectedSetZeroValueMatchesNothing covers the literal zero value (not
+// one built by newProtectedSet(nil)), since every existing test that builds
+// &Client{} directly relies on this.
+func TestProtectedSetZeroValueMatchesNothing(t *testing.T) {
+	t.Parallel()
+
+	var p protectedSet
+
+	if p.matches("anything", "/anything") {
+		t.Error("zero value protectedSet matched, want it to match nothing")
+	}
+}
+
+// TestProtectedSetEmpty covers the empty helper used for the startup log
+// decision: nil entries are empty, and even one entry makes it non-empty.
+func TestProtectedSetEmpty(t *testing.T) {
+	t.Parallel()
+
+	if !newProtectedSet(nil).empty() {
+		t.Error("newProtectedSet(nil).empty() = false, want true")
+	}
+	if newProtectedSet([]string{"proxy"}).empty() {
+		t.Error("newProtectedSet([]string{\"proxy\"}).empty() = true, want false")
+	}
+}

--- a/internal/dockerx/types.go
+++ b/internal/dockerx/types.go
@@ -64,11 +64,12 @@ type ContainerSummary struct {
 	Health    string            `json:"health,omitempty"` // "" when Health is nil
 	Labels    map[string]string `json:"labels"`
 	Ports     []Port            `json:"ports"`
-	// Protected reports whether this is the agent's own container (D18). No
-	// omitempty: a false value must appear in the JSON, or an app that
-	// cannot distinguish "not protected" from "this agent version does not
-	// report protection" would quietly offer a delete button on the agent
-	// itself.
+	// Protected reports whether this is the agent's own container or one
+	// listed in DEVMON_PROTECTED_CONTAINERS (D18); every mutating route
+	// refuses it. No omitempty: a false value must appear in the JSON, or an
+	// app that cannot distinguish "not protected" from "this agent version
+	// does not report protection" would quietly offer a delete button on a
+	// container it should not.
 	Protected bool `json:"protected"`
 }
 
@@ -100,8 +101,10 @@ type ContainerDetail struct {
 	Mounts        []Mount           `json:"mounts"`
 	Networks      []EndpointSummary `json:"networks"`
 	Ports         []Port            `json:"ports"`
-	// Protected reports whether this is the agent's own container (D18). See
-	// ContainerSummary.Protected for why it has no omitempty.
+	// Protected reports whether this is the agent's own container or one
+	// listed in DEVMON_PROTECTED_CONTAINERS (D18); every mutating route
+	// refuses it. See ContainerSummary.Protected for why it has no
+	// omitempty.
 	Protected bool `json:"protected"`
 }
 

--- a/internal/dockerx/types_test.go
+++ b/internal/dockerx/types_test.go
@@ -381,7 +381,7 @@ func TestContainerDetailNeverCarriesEnv(t *testing.T) {
 	}
 
 	// Act
-	got := toContainerDetail(r, "")
+	got := toContainerDetail(r, "", protectedSet{})
 	raw, err := json.Marshal(got)
 	if err != nil {
 		t.Fatalf("json.Marshal(got) error = %v", err)

--- a/internal/e2e/api/contract_protected_test.go
+++ b/internal/e2e/api/contract_protected_test.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/client"
+
+	"github.com/scnplt/devmon-agent/internal/e2e/harness"
+)
+
+// This file exercises DEVMON_PROTECTED_CONTAINERS: an optional, startup-only
+// list of container names or IDs that every lifecycle route refuses in every
+// policy mode, independent of the agent's own self-exclusion (which needs a
+// containerised agent and lives in internal/e2e/incontainer). It replays the
+// plan's checklist for the new knob: refusal by every reference form the
+// operator could have listed (name, short ID, full ID), a second,
+// deliberately unprotected fixture proving the refusal is target-specific and
+// not a blanket denial, the "protected": true projection in both list and
+// inspect, reads and logs staying unaffected, and the audit trail recording
+// outcome denied_protected with the target exactly as the client supplied it.
+//
+// What this file deliberately does NOT cover: a self-exclusion-style
+// "TestProtectedContainerDoesNotWeakenSelfRule" is not meaningful here — this
+// package's agent is a host binary with no container of its own, so it has no
+// self rule for a protected-list entry to interact with; that interaction
+// (self wins when a container is listed as both self and protected) is a
+// dockerx-level unit test (internal/dockerx/lifecycle_test.go's
+// TestLifecycleSelfWinsOverProtected), not an e2e concern. Likewise, one
+// agent protecting a SIBLING agent's own container needs two containerised
+// agents and is explicitly out of scope for this phase (plan's NOT building
+// list).
+
+// protectedContainerBody is the exact error body internal/httpapi/reads.go
+// serves for dockerx.ErrProtectedContainer. Declared locally rather than
+// imported (this suite's own convention, mirrored from
+// internal/e2e/incontainer's selfExclusionBody): a wording change must be
+// something this suite notices, which it cannot do if it shares the constant
+// with the server that produces it.
+const protectedContainerBody = "container is protected by host configuration"
+
+// outcomeDeniedProtected is the audit outcome internal/httpapi/reads.go
+// records for a protected-container refusal (internal/state/audit.go's
+// OutcomeDeniedProtected constant). Declared locally for the same reason as
+// protectedContainerBody.
+const outcomeDeniedProtected = "denied_protected"
+
+// protectedRefFormOrder fixes the iteration order over the three reference
+// forms so subtest names and the audit-order assertion below stay stable
+// across runs.
+var protectedRefFormOrder = []string{"name", "short", "full"}
+
+// refForms returns id's three reference forms: its container name with
+// Docker's leading "/" stripped (dockerx.ValidateRef's pattern rejects a
+// leading slash, so the raw InspectResponse.Name would fail validation before
+// the protected-container check ever runs), its 12-character short ID, and
+// its 64-character full ID. Built from ContainerInspect, never from `docker
+// ps` output, mirroring internal/e2e/incontainer/contract_selfexclusion_test.go's
+// helper of the same name in the sibling package.
+func refForms(t *testing.T, e *client.Client, id string) map[string]string {
+	t.Helper()
+
+	if len(id) != 64 {
+		t.Fatalf("container ID %q is not a 64-character full ID", id)
+	}
+	res, err := e.ContainerInspect(context.Background(), id, client.ContainerInspectOptions{})
+	if err != nil {
+		t.Fatalf("inspect container %s: %v", id, err)
+	}
+	name := strings.TrimPrefix(res.Container.Name, "/")
+
+	return map[string]string{
+		"name":  name,
+		"short": id[:12],
+		"full":  id,
+	}
+}
+
+// protectedLifecycleRoute is one of the five mutating routes under test.
+type protectedLifecycleRoute struct {
+	operation string
+	method    string
+	path      func(ref string) string
+}
+
+var protectedLifecycleRoutes = []protectedLifecycleRoute{
+	{"start", http.MethodPost, func(ref string) string { return "/v1/containers/" + ref + "/start" }},
+	{"restart", http.MethodPost, func(ref string) string { return "/v1/containers/" + ref + "/restart" }},
+	{"stop", http.MethodPost, func(ref string) string { return "/v1/containers/" + ref + "/stop" }},
+	{"kill", http.MethodPost, func(ref string) string { return "/v1/containers/" + ref + "/kill" }},
+	{"delete", http.MethodDelete, func(ref string) string { return "/v1/containers/" + ref }},
+}
+
+// protectedCall records one refused attempt's operation and the exact
+// reference string the test sent, so the audit assertion below can check the
+// trail against what was actually requested rather than a guess.
+type protectedCall struct {
+	operation string
+	target    string
+}
+
+// TestProtectedContainerRefusedByEveryForm is the headline metric for this
+// knob: a full-mode agent — the most permissive policy tier there is —
+// refuses all five lifecycle routes against a container named in
+// DEVMON_PROTECTED_CONTAINERS, by every one of the three reference forms a
+// client could plausibly send. It then proves the refusal is specific to that
+// target (a second, unprotected fixture created AFTER the agent started still
+// answers normally), that both read projections mark the protected row, that
+// reads and logs are unaffected, that the audit trail records
+// denied_protected with the target exactly as supplied, and that the Engine
+// itself (not the agent) still shows the protected container running,
+// untouched by any of the fifteen refused attempts.
+//
+// The environment is fixed at agent start (config is read once, D5), so the
+// fixture must exist and its name must be known BEFORE StartAgent runs.
+func TestProtectedContainerRefusedByEveryForm(t *testing.T) {
+	t.Parallel()
+	engine := harness.RequireEngine(t)
+
+	protectedID := harness.StartFixture(t, engine, harness.FixtureOptions{NameSuffix: "protected"})
+	waitContainerRunning(t, engine, protectedID)
+	protectedRefs := refForms(t, engine, protectedID)
+
+	a := harness.StartAgent(t, harness.AgentOptions{
+		PolicyMode: "full",
+		Env:        map[string]string{"DEVMON_PROTECTED_CONTAINERS": protectedRefs["name"]},
+	})
+	d := harness.PairDevice(t, a, "protected-refused-every-form")
+
+	// Fifteen cells, all the same answer: none may reach the Engine, so the
+	// container's running state never changes regardless of which route or
+	// reference form is tried.
+	var calls []protectedCall
+	for _, route := range protectedLifecycleRoutes {
+		for _, form := range protectedRefFormOrder {
+			ref := protectedRefs[form]
+			calls = append(calls, protectedCall{operation: route.operation, target: ref})
+
+			t.Run(route.operation+"/"+form, func(t *testing.T) {
+				status, obj := d.JSON(t, route.method, route.path(ref))
+				if status != http.StatusForbidden {
+					t.Fatalf("%s %s (protected, by %s): status = %d, want %d; body = %v",
+						route.method, route.path(ref), form, status, http.StatusForbidden, obj)
+				}
+				if obj["error"] != protectedContainerBody {
+					t.Errorf("%s %s (protected, by %s): error = %v, want %q",
+						route.method, route.path(ref), form, obj["error"], protectedContainerBody)
+				}
+			})
+		}
+	}
+
+	// Falsifiability: a second fixture, created only now — after the agent's
+	// environment (and therefore its protected list) is already fixed — is
+	// NOT a member of that list and must behave exactly like any other
+	// fixture. If every mutating request against this agent failed
+	// regardless of target, the fifteen 403s above would prove nothing about
+	// the protected list specifically.
+	unprotectedID := harness.StartFixture(t, engine, harness.FixtureOptions{NameSuffix: "unprotected"})
+	waitContainerRunning(t, engine, unprotectedID)
+
+	status, _, raw := d.Do(t, http.MethodPost, "/v1/containers/"+unprotectedID+"/restart", nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("POST .../restart on an unprotected fixture created after the agent started: status = %d, want %d; body = %s",
+			status, http.StatusNoContent, raw)
+	}
+	assertNoBody(t, raw)
+
+	// Both read projections mark the protected row, and only the protected
+	// row.
+	items := readEnvelope(t, d, "/v1/containers?all=true")
+	protectedRow := findByKey(t, items, "id", protectedID)
+	if protectedRow["protected"] != true {
+		t.Errorf("protected fixture list row: protected = %v, want true", protectedRow["protected"])
+	}
+	unprotectedRow := findByKey(t, items, "id", unprotectedID)
+	if unprotectedRow["protected"] != false {
+		t.Errorf("unprotected fixture list row: protected = %v, want false", unprotectedRow["protected"])
+	}
+
+	status, detail := d.JSON(t, http.MethodGet, "/v1/containers/"+protectedID)
+	if status != http.StatusOK {
+		t.Fatalf("GET /v1/containers/%s: status = %d, want %d", protectedID, status, http.StatusOK)
+	}
+	if detail["protected"] != true {
+		t.Errorf("protected fixture inspect: protected = %v, want true", detail["protected"])
+	}
+
+	// Reads and logs are unaffected: the protected list narrows mutation
+	// only, mirroring self-exclusion's own scope.
+	status, _, raw = d.Do(t, http.MethodGet, "/v1/containers/"+protectedID+"/logs", nil)
+	if status != http.StatusOK {
+		t.Errorf("GET .../logs on the protected fixture: status = %d, want %d; body = %s", status, http.StatusOK, raw)
+	}
+
+	// The audit trail: exactly the fifteen refused calls carry outcome
+	// denied_protected, each with the target recorded exactly as this test
+	// supplied it. Identity rows (the pair request PairDevice itself makes)
+	// are excluded, mirroring contract_audit_test.go's own convention.
+	rows := nonIdentityAuditRows(harness.ListAudit(t, a, auditListLimit))
+	var deniedRows []harness.AuditRow
+	for _, row := range rows {
+		if row.Outcome == outcomeDeniedProtected {
+			deniedRows = append(deniedRows, row)
+		}
+	}
+	if len(deniedRows) != len(calls) {
+		t.Fatalf("audit list holds %d denied_protected rows, want exactly %d: %+v", len(deniedRows), len(calls), deniedRows)
+	}
+	// ListAudit orders newest first (harness/cli.go's documented GOTCHA), and
+	// calls were made oldest first, so the comparison walks calls in reverse.
+	for i, row := range deniedRows {
+		want := calls[len(calls)-1-i]
+		if row.Operation != want.operation {
+			t.Errorf("denied_protected row %d: operation = %q, want %q", i, row.Operation, want.operation)
+		}
+		if row.Target != want.target {
+			t.Errorf("denied_protected row %d: target = %q, want %q", i, row.Target, want.target)
+		}
+	}
+
+	// The metric itself, asked of the ENGINE, never the agent: still running,
+	// untouched by any of the fifteen refused attempts.
+	waitContainerRunning(t, engine, protectedID)
+}
+
+// TestProtectedContainerByShortIDEnv asserts an operator may list a
+// container's 12-character short ID instead of its name, and a request that
+// addresses the SAME container by NAME is still refused — the matching rule
+// resolves the request's target to an ID before comparing (dockerx/protected.go),
+// so an entry recorded in the environment as an ID form still protects every
+// reference form of that container, not just the one the operator typed.
+func TestProtectedContainerByShortIDEnv(t *testing.T) {
+	t.Parallel()
+	engine := harness.RequireEngine(t)
+
+	protectedID := harness.StartFixture(t, engine, harness.FixtureOptions{NameSuffix: "protected-short-id"})
+	waitContainerRunning(t, engine, protectedID)
+	refs := refForms(t, engine, protectedID)
+
+	a := harness.StartAgent(t, harness.AgentOptions{
+		PolicyMode: "full",
+		Env:        map[string]string{"DEVMON_PROTECTED_CONTAINERS": refs["short"]},
+	})
+	d := harness.PairDevice(t, a, "protected-short-id-env")
+
+	status, obj := d.JSON(t, http.MethodPost, "/v1/containers/"+refs["name"]+"/stop")
+	if status != http.StatusForbidden {
+		t.Fatalf("POST .../stop (by name, protected via a 12-hex short ID in the env): status = %d, want %d; body = %v",
+			status, http.StatusForbidden, obj)
+	}
+	if obj["error"] != protectedContainerBody {
+		t.Errorf("POST .../stop (by name, protected via a 12-hex short ID in the env): error = %v, want %q",
+			obj["error"], protectedContainerBody)
+	}
+}

--- a/internal/e2e/api/contract_startup_test.go
+++ b/internal/e2e/api/contract_startup_test.go
@@ -93,6 +93,29 @@ func TestConfigFaultsReportedTogether(t *testing.T) {
 			t.Errorf("stderr does not name DEVMON_RATE_GUARDED_PER_SEC; stderr = %s", stderr)
 		}
 	})
+
+	// One well-formed entry alongside one malformed entry in
+	// DEVMON_PROTECTED_CONTAINERS is a configuration fault: the variable is
+	// optional, but once set, every entry must match the same grammar as
+	// DEVMON_SELF_CONTAINER (internal/config/config.go's protectedContainers).
+	// A space inside an entry is never valid, mirroring DEVMON_SELF_CONTAINER's
+	// own rejection table.
+	t.Run("a malformed DEVMON_PROTECTED_CONTAINERS entry is a configuration fault", func(t *testing.T) {
+		t.Parallel()
+
+		a := harness.StartAgent(t, harness.AgentOptions{
+			Env:           map[string]string{"DEVMON_PROTECTED_CONTAINERS": "ok-name,bad name!"},
+			ExpectFailure: true,
+		})
+
+		exitCode, stderr := a.Wait(t)
+		if exitCode != 2 {
+			t.Errorf("exit code = %d, want 2 (config fault)", exitCode)
+		}
+		if !strings.Contains(stderr, "DEVMON_PROTECTED_CONTAINERS") {
+			t.Errorf("stderr does not name DEVMON_PROTECTED_CONTAINERS; stderr = %s", stderr)
+		}
+	})
 }
 
 // TestStartupFailsWhenEngineUnreachable asserts an agent pointed at a Docker

--- a/internal/httpapi/lifecycle_test.go
+++ b/internal/httpapi/lifecycle_test.go
@@ -103,6 +103,7 @@ func TestLifecycleRoutesStatusMatrix(t *testing.T) {
 		{name: "success", err: nil, wantStatus: http.StatusNoContent},
 		{name: "not modified", err: dockerx.ErrNotModified, wantStatus: http.StatusNoContent},
 		{name: "self protected", err: dockerx.ErrSelfProtected, wantStatus: http.StatusForbidden, wantBody: msgSelfProtected},
+		{name: "protected container", err: dockerx.ErrProtectedContainer, wantStatus: http.StatusForbidden, wantBody: msgProtectedContainer},
 		{name: "self unknown", err: dockerx.ErrSelfUnknown, wantStatus: http.StatusServiceUnavailable, wantBody: msgSelfUnknown},
 		{name: "conflict", err: dockerx.ErrConflict, wantStatus: http.StatusConflict, wantBody: msgContainerConflict},
 		{name: "not found", err: dockerx.ErrNotFound, wantStatus: http.StatusNotFound, wantBody: msgNotFound},
@@ -185,6 +186,47 @@ func TestLifecycleNotModifiedAuditsAsSuccess(t *testing.T) {
 			}
 			if entries[0].Outcome != state.OutcomeSuccess {
 				t.Errorf("outcome = %q, want %q", entries[0].Outcome, state.OutcomeSuccess)
+			}
+		})
+	}
+}
+
+// TestLifecycleProtectedContainerAuditsAsDeniedProtected asserts that a
+// dockerx.ErrProtectedContainer result audits as OutcomeDeniedProtected,
+// matching the 403 status writeDockerError answers for it, and that this
+// outcome is distinct from OutcomeDeniedSelf (mirrors
+// TestLifecycleNotModifiedAuditsAsSuccess).
+func TestLifecycleProtectedContainerAuditsAsDeniedProtected(t *testing.T) {
+	t.Parallel()
+
+	for _, route := range lifecycleRouteCases() {
+		t.Run(route.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fd := &fakeDocker{}
+			route.setErr(fd, dockerx.ErrProtectedContainer)
+			s, st := testServerWithDocker(t, policy.ModeFull, fd)
+			serial := pairDeviceForRead(t, st)
+			handler := auditChain(s, route.op, route.handler(s))
+			rec := httptest.NewRecorder()
+
+			// Act
+			handler.ServeHTTP(rec, lifecycleRequest(serial))
+
+			// Assert
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusForbidden, rec.Body.String())
+			}
+			entries, err := st.ListAudit(context.Background(), 10)
+			if err != nil {
+				t.Fatalf("ListAudit: %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("len(entries) = %d, want 1", len(entries))
+			}
+			if entries[0].Outcome != state.OutcomeDeniedProtected {
+				t.Errorf("outcome = %q, want %q", entries[0].Outcome, state.OutcomeDeniedProtected)
 			}
 		})
 	}

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -90,6 +90,10 @@ const (
 	// agent's own container — a fixed rule, not a policy tier (D1).
 	msgSelfProtected = "the agent cannot act on itself"
 
+	// msgProtectedContainer is served when a lifecycle operation targets a
+	// container matching the operator's DEVMON_PROTECTED_CONTAINERS list.
+	msgProtectedContainer = "container is protected by host configuration"
+
 	// msgSelfUnknown is served when the agent is containerised but could not
 	// determine which container it is, so the self-exclusion rule cannot be
 	// enforced and lifecycle operations fail closed (D3).
@@ -104,9 +108,9 @@ const (
 // writeDockerError maps a dockerx failure onto a status code. ErrInvalidRef
 // and ErrConflict are client mistakes (400, 409), ErrNotFound is an answer
 // (404), ErrNotModified is a no-op success (204: the object was already in
-// the requested state, D9), ErrSelfProtected and ErrSelfUnknown are the
-// self-exclusion rule refusing an operation (403, 503), and everything else
-// is the Engine failing upstream of us (502) — never 500, which must keep
+// the requested state, D9), ErrSelfProtected, ErrProtectedContainer, and
+// ErrSelfUnknown refuse an operation (403, 403, 503), and everything else is
+// the Engine failing upstream of us (502) — never 500, which must keep
 // meaning "the agent itself broke". r carries the in-flight audit entry (a
 // no-op outside a mutating route, via setAuditOutcome), so every failure
 // path — including the pre-existing not-found and invalid-ref branches — is
@@ -127,6 +131,9 @@ func (s *Server) writeDockerError(w http.ResponseWriter, r *http.Request, op str
 	case errors.Is(err, dockerx.ErrSelfProtected):
 		setAuditOutcome(r.Context(), state.OutcomeDeniedSelf, "")
 		s.writeError(w, http.StatusForbidden, msgSelfProtected)
+	case errors.Is(err, dockerx.ErrProtectedContainer):
+		setAuditOutcome(r.Context(), state.OutcomeDeniedProtected, "")
+		s.writeError(w, http.StatusForbidden, msgProtectedContainer)
 	case errors.Is(err, dockerx.ErrSelfUnknown):
 		setAuditOutcome(r.Context(), state.OutcomeUnavailable, "")
 		s.writeError(w, http.StatusServiceUnavailable, msgSelfUnknown)

--- a/internal/state/audit.go
+++ b/internal/state/audit.go
@@ -24,11 +24,14 @@ const (
 	OutcomeSuccess      = "success"
 	OutcomeDeniedPolicy = "denied_policy"
 	OutcomeDeniedSelf   = "denied_self"
-	OutcomeNotFound     = "not_found"
-	OutcomeInvalid      = "invalid"
-	OutcomeConflict     = "conflict"
-	OutcomeUnavailable  = "unavailable" // self ID unknown (D3)
-	OutcomeEngineError  = "engine_error"
+	// OutcomeDeniedProtected is recorded when a lifecycle operation targets a
+	// container matching the operator's DEVMON_PROTECTED_CONTAINERS list.
+	OutcomeDeniedProtected = "denied_protected"
+	OutcomeNotFound        = "not_found"
+	OutcomeInvalid         = "invalid"
+	OutcomeConflict        = "conflict"
+	OutcomeUnavailable     = "unavailable" // self ID unknown (D3)
+	OutcomeEngineError     = "engine_error"
 	// OutcomeInternalError covers a failure on the agent's own side that is
 	// neither the caller's fault nor a Docker Engine error — for example a
 	// store write that failed while issuing or recording a device


### PR DESCRIPTION
## Summary

Self-exclusion protects exactly one container: the agent's own. With two agents on one host, a device paired to agent A cannot touch A but can stop, kill, or delete agent B, and B's devices can do the same to A. The same gap covers any container an operator wants out of remote reach, such as a reverse proxy.

This adds one optional startup variable, `DEVMON_PROTECTED_CONTAINERS`: a comma-separated list of container names or IDs. A matching container is refused by every lifecycle route with `403 container is protected by host configuration` in every policy mode, and its rows in list and inspect carry `protected: true`, the same field the agent's own row already uses. Reads, inspect, logs, and the event stream are unaffected.

An agent started without the variable behaves exactly as 0.6.0 did.

## What changed

- **config**: `DEVMON_PROTECTED_CONTAINERS` parsed once at startup with the `DEVMON_SELF_CONTAINER` grammar per entry; blanks ignored, duplicates dropped, malformed entry is a startup fault (exit 2).
- **dockerx**: new `protectedSet` built once in `New`, which now takes an `Options` struct. `resolveTarget` checks it after the self rule, so self-exclusion keeps precedence and cannot be weakened by the list.
- **matching rule**: exact name (leading `/` trimmed), or ID when the entry is 12 or 64 lowercase hex characters. No other prefix length, so a name like `cafe` cannot protect every container whose ID happens to start with it.
- **httpapi / state**: `ErrProtectedContainer` maps to 403 with its own body; audit outcome `denied_protected`.
- **e2e**: 15 refusal cells (5 routes x name/short/full), unlisted fixture still served, `protected: true` in list and inspect, logs still 200, audit rows, Engine still shows the container running, short-ID env form, startup fault case.
- **docs**: CONFIGURATION (table row and a "Protecting other containers" section), README, compose.example.yaml, API.md, openapi.yaml, THREAT-MODEL, OPERATIONS, CHANGELOG Unreleased.
- **install.sh**: `--protected-containers` flag, an optional prompt that Enter skips, validators, conditional compose output.

Not built on purpose: no `protected` field on the event-stream snapshot, nothing new on `/v1/status` (unauthenticated, would leak host topology), no Engine verification of entries at startup, no client-facing way to read or change the list.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go vet -tags e2e ./...`, `golangci-lint run ./...` (plus `--build-tags e2e`), `gosec ./...` clean
- [x] `go test ./internal/... -race`, coverage 93.9% (floor 90%)
- [x] shellcheck, doc-citations, openapi-lint clean
- [x] e2e api, harness, and incontainer suites green from WSL2 Ubuntu against Docker Desktop's Engine: 86 top-level tests, 0 failures, 2 documented endurance skips; self-exclusion contracts unchanged
- [x] Manual: two agents on one host, each listing the other; from a device paired to A, stop on B answers 403, list shows B `protected: true`, B's logs still stream, `devmon-agent audit list` shows `denied_protected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
