### PR TITLE
chore: prepare the 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ moved.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-07
+
+A feature release. Self-exclusion has always protected exactly one container
+— the agent's own. This release lets the operator name others, so a container
+the operator wants out of remote reach stays out of it in every policy mode.
+
 The configuration surface gains one optional variable,
 `DEVMON_PROTECTED_CONTAINERS`, and loses none. An agent started without it
 behaves exactly as 0.6.0 did. No route changed, and the one response field
@@ -40,6 +46,31 @@ involved, `protected`, widened its meaning without changing its shape.
   enforced in the same layer as self-exclusion, which takes precedence when
   both apply. Refusals are audited as `denied_protected`. `install.sh` gains
   `--protected-containers` and a matching prompt that Enter skips.
+  ([#137](https://github.com/scnplt/devmon-agent/pull/137))
+
+### Internal
+
+- The Docker SDK moved to `github.com/moby/moby/client` 0.6.0 and
+  `github.com/moby/moby/api` 1.56.0. Both are additive — an `annotation`
+  filter on the container list and `HostConfig.Umask` on create — and the
+  agent negotiates the API version at startup, so nothing changes on the wire
+  against an older Engine. `modernc.org/sqlite` moved to 1.58.0, the
+  `golang:1.27-alpine` builder digest was refreshed, and
+  `docker/setup-qemu-action` moved to 4.3.0 in the release workflow.
+  ([#139](https://github.com/scnplt/devmon-agent/pull/139),
+  [#140](https://github.com/scnplt/devmon-agent/pull/140),
+  [#141](https://github.com/scnplt/devmon-agent/pull/141))
+- The README shrank from over a thousand lines to an introduction, and the
+  detail moved into `docs/INSTALL.md`, `docs/CONFIGURATION.md`,
+  `docs/OPERATIONS.md`, `docs/API.md`, and `docs/DEVELOPMENT.md`. The
+  doc-citation check now resolves anchors across those files as well as the
+  README. This landed on `main` after 0.6.0 without a tag, so 0.7.0 is the
+  first image whose documented version matches it.
+  ([#134](https://github.com/scnplt/devmon-agent/pull/134))
+- The plan-driven PRPs workflow was retired. `CLAUDE.md` is now the single
+  authority on model routing, commit cadence, and the gate list, and the
+  gate list mirrors `ci.yml` step for step.
+  ([#138](https://github.com/scnplt/devmon-agent/pull/138))
 
 ## [0.6.0] - 2026-08-29
 
@@ -566,7 +597,8 @@ First public release — the full surface.
 
 [#120]: https://github.com/scnplt/devmon-agent/issues/120
 
-[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/scnplt/devmon-agent/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/scnplt/devmon-agent/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/scnplt/devmon-agent/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/scnplt/devmon-agent/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/scnplt/devmon-agent/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ without SSH and without exposing the Docker socket to the internet.
   an audit table that outlives the operational log, and the port is rate
   limited so it survives being scanned.
 
-Current version: **0.6.0** ([CHANGELOG.md](CHANGELOG.md)).
+Current version: **0.7.0** ([CHANGELOG.md](CHANGELOG.md)).
 License: [AGPL-3.0-only](LICENSE).
 
 ## Install

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -37,7 +37,7 @@
 
 services:
   devmon-agent:
-    image: ghcr.io/scnplt/devmon-agent:0.6.0
+    image: ghcr.io/scnplt/devmon-agent:0.7.0
 
     # Pinned so the agent can name itself through DEVMON_SELF_CONTAINER below.
     # Without it compose derives the container name from the project directory,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -68,7 +68,7 @@ docker run -d --name devmon-agent \
   --read-only --tmpfs /tmp \
   --pids-limit 256 \
   -e DEVMON_PUBLIC_ADDR=vps.example.com \
-  ghcr.io/scnplt/devmon-agent:0.6.0
+  ghcr.io/scnplt/devmon-agent:0.7.0
 ```
 
 The four hardening flags are not needed to run the agent and none of them
@@ -92,7 +92,7 @@ the full list is in [`CONFIGURATION.md`](CONFIGURATION.md).
 
 ```bash
 curl -sk https://vps.example.com:8443/v1/status
-# {"api_version":"v1","agent_version":"0.6.0","policy_mode":"default",
+# {"api_version":"v1","agent_version":"0.7.0","policy_mode":"default",
 #  "server_time":"…Z","ca_fingerprint":"a1b2c3…"}
 ```
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,7 @@ openapi: 3.1.1
 
 info:
   title: devmon-agent
-  version: 0.6.0
+  version: 0.7.0
   summary: A narrow, mTLS-authenticated Docker control API.
   description: |
     One agent runs per Docker host. It is the sole holder of the Docker socket
@@ -123,7 +123,7 @@ paths:
                 default:
                   value:
                     api_version: v1
-                    agent_version: 0.6.0
+                    agent_version: 0.7.0
                     policy_mode: default
                     server_time: "2026-08-11T09:12:44Z"
                     ca_fingerprint: a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
@@ -981,7 +981,7 @@ components:
         agent_version:
           type: string
           description: The agent build's version. `dev` in an unstamped build.
-          examples: ["0.6.0"]
+          examples: ["0.7.0"]
         policy_mode:
           $ref: "#/components/schemas/PolicyMode"
         server_time:

--- a/install.sh
+++ b/install.sh
@@ -19,10 +19,10 @@ set -eu
 # ---------------------------------------------------------------------------
 
 # IMAGE_REPO and IMAGE_TAG name the released image the compose file pulls.
-# They must stay in step with README.md and compose.example.yaml, which name
-# the same tag.
+# They must stay in step with README.md, docs/INSTALL.md, and compose.example.yaml,
+# which name the same tag.
 IMAGE_REPO='ghcr.io/scnplt/devmon-agent'
-IMAGE_TAG='0.6.0'
+IMAGE_TAG='0.7.0'
 
 # NONROOT_UID is the UID the distroless/static:nonroot image runs as. The state
 # directory must be owned by it or startup fails at MkdirAll with "permission


### PR DESCRIPTION
## Summary

Release preparation for 0.7.0, the same shape as #132 was for 0.6.0.

- `CHANGELOG.md`: the `Unreleased` section becomes `[0.7.0] - 2026-09-07`. The one user-facing entry is operator-protected containers via `DEVMON_PROTECTED_CONTAINERS` (#137). A new `Internal` section records the moby client/api, sqlite, builder-digest and QEMU-action bumps (#139, #140, #141), the README split into `docs/` (#134), and the retired PRPs workflow (#138). Link references gain `[0.7.0]` and `[Unreleased]` now compares against `v0.7.0`.
- The pinned image tag and documented version move from 0.6.0 to 0.7.0 in `README.md`, `install.sh`, `compose.example.yaml`, `docs/INSTALL.md`, and `docs/openapi.yaml` (`info.version`, the `/v1/status` example, and the `agent_version` schema example).
- The `IMAGE_TAG` comment in `install.sh` now also names `docs/INSTALL.md`, which has carried the tag since #134.

**No Go code changed.** Version 0.7.0 is a minor bump: the release adds a startup variable and a 403 refusal path, and nothing existing changed shape.

## Test plan

- [x] `make doc-citations` — all citations resolve
- [x] `make openapi-lint` — valid
- [x] Full Go gate list (gofmt, vet, build, `-race` tests, 93.9% coverage, golangci-lint, gosec, govulncheck) — clean, unchanged tree
- [ ] `shellcheck` is not installed locally; the `shellcheck` job runs on the `dev` → `main` PR

## After merge

1. Open the `dev` → `main` release PR; the full release bar runs there.
2. Tag `main` as `v0.7.0` — the tag push publishes `ghcr.io/scnplt/devmon-agent:0.7.0` and moves `latest`.
3. `gh release create v0.7.0` with the 0.7.0 changelog section as the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
