### PR TITLE
docs: run conditional gates in /git-commit only when their condition applies

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -51,10 +51,12 @@ either one through a PR. See `CLAUDE.md` and
 
 ### 3. Quality gates
 
-Run every gate listed in `CLAUDE.md` under **Gates (MANDATORY)** — that section is the only
-gate list; this skill does not keep its own copy. All must pass before committing. If any
-fails, fix it — do not commit around it and do not use `--no-verify`. Skip a gate only if
-the tool is not installed, and say so explicitly in the final report.
+Run the gates listed in `CLAUDE.md` under **Gates (MANDATORY)** — that section is the only
+gate list; this skill does not keep its own copy. Unconditional gates always run. A gate
+marked "only when …" runs when its condition applies to the files being committed, and is
+then just as mandatory. Every applicable gate must pass before committing. If any fails,
+fix it — do not commit around it and do not use `--no-verify`. Skip a gate only if the
+tool is not installed, and say so explicitly in the final report.
 
 ### 4. Secret scan
 


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit finding on #143 against `.claude/skills/git-commit/SKILL.md`: the gate step said "run every gate listed in `CLAUDE.md`", but `CLAUDE.md` marks `make doc-citations`, `make openapi-lint`, and `make shellcheck` as conditional. The step now says that unconditional gates always run, a conditional gate runs whenever its listed condition applies to the files being committed and is then just as mandatory, every applicable gate must pass, and a gate whose tool is not installed is skipped and reported explicitly.

One paragraph changed, no other file touched. `CLAUDE.md` stays the only gate list.

## Test plan

- [x] Unconditional gate list run locally on the unchanged Go tree: gofmt, vet, build, `-race` tests, 93.9% coverage, golangci-lint, gosec, govulncheck — clean
- [x] None of the three conditional gates applies to a `.claude/**` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
