### PR TITLE
test: cover every ref-form x entry-form pair for protected containers

### DIFF
--- a/internal/dockerx/lifecycle_test.go
+++ b/internal/dockerx/lifecycle_test.go
@@ -397,43 +397,52 @@ func TestLifecycleRejectsProtectedAllFive(t *testing.T) {
 	t.Parallel()
 
 	refForms := []struct {
-		name    string
-		ref     string
-		entries []string
+		name string
+		ref  string
 	}{
-		{name: "by name", ref: protectedFixtureName, entries: []string{protectedFixtureName}},
-		{name: "by short ID", ref: protectedFixtureShortID, entries: []string{protectedFixtureShortID}},
-		{name: "by full ID", ref: protectedFixtureFullID, entries: []string{protectedFixtureFullID}},
+		{name: "ref name", ref: protectedFixtureName},
+		{name: "ref short ID", ref: protectedFixtureShortID},
+		{name: "ref full ID", ref: protectedFixtureFullID},
+	}
+	entryForms := []struct {
+		name  string
+		entry string
+	}{
+		{name: "entry name", entry: protectedFixtureName},
+		{name: "entry short ID", entry: protectedFixtureShortID},
+		{name: "entry full ID", entry: protectedFixtureFullID},
 	}
 
-	for _, form := range refForms {
-		for _, op := range lifecycleOps() {
-			t.Run(form.name+"/"+op.name, func(t *testing.T) {
-				t.Parallel()
+	for _, rf := range refForms {
+		for _, ef := range entryForms {
+			for _, op := range lifecycleOps() {
+				t.Run(rf.name+"/"+ef.name+"/"+op.name, func(t *testing.T) {
+					t.Parallel()
 
-				// Arrange
-				spy := &mutatingCallSpy{}
-				c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
-					inspectRoute(form.ref): jsonHandler(http.StatusOK, container.InspectResponse{
-						ID:   protectedFixtureFullID,
-						Name: "/" + protectedFixtureName,
-					}),
-					op.actionRoute(protectedFixtureFullID): spy.handler,
+					// Arrange
+					spy := &mutatingCallSpy{}
+					c, _ := newFakeEngine(t, map[string]http.HandlerFunc{
+						inspectRoute(rf.ref): jsonHandler(http.StatusOK, container.InspectResponse{
+							ID:   protectedFixtureFullID,
+							Name: "/" + protectedFixtureName,
+						}),
+						op.actionRoute(protectedFixtureFullID): spy.handler,
+					})
+					c = withSelf(c, false, "")
+					c = withProtected(c, ef.entry)
+
+					// Act
+					err := op.call(c, context.Background(), rf.ref)
+
+					// Assert
+					if !errors.Is(err, ErrProtectedContainer) {
+						t.Fatalf("err = %v, want errors.Is(err, ErrProtectedContainer)", err)
+					}
+					if spy.hit {
+						t.Error("mutating Engine endpoint was reached, want it never contacted")
+					}
 				})
-				c = withSelf(c, false, "")
-				c = withProtected(c, form.entries...)
-
-				// Act
-				err := op.call(c, context.Background(), form.ref)
-
-				// Assert
-				if !errors.Is(err, ErrProtectedContainer) {
-					t.Fatalf("err = %v, want errors.Is(err, ErrProtectedContainer)", err)
-				}
-				if spy.hit {
-					t.Error("mutating Engine endpoint was reached, want it never contacted")
-				}
-			})
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit finding on #143 against `resolveTarget` in `internal/dockerx/lifecycle.go`. The finding had two parts; one is applied, one is skipped.

**Applied — unit coverage for cross-form requests.** `TestLifecycleRejectsProtectedAllFive` said it proved refusal "regardless of which of the three ref forms the device used and which of those same forms the operator listed", but its table held only the three same-form pairs. A request by full ID against a name entry, or by name against a short-ID entry, was proven only by the e2e suite against a real Engine. The table is now split into ref forms and entry forms and iterates the cross product: 3 × 3 × 5 lifecycle ops = 45 subtests, all passing. Test-only; no production line changed.

**Skipped — "use the inspected container's resolved aliases consistently with list projections".** Verified against the current code and found unreachable:

- A lifecycle ref cannot be a link alias: `refPattern` in `internal/dockerx/ref.go` forbids `/`, and every alias the Engine reports has the shape `/linker/alias`.
- A configured entry cannot be a link alias either: `containerRefPattern` in `internal/config` forbids `/`, and `trimContainerName` strips only the single leading slash, so an alias trims to `linker/alias` and never equals an entry on the list path.
- `container.InspectResponse` carries only the primary `Name`; reverse-link aliases exist only in list responses.

So for every input that can reach either path, the list projection's `matches(s.ID, s.Names...)` and `resolveTarget`'s `matches(detail.ID, detail.Name)` reduce to the same primary-name-or-ID decision, and the enforcement path already refuses ID, primary-name, and short-ID requests, as the extended unit test and the existing e2e contracts show.

## Test plan

- [x] `go test ./internal/dockerx -race -run TestLifecycleRejectsProtectedAllFive -v` — 45 subtests pass, including every off-diagonal pair
- [x] Full gate list: gofmt, vet, build, `-race` tests for `internal/` and `cmd/`, coverage 93.9% against the 90% floor, golangci-lint, gosec, govulncheck — clean
- [x] Implemented by `go-implementer`; gate output re-run and verified in the main session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
