### PR TITLE
fix: require two characters for protected-container refs in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -375,6 +375,7 @@ is_valid_public_addr() {
 # [A-Za-z0-9_.-]. Two characters minimum, no spaces, no slashes, and nothing
 # that could close the YAML scalar it is written into.
 is_valid_container_ref() {
+	[ ${#1} -ge 2 ] || return 1
 	case "$1" in
 	[A-Za-z0-9][A-Za-z0-9_.-]*) ;;
 	*) return 1 ;;


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit finding on #143 against `install.sh`: `is_valid_container_ref` documented a two-character minimum, but its pattern `[A-Za-z0-9][A-Za-z0-9_.-]*` ends in `*`, so a single alphanumeric character passed the installer's `--protected-containers` check and was then rejected at startup by `containerRefPattern` in `internal/config`, whose `+` requires at least two. The function now checks `${#1} -ge 2` before the pattern, so the installer refuses exactly what the agent refuses. Allowed characters and list handling are unchanged.

One line added, no other file touched.

## Test plan

- [x] `sh -n install.sh` — syntax clean
- [x] Both validators extracted verbatim and exercised: `a`, `7`, empty, `-ab`, `_ab`, `a b`, `a/b`, `a"b` rejected; `ab`, `a1`, `web-1.prod_x`, a 12-hex short ID accepted; list form accepts empty, `ab,cd`, `ab,,cd,` and rejects `ab,c`, `a`, `ab,c d`
- [x] `make doc-citations` — all citations resolve
- [x] Unconditional Go gate list on the unchanged tree — clean, coverage 93.9%
- [ ] `shellcheck` is not installed locally; the `shellcheck` job runs on the `dev` → `main` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
